### PR TITLE
Add playlist dropdown option for watch URLs with list param

### DIFF
--- a/src/app/main/main.component.html
+++ b/src/app/main/main.component.html
@@ -93,7 +93,7 @@
       </div>
     </mat-card-content>
     <mat-card-actions>
-      @if (sponsorBlockApiEnabled) {
+      @if (shouldShowDownloadMenu()) {
         <div class="download-split-button">
           <button class="download-main-action" (click)="downloadClicked()" [disabled]="downloadingfile || url === ''" type="button" mat-stroked-button color="accent">
             <ng-container i18n="Main download button">
@@ -105,9 +105,16 @@
           </button>
         </div>
         <mat-menu #downloadMenu="matMenu" xPosition="after">
-          <button mat-menu-item (click)="downloadClicked(true)" [disabled]="downloadingfile || url === ''">
-            <span i18n="Main download button option without SponsorBlock">Download without SponsorBlock</span>
-          </button>
+          @if (hasPlaylistUrlInInput()) {
+            <button mat-menu-item (click)="downloadPlaylistClicked()" [disabled]="downloadingfile || url === ''">
+              <span i18n="Main download button option for playlist">Download Playlist</span>
+            </button>
+          }
+          @if (sponsorBlockApiEnabled) {
+            <button mat-menu-item (click)="downloadClicked(true)" [disabled]="downloadingfile || url === ''">
+              <span i18n="Main download button option without SponsorBlock">Download without SponsorBlock</span>
+            </button>
+          }
         </mat-menu>
       } @else {
         <button style="margin-left: 8px; margin-bottom: 8px" (click)="downloadClicked()" [disabled]="downloadingfile || url === ''" type="submit" mat-stroked-button color="accent">

--- a/src/app/main/main.component.spec.ts
+++ b/src/app/main/main.component.spec.ts
@@ -178,4 +178,58 @@ describe('MainComponent', () => {
     expect(component.download_uids).toEqual(['download-9']);
     expect(component.current_download && component.current_download.uid).toBe('download-9');
   });
+
+  it('shows playlist download option for single YouTube URL with list param', () => {
+    component.url = 'https://www.youtube.com/watch?v=wOWhfNB_r-0&list=PLIhvC56v63IJIujb5cyE13oLuyORZpdkL&index=6';
+
+    expect(component.hasPlaylistUrlInInput()).toBeTrue();
+    expect(component.shouldShowDownloadMenu()).toBeTrue();
+  });
+
+  it('does not show playlist download option for non-playlist URL', () => {
+    component.url = 'https://www.youtube.com/watch?v=wOWhfNB_r-0';
+
+    expect(component.hasPlaylistUrlInInput()).toBeFalse();
+  });
+
+  it('keeps download menu visible when sponsorblock option is enabled', () => {
+    component.sponsorBlockApiEnabled = true;
+    component.url = 'https://www.youtube.com/watch?v=wOWhfNB_r-0';
+
+    expect(component.shouldShowDownloadMenu()).toBeTrue();
+  });
+
+  it('maps playlist menu action to canonical playlist URL', () => {
+    component.url = 'https://www.youtube.com/watch?v=wOWhfNB_r-0&list=PLIhvC56v63IJIujb5cyE13oLuyORZpdkL&index=6';
+    const download_spy = spyOn(component, 'downloadClicked');
+
+    component.downloadPlaylistClicked();
+
+    expect(download_spy).toHaveBeenCalledWith(
+      false,
+      'https://www.youtube.com/playlist?list=PLIhvC56v63IJIujb5cyE13oLuyORZpdkL',
+      false
+    );
+  });
+
+  it('falls back to normal download when playlist action is unavailable', () => {
+    component.url = 'https://www.youtube.com/watch?v=wOWhfNB_r-0';
+    const download_spy = spyOn(component, 'downloadClicked');
+
+    component.downloadPlaylistClicked();
+
+    expect(download_spy).toHaveBeenCalledWith();
+  });
+
+  it('keeps main download as single-video for watch URLs that include list param', () => {
+    const download_file_spy = jasmine.createSpy('downloadFile').and.returnValue(of({download: {uid: 'queued-1'}}));
+    (component as any).postsService.downloadFile = download_file_spy;
+    component.url = 'https://www.youtube.com/watch?v=wOWhfNB_r-0&list=PLIhvC56v63IJIujb5cyE13oLuyORZpdkL&index=6';
+    component.autoplay = true;
+
+    component.downloadClicked();
+
+    const called_url = download_file_spy.calls.argsFor(0)[0];
+    expect(called_url).toBe('https://www.youtube.com/watch?v=wOWhfNB_r-0');
+  });
 });

--- a/src/app/main/main.component.ts
+++ b/src/app/main/main.component.ts
@@ -330,16 +330,39 @@ export class MainComponent implements OnInit {
   }
 
   // download click handler
-  downloadClicked(disableSponsorBlock = false): void {
+  shouldShowDownloadMenu(): boolean {
+    return this.sponsorBlockApiEnabled || this.hasPlaylistUrlInInput();
+  }
+
+  hasPlaylistUrlInInput(): boolean {
+    return this.getPlaylistDownloadUrl(this.url || '') !== null;
+  }
+
+  downloadPlaylistClicked(): void {
+    const playlist_url = this.getPlaylistDownloadUrl(this.url || '');
+    if (!playlist_url) {
+      this.downloadClicked();
+      return;
+    }
+    this.downloadClicked(false, playlist_url, false);
+  }
+
+  downloadClicked(disableSponsorBlock = false, urlOverride: string | null = null, sanitizeSingleWatchUrl = true): void {
+    let effective_url = typeof urlOverride === 'string' ? urlOverride : (this.url || '');
+
     // Sanitize single YouTube watch URLs (keep only v=...)
-    const _urlsForSanitize = this.getURLArray(this.url || '');
-    if (_urlsForSanitize.length === 1) {
-      const _sanitized = this.sanitizeYouTubeWatchUrl(_urlsForSanitize[0]);
-      if (_sanitized && _sanitized !== _urlsForSanitize[0]) {
-        this.url = _sanitized;
+    const urls_for_sanitize = this.getURLArray(effective_url);
+    if (sanitizeSingleWatchUrl && urls_for_sanitize.length === 1) {
+      const sanitized = this.sanitizeYouTubeWatchUrl(urls_for_sanitize[0]);
+      if (sanitized && sanitized !== urls_for_sanitize[0]) {
+        effective_url = sanitized;
+        if (urlOverride === null) {
+          this.url = sanitized;
+        }
       }
     }
-    if (!this.ValidURL(this.url)) {
+
+    if (!this.ValidURL(effective_url)) {
       this.urlError = true;
       return;
     }
@@ -383,9 +406,9 @@ export class MainComponent implements OnInit {
     this.selectedQuality = '';
     this.downloadingfile = true;
 
-    const urls = this.getURLArray(this.url);
+    const urls = this.getURLArray(effective_url);
     for (let i = 0; i < urls.length; i++) {
-      const url = this.sanitizeYouTubeWatchUrl(urls[i]);
+      const url = sanitizeSingleWatchUrl ? this.sanitizeYouTubeWatchUrl(urls[i]) : urls[i];
       this.postsService.downloadFile(url, type as FileType, (customQualityConfiguration || selected_quality === '' || typeof selected_quality !== 'string' ? null : selected_quality),
         customQualityConfiguration, customArgs, additionalArgs, customOutput, youtubeUsername, youtubePassword, cropFileSettings, disableSponsorBlock).subscribe(res => {
           const queued_downloads = Array.isArray(res['downloads']) && res['downloads'].length > 0
@@ -529,17 +552,6 @@ export class MainComponent implements OnInit {
 
   inputChanged(new_val: string): void {
     this.selectedQuality = '';
-
-    // Sanitize YouTube watch URLs (keep only v=...) so a \"video-from-playlist\" link
-    // doesn't get treated like a playlist by the downloader.
-    const urls = this.getURLArray(new_val || '');
-    if (urls.length === 1) {
-      const sanitized = this.sanitizeYouTubeWatchUrl(urls[0]);
-      if (sanitized && sanitized !== urls[0]) {
-        this.url = sanitized;
-        new_val = sanitized;
-      }
-    }
     if (new_val === '' || !new_val) {
       this.results_showing = false;
     } else {
@@ -614,6 +626,24 @@ export class MainComponent implements OnInit {
     } catch {
       return null;
     }
+  }
+
+  private getPlaylistDownloadUrl(raw: string): string | null {
+    const urls = this.getURLArray(raw || '');
+    if (urls.length !== 1) return null;
+    const playlist_id = this.getYouTubePlaylistId(urls[0]);
+    if (!playlist_id) return null;
+    return `https://www.youtube.com/playlist?list=${encodeURIComponent(playlist_id)}`;
+  }
+
+  private getYouTubePlaylistId(raw: string): string | null {
+    const parsed_url = this.safeParseURL(raw);
+    if (!parsed_url) return null;
+    const host = parsed_url.hostname.replace(/^www\./, '').toLowerCase();
+    const is_youtube_host = host === 'youtube.com' || host === 'm.youtube.com' || host === 'music.youtube.com' || host === 'youtu.be';
+    if (!is_youtube_host) return null;
+    const playlist_id = parsed_url.searchParams.get('list');
+    return playlist_id || null;
   }
 
   // If this is a YouTube watch URL (or youtu.be), return a canonical single-video URL with ONLY v=


### PR DESCRIPTION
## Summary
- show the download split-button when SponsorBlock is enabled or the pasted URL has a YouTube `list` query param
- add a `Download Playlist` menu option (first item) when playlist download is applicable
- keep default main `Download` behavior as single-video for watch URLs
- preserve existing `Download without SponsorBlock` option when SponsorBlock is enabled
- add unit tests covering menu visibility, playlist mapping, fallback behavior, and single-video default behavior

## Testing
- `CHROME_BIN=/usr/bin/chromium npm test -- --watch=false --browsers=ChromeHeadless --include src/app/main/main.component.spec.ts`
- Result: `15 SUCCESS`