### PR TITLE
fix: stop unnecessary yt-dlp redownload on startup

### DIFF
--- a/backend/test/tests.js
+++ b/backend/test/tests.js
@@ -731,6 +731,33 @@ describe('youtube-dl', function() {
         config_api.setConfigItem('ytdl_default_downloader', original_fork);
     });
 
+    it('Does not redownload when details already exist for selected fork', async function() {
+        this.timeout(300000);
+
+        const selected_fork = config_api.getConfigItem('ytdl_default_downloader');
+        const current_details = fs.readJSONSync(CONSTS.DETAILS_BIN_PATH);
+        const current_version = current_details[selected_fork].version;
+
+        let update_called = false;
+        const original_get_latest = youtubedl_api.getLatestUpdateVersion;
+        const original_update = youtubedl_api.updateYoutubeDL;
+
+        try {
+            youtubedl_api.getLatestUpdateVersion = async () => current_version;
+            youtubedl_api.updateYoutubeDL = async () => { update_called = true; };
+
+            await youtubedl_api.checkForYoutubeDLUpdate();
+
+            const details_after = fs.readJSONSync(CONSTS.DETAILS_BIN_PATH);
+            assert(details_after[selected_fork]);
+            assert(details_after[selected_fork].version === current_version);
+            assert(!update_called);
+        } finally {
+            youtubedl_api.getLatestUpdateVersion = original_get_latest;
+            youtubedl_api.updateYoutubeDL = original_update;
+        }
+    });
+
     it('Run process', async function() {
         this.timeout(300000);
         const downloader_api = require('../downloader');

--- a/backend/youtube-dl.js
+++ b/backend/youtube-dl.js
@@ -117,14 +117,19 @@ exports.killYoutubeDLProcess = async (child_process) => {
 
 exports.checkForYoutubeDLUpdate = async () => {
     const selected_fork = config_api.getConfigItem('ytdl_default_downloader');
-    const output_file_path = getYoutubeDLPath();
-    // get current version
-    let current_app_details_exists = fs.existsSync(CONSTS.DETAILS_BIN_PATH);
-    if (!current_app_details_exists[selected_fork]) {
+    const output_file_path = getYoutubeDLPath(selected_fork);
+
+    let current_app_details = fs.existsSync(CONSTS.DETAILS_BIN_PATH)
+        ? fs.readJSONSync(CONSTS.DETAILS_BIN_PATH)
+        : {};
+
+    // Initialize details when file/fork metadata is missing.
+    if (!current_app_details[selected_fork]) {
         logger.warn(`Failed to get youtube-dl binary details at location '${CONSTS.DETAILS_BIN_PATH}'. Generating file...`);
         updateDetailsJSON(CONSTS.OUTDATED_YOUTUBEDL_VERSION, selected_fork, output_file_path);
+        current_app_details = fs.readJSONSync(CONSTS.DETAILS_BIN_PATH);
     }
-    const current_app_details = JSON.parse(fs.readFileSync(CONSTS.DETAILS_BIN_PATH));
+
     const current_version = current_app_details[selected_fork]['version'];
     const current_fork = current_app_details[selected_fork]['downloader'];
 


### PR DESCRIPTION
## Summary
- fix downloader metadata check in `checkForYoutubeDLUpdate()`
- read `appdata/youtube-dl.json` as an object and validate selected-fork metadata correctly
- use selected-fork path consistently when evaluating updater state
- add a regression test to ensure existing metadata does not trigger redownload

## Why
On startup, the code treated the boolean result of `fs.existsSync()` like an object (`current_app_details_exists[selected_fork]`), which caused false "missing details" detection and unnecessary update downloads.

## Validation
- `npm --prefix backend test` (68 passing)
