### PR TITLE
perf(player): optimize chapter loading and chapter UI state updates

### DIFF
--- a/src/app/player/player.component.html
+++ b/src/app/player/player.component.html
@@ -27,13 +27,13 @@
                   <div class="col-auto chapter-column">
                     <div class="chapter-dropdown-wrapper" (click)="$event.stopPropagation()">
                       <button class="chapter-dropdown-trigger" type="button" (click)="toggleChapterDropdown($event)">
-                        <span class="chapter-dropdown-current">{{getCurrentChapterLabel()}}</span>
+                        <span class="chapter-dropdown-current">{{currentChapterLabel}}</span>
                         <mat-icon class="chapter-dropdown-icon" [class.open]="chapterDropdownOpen">chevron_right</mat-icon>
                       </button>
                       @if (chapterDropdownOpen) {
                         <div class="chapter-dropdown-menu">
-                          @for (chapter of currentChapters; track chapter.start_time) {
-                            <button class="chapter-item" [class.active]="isChapterActive(chapter)" (click)="selectChapterFromDropdown(chapter, $event)" type="button" [title]="chapter.title">
+                          @for (chapter of currentChapters; track chapter.start_time; let chapterIndex = $index) {
+                            <button class="chapter-item" [class.active]="chapterIndex === activeChapterIndex" (click)="selectChapterFromDropdown(chapter, $event)" type="button" [title]="chapter.title">
                               <span class="chapter-time">{{formatChapterTimestamp(chapter.start_time)}}</span>
                               <span class="chapter-label">{{chapter.title}}</span>
                             </button>

--- a/src/app/player/player.component.spec.ts
+++ b/src/app/player/player.component.spec.ts
@@ -25,6 +25,12 @@ describe('PlayerComponent', () => {
         }
       },
       setPageTitle: jasmine.createSpy('setPageTitle'),
+      getAllFiles: jasmine.createSpy('getAllFiles').and.returnValue({
+        subscribe: () => ({ unsubscribe() {} })
+      }),
+      getFile: jasmine.createSpy('getFile').and.returnValue({
+        subscribe: () => ({ unsubscribe() {} })
+      }),
       service_initialized: {
         pipe: () => ({
           subscribe: () => ({ unsubscribe() {} })
@@ -167,5 +173,46 @@ describe('PlayerComponent', () => {
     expect(clickEvent.stopPropagation).toHaveBeenCalled();
     expect(seekSpy).toHaveBeenCalledWith(42);
     expect(component.chapterDropdownOpen).toBeFalse();
+  });
+
+  it('should request autoplay queue without chapter metadata in bulk mode', () => {
+    const media: IMedia = {
+      title: 'Single file',
+      src: '/stream/test',
+      type: 'video/mp4',
+      label: 'Single file',
+      url: 'https://example.com/video',
+      uid: 'uid-single'
+    };
+    component.uid = 'uid-single';
+    component.playlist = [media];
+    component.currentItem = media;
+    component.autoplay_enabled = true;
+    component.autoplay_queue_initialized = false;
+    component.autoplay_queue_loading = false;
+
+    component.ensureAutoplayQueueReady();
+
+    expect(postsServiceStub.getAllFiles).toHaveBeenCalled();
+    expect(postsServiceStub.getAllFiles.calls.mostRecent().args[6]).toBeFalse();
+  });
+
+  it('should cache active chapter index and label from playback time', () => {
+    component.currentChapters = [
+      { title: 'Intro', start_time: 0, end_time: 30 },
+      { title: 'Part 2', start_time: 30, end_time: 90 }
+    ];
+    component.api = { currentTime: 45 } as unknown as VgApiService;
+
+    component.refreshCurrentChapterState();
+
+    expect(component.activeChapterIndex).toBe(1);
+    expect(component.currentChapterLabel).toBe('Part 2');
+
+    component.api = { currentTime: 5 } as unknown as VgApiService;
+    component.onPlaybackTimeUpdate();
+
+    expect(component.activeChapterIndex).toBe(0);
+    expect(component.currentChapterLabel).toBe('Intro');
   });
 });

--- a/src/app/player/player.component.ts
+++ b/src/app/player/player.component.ts
@@ -93,6 +93,10 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
   autoplay_queue_file_objs: DatabaseFile[] = [];
   currentChapters: IChapter[] = [];
   chapterDropdownOpen = false;
+  currentChapterLabel = $localize`Chapters`;
+  activeChapterIndex = -1;
+  chapterCacheByUID = new Map<string, IChapter[]>();
+  chapterLoadInFlight = new Set<string>();
 
   @ViewChild('twitchchat') twitchChat: TwitchChatComponent;
 
@@ -271,6 +275,7 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
 
       this.api.getDefaultMedia().subscriptions.loadedMetadata.subscribe(this.playVideo.bind(this));
       this.api.getDefaultMedia().subscriptions.ended.subscribe(this.nextVideo.bind(this));
+      this.api.getDefaultMedia().subscriptions.timeUpdate.subscribe(this.onPlaybackTimeUpdate.bind(this));
 
       if (this.timestamp) {
         this.api.seekTime(+this.timestamp);
@@ -503,6 +508,11 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
 
   createMediaObject(file_obj: DatabaseFile): IMedia {
     const mime_type = file_obj.isAudio ? 'audio/mp3' : 'video/mp4';
+    const hasChapterPayload = Array.isArray(file_obj.chapters);
+    const normalizedChapters = hasChapterPayload ? this.normalizeChapters(file_obj.chapters) : undefined;
+    if (hasChapterPayload && file_obj.uid) {
+      this.chapterCacheByUID.set(file_obj.uid, normalizedChapters);
+    }
     const mediaObject: IMedia = {
       title: file_obj.title,
       src: this.createStreamURL(file_obj.uid),
@@ -510,7 +520,7 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
       label: file_obj.title,
       url: file_obj.url,
       uid: file_obj.uid,
-      chapters: this.normalizeChapters(file_obj.chapters)
+      chapters: normalizedChapters
     };
     return mediaObject;
   }
@@ -570,7 +580,7 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
     const textSearch = this.queue_search?.trim() ? this.queue_search.trim() : null;
     const queueSubID = this.queue_sub_id || null;
 
-    this.postsService.getAllFiles(sort, null, textSearch, fileTypeFilter, this.queue_favorite_filter, queueSubID, true).subscribe(res => {
+    this.postsService.getAllFiles(sort, null, textSearch, fileTypeFilter, this.queue_favorite_filter, queueSubID, false).subscribe(res => {
       if (!this.autoplay_enabled) {
         this.autoplay_queue_loading = false;
         this.pending_autoplay_advance = false;
@@ -588,9 +598,7 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
       if (currentIndex === -1) return;
 
       this.playlist = newPlaylist;
-      this.currentIndex = currentIndex;
-      this.currentItem = this.playlist[currentIndex];
-      this.syncCurrentSingleFileMetadata();
+      this.updateCurrentItem(this.playlist[currentIndex], currentIndex);
       this.original_playlist = JSON.stringify(this.playlist);
       this.autoplay_queue_initialized = true;
 
@@ -618,7 +626,21 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   syncCurrentChapters(): void {
-    this.currentChapters = this.currentItem?.chapters ?? [];
+    const current_uid = this.currentItem?.uid;
+    if (Array.isArray(this.currentItem?.chapters)) {
+      this.currentChapters = this.currentItem.chapters;
+      if (current_uid) {
+        this.chapterCacheByUID.set(current_uid, this.currentChapters);
+      }
+    } else if (current_uid && this.chapterCacheByUID.has(current_uid)) {
+      this.currentChapters = this.chapterCacheByUID.get(current_uid) ?? [];
+      this.currentItem.chapters = this.currentChapters;
+    } else {
+      this.currentChapters = [];
+    }
+
+    this.refreshCurrentChapterState();
+    this.ensureCurrentItemChaptersLoaded();
     this.chapterDropdownOpen = false;
   }
 
@@ -639,14 +661,14 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   isChapterActive(chapter: IChapter): boolean {
-    if (!this.api) return false;
-    const current_time = this.api.currentTime || 0;
-    return current_time >= chapter.start_time && current_time < chapter.end_time;
+    return this.currentChapters[this.activeChapterIndex] === chapter;
   }
 
   jumpToChapter(chapter: IChapter): void {
     if (!this.api) return;
-    this.setPlaybackTimestamp(Math.floor(chapter.start_time));
+    const target_time = Math.floor(chapter.start_time);
+    this.setPlaybackTimestamp(target_time);
+    this.refreshCurrentChapterState(target_time);
   }
 
   toggleChapterDropdown(event: MouseEvent): void {
@@ -662,12 +684,13 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
 
   getCurrentChapter(): IChapter | null {
     if (this.currentChapters.length === 0) return null;
-    const active_chapter = this.currentChapters.find(chapter => this.isChapterActive(chapter));
+    const current_time = this.api?.currentTime ?? 0;
+    const active_chapter = this.currentChapters.find(chapter => current_time >= chapter.start_time && current_time < chapter.end_time);
     return active_chapter ?? this.currentChapters[0];
   }
 
   getCurrentChapterLabel(): string {
-    return this.getCurrentChapter()?.title ?? $localize`Chapters`;
+    return this.currentChapterLabel;
   }
 
   formatChapterTimestamp(total_seconds: number): string {
@@ -686,6 +709,66 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
     const idx = this.autoplay_queue_file_objs.findIndex(file_obj => file_obj.uid === updated_file.uid);
     if (idx >= 0) {
       this.autoplay_queue_file_objs[idx] = updated_file;
+    }
+  }
+
+  onPlaybackTimeUpdate(): void {
+    this.refreshCurrentChapterState();
+  }
+
+  refreshCurrentChapterState(current_time = this.api?.currentTime ?? 0): void {
+    if (this.currentChapters.length === 0) {
+      this.activeChapterIndex = -1;
+      this.currentChapterLabel = $localize`Chapters`;
+      return;
+    }
+
+    const next_active_index = this.currentChapters.findIndex(chapter => current_time >= chapter.start_time && current_time < chapter.end_time);
+    this.activeChapterIndex = next_active_index >= 0 ? next_active_index : 0;
+    this.currentChapterLabel = this.currentChapters[this.activeChapterIndex]?.title ?? $localize`Chapters`;
+  }
+
+  ensureCurrentItemChaptersLoaded(): void {
+    const current_uid = this.currentItem?.uid;
+    if (!current_uid || this.chapterLoadInFlight.has(current_uid)) {
+      return;
+    }
+
+    if (this.chapterCacheByUID.has(current_uid)) {
+      this.applyChaptersToMedia(current_uid, this.chapterCacheByUID.get(current_uid) ?? []);
+      return;
+    }
+
+    this.chapterLoadInFlight.add(current_uid);
+    this.postsService.getFile(current_uid, this.uuid).subscribe(res => {
+      this.chapterLoadInFlight.delete(current_uid);
+      const normalized_chapters = this.normalizeChapters(res?.file?.chapters);
+      this.chapterCacheByUID.set(current_uid, normalized_chapters);
+      this.applyChaptersToMedia(current_uid, normalized_chapters);
+    }, () => {
+      this.chapterLoadInFlight.delete(current_uid);
+    });
+  }
+
+  applyChaptersToMedia(uid: string, chapters: IChapter[]): void {
+    const playlist_item = this.playlist.find(media => media.uid === uid);
+    if (playlist_item) {
+      playlist_item.chapters = chapters;
+    }
+
+    const current_queue_file = this.autoplay_queue_file_objs.find(file_obj => file_obj.uid === uid);
+    if (current_queue_file) {
+      current_queue_file.chapters = chapters;
+    }
+
+    if (this.db_file?.uid === uid) {
+      this.db_file.chapters = chapters;
+    }
+
+    if (this.currentItem?.uid === uid) {
+      this.currentItem.chapters = chapters;
+      this.currentChapters = chapters;
+      this.refreshCurrentChapterState();
     }
   }
 


### PR DESCRIPTION
## Summary
- optimize autoplay queue loading by calling `getAllFiles` with `include_chapters=false` to avoid sidecar chapter parsing for the entire library queue
- add lazy chapter hydration for the active media item when chapter payload is missing, with in-memory UID cache to avoid repeat fetches
- replace template-time chapter computations with cached `activeChapterIndex` and `currentChapterLabel` updated from player `timeUpdate` events
- keep existing chapter UX behavior (active highlight + chapter jump) while reducing per-change-detection work

## Validation
- `npm run -s lint`
- `CHROME_BIN=chromium npm run -s test -- --watch=false --browsers=ChromeHeadless --include src/app/player/player.component.spec.ts`
- `npm run -s build`
