### PR TITLE
chore: optimize loading and polling performance

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1595,12 +1595,8 @@ app.post('/api/getPlaylist', optionalJwt, async (req, res) => {
     const file_objs = [];
 
     if (playlist && include_file_metadata) {
-        for (let i = 0; i < playlist['uids'].length; i++) {
-            const uid = playlist['uids'][i];
-            const file_obj = await files_api.getVideo(uid, uuid);
-            if (file_obj) file_objs.push(file_obj);
-            // TODO: remove file from playlist if could not be found
-        }
+        file_objs.push(...(await files_api.getVideosByUIDs(playlist['uids'], uuid)));
+        // TODO: remove file from playlist if could not be found
     }
 
     res.send({
@@ -2234,9 +2230,14 @@ app.post('/api/downloads', optionalJwt, async (req, res) => {
     const user_uid = req.isAuthenticated() ? req.user.uid : null;
     const uids = req.body.uids;
     const filter_obj = getScopedFilterByUser(user_uid);
-    let downloads = await db_api.getRecords('download_queue', filter_obj);
-
-    if (uids) downloads = downloads.filter(download => uids.includes(download['uid']));
+    if (Array.isArray(uids)) {
+        if (uids.length === 0) {
+            res.send({downloads: []});
+            return;
+        }
+        filter_obj['uid'] = {$in: uids};
+    }
+    const downloads = await db_api.getRecords('download_queue', filter_obj);
 
     res.send({downloads: downloads});
 });

--- a/backend/db.js
+++ b/backend/db.js
@@ -932,18 +932,24 @@ exports.applyFilterLocalDB = (db_path, filter_obj, operation) => {
                 filtered &= record[filter_prop] === undefined || record[filter_prop] === null;
             } else {
                 if (typeof filter_prop_value === 'object') {
+                    const record_value = filter_prop.includes('.')
+                        ? utils.searchObjectByString(record, filter_prop)
+                        : record[filter_prop];
                     if ('$regex' in filter_prop_value) {
-                        filtered &= (record[filter_prop].search(new RegExp(filter_prop_value['$regex'], filter_prop_value['$options'])) !== -1);
+                        filtered &= typeof record_value === 'string'
+                            && (record_value.search(new RegExp(filter_prop_value['$regex'], filter_prop_value['$options'])) !== -1);
                     } else if ('$ne' in filter_prop_value) {
-                        filtered &= filter_prop in record && record[filter_prop] !== filter_prop_value['$ne'];
+                        filtered &= record_value !== undefined && record_value !== filter_prop_value['$ne'];
                     } else if ('$lt' in filter_prop_value) {
-                        filtered &= filter_prop in record && record[filter_prop] < filter_prop_value['$lt'];
+                        filtered &= record_value !== undefined && record_value < filter_prop_value['$lt'];
                     } else if ('$gt' in filter_prop_value) {
-                        filtered &= filter_prop in record && record[filter_prop] > filter_prop_value['$gt'];
+                        filtered &= record_value !== undefined && record_value > filter_prop_value['$gt'];
                     } else if ('$lte' in filter_prop_value) {
-                        filtered &= filter_prop in record && record[filter_prop] <= filter_prop_value['$lt'];
+                        filtered &= record_value !== undefined && record_value <= filter_prop_value['$lte'];
                     } else if ('$gte' in filter_prop_value) {
-                        filtered &= filter_prop in record && record[filter_prop] >= filter_prop_value['$gt'];
+                        filtered &= record_value !== undefined && record_value >= filter_prop_value['$gte'];
+                    } else if ('$in' in filter_prop_value) {
+                        filtered &= Array.isArray(filter_prop_value['$in']) && filter_prop_value['$in'].includes(record_value);
                     }
                 } else {
                     // handle case of nested property check
@@ -962,4 +968,8 @@ exports.applyFilterLocalDB = (db_path, filter_obj, operation) => {
 // should only be used for tests
 exports.setLocalDBMode = (mode) => {
     using_local_db = mode;
+}
+
+exports.isUsingLocalDB = () => {
+    return using_local_db;
 }

--- a/backend/downloader.js
+++ b/backend/downloader.js
@@ -175,7 +175,7 @@ async function fixDownloadState() {
 async function checkDownloads() {
     if (!should_check_downloads) return;
 
-    const downloads = await db_api.getRecords('download_queue');
+    const downloads = await db_api.getRecords('download_queue', {finished: false});
     downloads.sort((download1, download2) => download1.timestamp_start - download2.timestamp_start);
 
     await mutex.runExclusive(async () => {

--- a/backend/files.js
+++ b/backend/files.js
@@ -12,6 +12,10 @@ function shouldRestrictToUser(user_uid) {
     return config_api.getConfigItem('ytdl_multi_user_mode') && user_uid !== null && user_uid !== undefined;
 }
 
+function escapeRegex(text = '') {
+    return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 exports.registerFileDB = async (file_path, type, user_uid = null, category = null, sub_id = null, cropFileSettings = null, file_object = null) => {
     if (!file_object) file_object = generateFileObject(file_path, type);
     if (!file_object) {
@@ -228,15 +232,10 @@ exports.setPlaylistProperty = async (playlist_id, assignment_obj, user_uid = nul
 
 exports.calculatePlaylistDuration = async (playlist, playlist_file_objs = null) => {
     if (!playlist_file_objs) {
-        playlist_file_objs = [];
         const playlist_uids = Array.isArray(playlist['uids']) ? playlist['uids'] : [];
         const max_playlist_uids_to_scan = 10000;
         const playlist_uids_to_scan = playlist_uids.slice(0, max_playlist_uids_to_scan);
-        for (let i = 0; i < playlist_uids_to_scan.length; i++) {
-            const uid = playlist_uids_to_scan[i];
-            const file_obj = await exports.getVideo(uid, playlist.user_uid);
-            if (file_obj) playlist_file_objs.push(file_obj);
-        }
+        playlist_file_objs = await exports.getVideosByUIDs(playlist_uids_to_scan, playlist.user_uid);
     }
 
     return playlist_file_objs.reduce((a, b) => a + utils.durationStringToNumber(b.duration), 0);
@@ -343,17 +342,35 @@ exports.getVideo = async (file_uid, user_uid = null, sub_id = null) => {
     return await db_api.getRecord('files', filter_obj);
 }
 
+exports.getVideosByUIDs = async (file_uids = [], user_uid = null) => {
+    if (!Array.isArray(file_uids) || file_uids.length === 0) return [];
+
+    const ordered_uids = file_uids.filter(uid => uid !== undefined && uid !== null);
+    if (ordered_uids.length === 0) return [];
+
+    const unique_uids = [...new Set(ordered_uids)];
+    const filter_obj = {uid: {$in: unique_uids}};
+    if (shouldRestrictToUser(user_uid)) filter_obj['user_uid'] = user_uid;
+
+    const file_objs = await db_api.getRecords('files', filter_obj);
+    const file_by_uid = new Map(file_objs.map(file_obj => [file_obj.uid, file_obj]));
+    return ordered_uids.map(uid => file_by_uid.get(uid)).filter(Boolean);
+}
+
 exports.getAllFiles = async (sort, range, text_search, file_type_filter, favorite_filter, sub_id, uuid) => {
     const filter_obj = {};
     if (config_api.getConfigItem('ytdl_multi_user_mode')) {
         filter_obj['user_uid'] = uuid;
     }
-    const regex = true;
+
     if (text_search) {
-        if (regex) {
-            filter_obj['title'] = {$regex: `.*${text_search}.*`, $options: 'i'};
-        } else {
-            filter_obj['$text'] = { $search: utils.createEdgeNGrams(text_search) };
+        const normalized_text_search = text_search.trim();
+        if (normalized_text_search !== '') {
+            if (db_api.isUsingLocalDB()) {
+                filter_obj['title'] = {$regex: escapeRegex(normalized_text_search), $options: 'i'};
+            } else {
+                filter_obj['$text'] = { $search: utils.createEdgeNGrams(normalized_text_search) };
+            }
         }
     }
 
@@ -367,8 +384,8 @@ exports.getAllFiles = async (sort, range, text_search, file_type_filter, favorit
 
     if (file_type_filter === 'audio_only') filter_obj['isAudio'] = true;
     else if (file_type_filter === 'video_only') filter_obj['isAudio'] = false;
-    
-    const files = JSON.parse(JSON.stringify(await db_api.getRecords('files', filter_obj, false, sort, range, text_search)));
+
+    const files = await db_api.getRecords('files', filter_obj, false, sort, range);
     const file_count = await db_api.getRecords('files', filter_obj, true);
 
     return {files, file_count};

--- a/backend/subscriptions.js
+++ b/backend/subscriptions.js
@@ -462,21 +462,37 @@ async function generateArgsForSubscription(sub, user_uid, redownload = false, de
 
 async function getFilesToDownload(sub, output_jsons) {
     const files_to_download = [];
+
+    const [existing_sub_files, pending_sub_downloads] = await Promise.all([
+        db_api.getRecords('files', {sub_id: sub.id}),
+        db_api.getRecords('download_queue', {sub_id: sub.id, error: null, finished: false})
+    ]);
+
+    const urls_with_existing_files = new Set(existing_sub_files.map(file => file.url));
+    const paths_with_existing_files = new Set(existing_sub_files.map(file => file.path));
+    const urls_with_pending_downloads = new Set(pending_sub_downloads.map(download => download.url));
+
     for (let i = 0; i < output_jsons.length; i++) {
         const output_json = output_jsons[i];
-        const file_missing = !(await db_api.getRecord('files', {sub_id: sub.id, url: output_json['webpage_url']})) && !(await db_api.getRecord('download_queue', {sub_id: sub.id, url: output_json['webpage_url'], error: null, finished: false}));
-        if (file_missing) {
-            const file_with_path_exists = await db_api.getRecord('files', {sub_id: sub.id, path: output_json['_filename']});
-            if (file_with_path_exists) {
-                // or maybe just overwrite???
-                logger.info(`Skipping adding file ${output_json['_filename']} for subscription ${sub.name} as a file with that path already exists.`)
-                continue;
-            }
-            const exists_in_archive = await archive_api.existsInArchive(output_json['extractor'], output_json['id'], sub.type, sub.user_uid, sub.id);
-            if (exists_in_archive) continue;
+        if (!output_json || !output_json['webpage_url']) continue;
 
-            files_to_download.push(output_json);
+        const output_url = output_json['webpage_url'];
+        const output_path = output_json['_filename'];
+
+        const file_missing = !urls_with_existing_files.has(output_url) && !urls_with_pending_downloads.has(output_url);
+        if (!file_missing) continue;
+
+        if (output_path && paths_with_existing_files.has(output_path)) {
+            // or maybe just overwrite???
+            logger.info(`Skipping adding file ${output_path} for subscription ${sub.name} as a file with that path already exists.`)
+            continue;
         }
+
+        const exists_in_archive = await archive_api.existsInArchive(output_json['extractor'], output_json['id'], sub.type, sub.user_uid, sub.id);
+        if (exists_in_archive) continue;
+
+        files_to_download.push(output_json);
+        urls_with_pending_downloads.add(output_url);
     }
     return files_to_download;
 }

--- a/src/app/components/downloads/downloads.component.ts
+++ b/src/app/components/downloads/downloads.component.ts
@@ -45,7 +45,7 @@ export class DownloadsComponent implements OnInit, OnDestroy {
   displayedColumnsBig: string[] = ['timestamp_start', 'title', 'sub_name', 'percent_complete', 'actions'];
   displayedColumnsSmall: string[] = ['title', 'percent_complete', 'actions'];
   displayedColumns: string[] = this.displayedColumnsBig;
-  dataSource = null; // new MatTableDataSource<Download>();
+  dataSource = new MatTableDataSource<Download>([]);
 
   // The purpose of this is to reduce code reuse for displaying these actions as icons or in a menu
   downloadActions: DownloadAction[] = [
@@ -144,19 +144,14 @@ export class DownloadsComponent implements OnInit, OnDestroy {
 
   getCurrentDownloads(): void {
     this.postsService.getCurrentDownloads(this.uids).subscribe(res => {
-      if (res['downloads'] !== null 
-        && res['downloads'] !== undefined
-        && JSON.stringify(this.downloads) !== JSON.stringify(res['downloads'])) {
-          this.downloads = this.combineDownloads(this.downloads, res['downloads']);
-          // this.downloads = res['downloads'];
-          this.downloads.sort(this.sort_downloads);
-          this.dataSource = new MatTableDataSource<Download>(this.downloads);
-          this.dataSource.paginator = this.paginator;
-          this.dataSource.sort = this.sort;
-          this.paused_download_exists = this.downloads.find(download => download['paused'] && !download['error']);
-          this.running_download_exists = this.downloads.find(download => !download['paused'] && !download['finished']);
-      } else {
-        // failed to get downloads
+      if (res['downloads'] !== null && res['downloads'] !== undefined) {
+        this.downloads = this.combineDownloads(this.downloads, res['downloads']);
+        this.downloads.sort(this.sort_downloads);
+        this.dataSource.data = this.downloads;
+        this.dataSource.paginator = this.paginator;
+        this.dataSource.sort = this.sort;
+        this.paused_download_exists = !!this.downloads.find(download => download['paused'] && !download['error']);
+        this.running_download_exists = !!this.downloads.find(download => !download['paused'] && !download['finished']);
       }
       this.downloads_retrieved = true;
     });
@@ -275,24 +270,30 @@ export class DownloadsComponent implements OnInit, OnDestroy {
   }
 
   combineDownloads(downloads_old: Download[], downloads_new: Download[]): Download[] {
-    // only keeps downloads that exist in the new set
-    downloads_old = downloads_old.filter(download_old => downloads_new.some(download_new => download_new.uid === download_old.uid));
+    const old_by_uid = new Map<string, Download>();
+    downloads_old.forEach(download => old_by_uid.set(download.uid, download));
 
-    // add downloads from the new set that the old one doesn't have
-    const downloads_to_add = downloads_new.filter(download_new => !downloads_old.some(download_old => download_new.uid === download_old.uid));
-    downloads_old.push(...downloads_to_add);
-    downloads_old.forEach(download_old => {
-      const download_new = downloads_new.find(download_to_check => download_old.uid === download_to_check.uid);
-      Object.keys(download_new).forEach(key => {
-        download_old[key] = download_new[key];
-      });
-  
-      Object.keys(download_old).forEach(key => {
-        if (!download_new[key]) delete download_old[key];
-      });
-    });
+    const combined_downloads: Download[] = [];
+    for (let i = 0; i < downloads_new.length; i++) {
+      const incoming_download = downloads_new[i];
+      const existing_download = old_by_uid.get(incoming_download.uid);
 
-    return downloads_old;
+      if (!existing_download) {
+        combined_downloads.push({...incoming_download});
+        continue;
+      }
+
+      const incoming_keys = new Set(Object.keys(incoming_download));
+      Object.keys(existing_download).forEach(key => {
+        if (!incoming_keys.has(key)) {
+          delete existing_download[key];
+        }
+      });
+      Object.assign(existing_download, incoming_download);
+      combined_downloads.push(existing_download);
+    }
+
+    return combined_downloads;
   }
 
   showError(download: Download): void {


### PR DESCRIPTION
## Summary
- optimize playlist/file loading by batching UID-based metadata fetches and reusing those paths for playlist duration calculations
- improve `/api/downloads` and downloads UI polling efficiency by switching to server-side UID filtering and linear-time client merge updates (removing expensive JSON stringify diffs and repeated datasource re-instantiation)
- reduce subscription check DB chatter by preloading existing files/queue items once per subscription scan and checking membership via sets
- improve file search behavior/performance by using text-search in Mongo mode and safe escaped regex only in local-db mode
- tighten downloader queue scanning to only read unfinished entries while scheduling
- extend local-db filter emulation to support `$in` and fix `$lte`/`$gte` behavior for parity with Mongo queries

## Validation
- `npm run lint`
- `npm test` (backend)
