### PR TITLE
chore: optimize remaining loading hot paths

### DIFF
--- a/backend/categories.js
+++ b/backend/categories.js
@@ -56,19 +56,38 @@ async function getCategories() {
 async function getCategoriesAsPlaylists() {
     const categories_as_playlists = [];
     const available_categories = await getCategories();
-    if (available_categories) {
-        for (let category of available_categories) {
-            const files_that_match = await db_api.getRecords('files', {'category.uid': category['uid']});
-            if (files_that_match && files_that_match.length > 0) {
-                category['thumbnailURL'] = files_that_match[0].thumbnailURL;
-                category['thumbnailPath'] = files_that_match[0].thumbnailPath;
-                category['duration'] = files_that_match.reduce((a, b) => a + utils.durationStringToNumber(b.duration), 0);
-                category['id'] = category['uid'];
-                category['auto'] = true;
-                categories_as_playlists.push(category);
-            }
+    if (!available_categories || available_categories.length === 0) return categories_as_playlists;
+
+    const category_uids = available_categories.map(category => category['uid']).filter(Boolean);
+    if (category_uids.length === 0) return categories_as_playlists;
+
+    const categorized_files = await db_api.getRecords('files', {'category.uid': {$in: category_uids}});
+    if (!categorized_files || categorized_files.length === 0) return categories_as_playlists;
+
+    const files_by_category_uid = new Map();
+    for (const categorized_file of categorized_files) {
+        const category_uid = categorized_file?.category?.uid;
+        if (!category_uid) continue;
+
+        if (!files_by_category_uid.has(category_uid)) {
+            files_by_category_uid.set(category_uid, []);
         }
+        files_by_category_uid.get(category_uid).push(categorized_file);
     }
+
+    for (const category of available_categories) {
+        const files_that_match = files_by_category_uid.get(category['uid']);
+        if (!files_that_match || files_that_match.length === 0) continue;
+
+        const category_playlist = {...category};
+        category_playlist['thumbnailURL'] = files_that_match[0].thumbnailURL;
+        category_playlist['thumbnailPath'] = files_that_match[0].thumbnailPath;
+        category_playlist['duration'] = files_that_match.reduce((a, b) => a + utils.durationStringToNumber(b.duration), 0);
+        category_playlist['id'] = category_playlist['uid'];
+        category_playlist['auto'] = true;
+        categories_as_playlists.push(category_playlist);
+    }
+
     return categories_as_playlists;
 }
 

--- a/backend/db.js
+++ b/backend/db.js
@@ -24,11 +24,24 @@ const tables = {
             title: 'text',
             uploader: 'text',
             uid: 'text'
-        }
+        },
+        indexes: [
+            { keys: { registered: -1 } },
+            { keys: { user_uid: 1, registered: -1 } },
+            { keys: { sub_id: 1, registered: -1 } },
+            { keys: { isAudio: 1, registered: -1 } },
+            { keys: { favorite: 1, registered: -1 } },
+            { keys: { url: 1, sub_id: 1 } },
+            { keys: { path: 1, sub_id: 1 } },
+            { keys: { 'category.uid': 1 } }
+        ]
     },
     playlists: {
         name: 'playlists',
-        primary_key: 'id'
+        primary_key: 'id',
+        indexes: [
+            { keys: { user_uid: 1 } }
+        ]
     },
     categories: {
         name: 'categories',
@@ -36,14 +49,22 @@ const tables = {
     },
     subscriptions: {
         name: 'subscriptions',
-        primary_key: 'id'
+        primary_key: 'id',
+        indexes: [
+            { keys: { user_uid: 1 } },
+            { keys: { paused: 1, streamingOnly: 1 } }
+        ]
     },
     downloads: {
         name: 'downloads'
     },
     users: {
         name: 'users',
-        primary_key: 'uid'
+        primary_key: 'uid',
+        indexes: [
+            { keys: { name: 1 } },
+            { keys: { oidc_subject: 1 } }
+        ]
     },
     roles: {
         name: 'roles',
@@ -51,7 +72,14 @@ const tables = {
     },
     download_queue: {
         name: 'download_queue',
-        primary_key: 'uid'
+        primary_key: 'uid',
+        indexes: [
+            { keys: { finished: 1, paused: 1, finished_step: 1, timestamp_start: 1 } },
+            { keys: { user_uid: 1, finished: 1, paused: 1 } },
+            { keys: { sub_id: 1, error: 1, finished: 1 } },
+            { keys: { sub_id: 1, url: 1, error: 1, finished: 1 } },
+            { keys: { running: 1, sub_id: 1 } }
+        ]
     },
     tasks: {
         name: 'tasks',
@@ -59,10 +87,17 @@ const tables = {
     },
     notifications: {
         name: 'notifications',
-        primary_key: 'uid'
+        primary_key: 'uid',
+        indexes: [
+            { keys: { user_uid: 1 } }
+        ]
     },
     archives: {
-        name: 'archives'
+        name: 'archives',
+        indexes: [
+            { keys: { extractor: 1, id: 1, type: 1, sub_id: 1, user_uid: 1 } },
+            { keys: { sub_id: 1, user_uid: 1, type: 1 } }
+        ]
     },
     test: {
         name: 'test'
@@ -213,20 +248,27 @@ exports._connectToDB = async (custom_connection_string = null) => {
         const existing_collections = (await database.listCollections({}, { nameOnly: true }).toArray()).map(collection => collection.name);
 
         const missing_tables = tables_list.filter(table => !(existing_collections.includes(table)));
-        missing_tables.forEach(async table => {
-            await database.createCollection(table);
-        });
+        await Promise.all(missing_tables.map(table => database.createCollection(table)));
 
-        tables_list.forEach(async table => {
+        for (const table of tables_list) {
+            const table_collection = database.collection(table);
+
             const primary_key = tables[table]['primary_key'];
             if (primary_key) {
-                await database.collection(table).createIndex({[primary_key]: 1}, { unique: true });
+                await table_collection.createIndex({[primary_key]: 1}, { unique: true });
             }
+
             const text_search = tables[table]['text_search'];
             if (text_search) {
-                await database.collection(table).createIndex(text_search);
+                await table_collection.createIndex(text_search);
             }
-        });
+
+            const extra_indexes = tables[table]['indexes'] || [];
+            for (const extra_index of extra_indexes) {
+                if (!extra_index || !extra_index.keys) continue;
+                await table_collection.createIndex(extra_index.keys, extra_index.options || {});
+            }
+        }
         using_local_db = false; // needs to happen for tests (in normal operation using_local_db is guaranteed false)
         return true;
     } catch(err) {

--- a/backend/downloader.js
+++ b/backend/downloader.js
@@ -686,27 +686,53 @@ async function checkDownloadPercent(download_uid) {
         if (!resulting_file_size || !files_to_check_for_progress || files_to_check_for_progress.length === 0) return;
 
         let sum_size = 0;
+        const basenames_by_directory = new Map();
         for (let i = 0; i < files_to_check_for_progress.length; i++) {
             const file_to_check_for_progress = files_to_check_for_progress[i];
             const dir = path.dirname(file_to_check_for_progress);
-            if (!fs.existsSync(dir)) continue;
+            const file_basename = path.basename(file_to_check_for_progress);
 
-            let files = [];
+            if (!basenames_by_directory.has(dir)) {
+                basenames_by_directory.set(dir, new Set());
+            }
+            basenames_by_directory.get(dir).add(file_basename);
+        }
+
+        for (const [dir, file_basenames] of basenames_by_directory.entries()) {
+            if (!fs.existsSync(dir)) continue;
+            const file_basename_list = [...file_basenames];
+
+            let dir_entries = [];
             try {
-                files = await fs.readdir(dir);
+                dir_entries = await fs.readdir(dir, {withFileTypes: true});
             } catch (e) {
                 continue;
             }
 
-            for (let j = 0; j < files.length; j++) {
-                const file = files[j];
-                if (!file.includes(path.basename(file_to_check_for_progress))) continue;
+            const matching_file_paths = [];
+            for (let i = 0; i < dir_entries.length; i++) {
+                const dir_entry = dir_entries[i];
+                if (!dir_entry || typeof dir_entry.isDirectory !== 'function' || dir_entry.isDirectory()) continue;
+
+                const entry_name = dir_entry.name;
+                const entry_matches_progress_file = file_basename_list.some(file_basename => entry_name.includes(file_basename));
+                if (!entry_matches_progress_file) continue;
+                matching_file_paths.push(path.join(dir, entry_name));
+            }
+
+            const matching_file_stats = await Promise.all(matching_file_paths.map(async matching_file_path => {
                 try {
-                    const file_stats = await fs.stat(path.join(dir, file));
-                    if (file_stats && file_stats.size) {
-                        sum_size += file_stats.size;
-                    }
-                } catch (e) {}
+                    return await fs.stat(matching_file_path);
+                } catch (e) {
+                    return null;
+                }
+            }));
+
+            for (let i = 0; i < matching_file_stats.length; i++) {
+                const file_stats = matching_file_stats[i];
+                if (file_stats && file_stats.size) {
+                    sum_size += file_stats.size;
+                }
             }
         }
 

--- a/backend/utils.js
+++ b/backend/utils.js
@@ -242,25 +242,46 @@ exports.addUIDsToCategory = (category, files) => {
 }
 
 exports.recFindByExt = async (base, ext, files, result, recursive = true) => {
-    files = files || (await fs.readdir(base))
-    result = result || []
+    const extension = `.${ext}`.toLowerCase();
+    const matching_files = result || [];
+    const directories_to_scan = [{dir: base, provided_files: Array.isArray(files) ? files : null}];
 
-    for (const file of files) {
-        var newbase = path.join(base,file)
-        if ( (await fs.stat(newbase)).isDirectory() )
-        {
-            if (!recursive) continue;
-            result = await exports.recFindByExt(newbase,ext,await fs.readdir(newbase),result)
+    while (directories_to_scan.length > 0) {
+        const current_scan = directories_to_scan.pop();
+        const current_dir = current_scan.dir;
+
+        let entries;
+        try {
+            if (current_scan.provided_files) {
+                entries = await Promise.all(current_scan.provided_files.map(async file_name => {
+                    const full_path = path.join(current_dir, file_name);
+                    const file_stats = await fs.stat(full_path);
+                    return {
+                        name: file_name,
+                        isDirectory: () => file_stats.isDirectory()
+                    };
+                }));
+            } else {
+                entries = await fs.readdir(current_dir, {withFileTypes: true});
+            }
+        } catch (err) {
+            continue;
         }
-        else
-        {
-            if ( file.substr(-1*(ext.length+1)) == '.' + ext )
-            {
-                result.push(newbase)
+
+        for (const entry of entries) {
+            const entry_path = path.join(current_dir, entry.name);
+            if (entry.isDirectory()) {
+                if (recursive) directories_to_scan.push({dir: entry_path, provided_files: null});
+                continue;
+            }
+
+            if (entry.name.toLowerCase().endsWith(extension)) {
+                matching_files.push(entry_path);
             }
         }
     }
-    return result
+
+    return matching_files;
 }
 
 exports.removeFileExtension = (filename) => {


### PR DESCRIPTION
## Summary
- finish item 4 by making Mongo collection/index initialization fully awaited (no async `forEach`) and adding practical secondary indexes for hot query paths (`files`, `download_queue`, `subscriptions`, `archives`, etc.)
- finish item 5 by optimizing filesystem-heavy scans:
  - `recFindByExt` now uses `readdir(..., { withFileTypes: true })` + iterative traversal to avoid per-entry recursive `stat` overhead
  - download progress checks now group by directory and read each directory once per tick
- finish item 6 by removing category playlist N+1 DB calls via a single `$in` query and in-memory grouping by `category.uid`
- item 7 (removing the expensive deep clone in file list loading) was already handled in the previous performance PR and remains intact

## Validation
- `npm test` (backend)
- `npm run lint`
