### PR TITLE
feat(ui): move playlists into a tabbed library view

### DIFF
--- a/src/app/components/recent-videos/recent-videos.component.html
+++ b/src/app/components/recent-videos/recent-videos.component.html
@@ -1,133 +1,139 @@
-<div class="container-fluid" style="max-width: 941px;">
-  <div class="row">
-    <!-- Sorting -->
-    <div class="col-12 order-2 col-sm-4 order-sm-1 d-flex justify-content-center">
-      <app-sort-property [(sortProperty)]="sortProperty" [(descendingMode)]="descendingMode" (sortOptionChanged)="sortOptionChanged($event)"></app-sort-property>
-    </div>
-    <!-- Files title -->
-    <div class="col-12 order-1 col-sm-4 order-sm-2 d-flex justify-content-center">
-      @if (!customHeader) {
-        <h4 class="my-videos-title" i18n="My files title">My files</h4>
-      }
-      @if (customHeader) {
-        <h4 class="my-videos-title">{{customHeader}}</h4>
-      }
-    </div>
-    <!-- Search -->
-    <div class="col-12 order-3 col-sm-4 order-sm-3 d-flex justify-content-center">
-      <mat-form-field appearance="outline" [ngClass]="searchIsFocused ? 'search-bar-focused' : 'search-bar-unfocused'" class="search-bar" color="accent">
-        <mat-label i18n="Search">Search</mat-label>
-        <input (focus)="searchIsFocused = true" (blur)="searchIsFocused = false" class="search-input" type="text" [(ngModel)]="search_text" (ngModelChange)="onSearchInputChanged($event)" matInput>
-        <mat-icon matSuffix>search</mat-icon>
-      </mat-form-field>
-    </div>
-  </div>
-  <!-- Filters -->
-  <div class="row justify-content-center">
-    <mat-chip-listbox class="filter-list" [value]="selectedFilters" [multiple]="true" (change)="selectedFiltersChanged($event)">
-      @for (filter of fileFilters | keyvalue: originalOrder; track filter.key) {
-        <mat-chip-option [value]="filter.key" [selected]="selectedFilters.includes(filter.key)" color="accent">{{filter.value.label}}</mat-chip-option>
-      }
-    </mat-chip-listbox>
-  </div>
-</div>
-<div>
-  <!-- Files -->
-  @if (!selectMode) {
-    <div class="container" style="margin-bottom: 16px">
-      <div class="row justify-content-center">
-        <!-- Real cards -->
-        @if (normal_files_received && paged_data) {
-          @for (file of paged_data; track file.uid; let i = $index) {
-            <div style="display: flex; align-items: center;" class="mb-2 mt-2 d-flex justify-content-center" [ngClass]="[ postsService.card_size === 'small' ? 'col-2 small-col' : '', postsService.card_size === 'medium' ? 'col-6 col-lg-4 medium-col' : '', postsService.card_size === 'large' ? 'col-12 large-col' : '' ]">
-              <app-unified-file-card [ngClass]="downloading_content[file.uid] ? 'blurred' : ''" [index]="i" [card_size]="postsService.card_size" [locale]="postsService.locale" (goToFile)="goToFile($event)" (goToSubscription)="goToSubscription($event)" (toggleFavorite)="toggleFavorite($event)" [file_obj]="file" [use_youtubedl_archive]="postsService.config['Downloader']['use_youtubedl_archive']" [availablePlaylists]="playlists" (addFileToPlaylist)="addFileToPlaylist($event)" [loading]="false" (deleteFile)="deleteFile($event)" [baseStreamPath]="postsService.path" [jwtString]="postsService.isLoggedIn ? this.postsService.token : ''" [apiKeyString]="!postsService.isLoggedIn ? postsService.auth_token : ''"></app-unified-file-card>
-              @if (downloading_content[file.uid]) {
-                <mat-spinner class="downloading-spinner" [diameter]="32"></mat-spinner>
+@if (!selectMode) {
+  @if (showLibraryTabs) {
+    <mat-tab-group class="library-tab-group" [selectedIndex]="activeLibraryTab" (selectedIndexChange)="libraryTabChanged($event)">
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <span i18n="Videos tab label">Videos</span>
+          <span class="tab-count">{{file_count}}</span>
+        </ng-template>
+        <ng-container [ngTemplateOutlet]="videoLibraryContent"></ng-container>
+      </mat-tab>
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <span i18n="Playlists tab label">Playlists</span>
+          <span class="tab-count">{{playlistLibraryItems.length}}</span>
+        </ng-template>
+
+        <div class="container-fluid library-header" style="max-width: 1080px;">
+          <div class="row">
+            <div class="col-12 order-2 col-sm-3 order-sm-1 d-flex justify-content-center">
+              <app-sort-property [(sortProperty)]="sortProperty" [(descendingMode)]="descendingMode" (sortOptionChanged)="sortOptionChanged($event)"></app-sort-property>
+            </div>
+            <div class="col-12 order-1 col-sm-3 order-sm-2 d-flex justify-content-center">
+              <h4 class="my-videos-title" i18n="Playlists library title">Playlists</h4>
+            </div>
+            <div class="col-12 order-4 col-sm-4 order-sm-3 d-flex justify-content-center">
+              <mat-form-field appearance="outline" [ngClass]="playlistSearchIsFocused ? 'search-bar-focused' : 'search-bar-unfocused'" class="search-bar" color="accent">
+                <mat-label i18n="Search playlists">Search playlists</mat-label>
+                <input (focus)="playlistSearchIsFocused = true" (blur)="playlistSearchIsFocused = false" class="search-input" type="text" [(ngModel)]="playlistSearchText" (ngModelChange)="onPlaylistSearchInputChanged($event)" matInput>
+                <mat-icon matSuffix>search</mat-icon>
+              </mat-form-field>
+            </div>
+            <div class="col-12 order-3 col-sm-2 order-sm-4 d-flex justify-content-center justify-content-sm-end">
+              <button (click)="openCreatePlaylistDialog()" class="create-playlist-button" mat-stroked-button color="accent">
+                <mat-icon>playlist_add</mat-icon>
+                <span i18n="Create playlist button">New playlist</span>
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div class="container" style="margin-bottom: 16px">
+          <div class="row justify-content-center">
+            @if (playlistLibraryReceived) {
+              @for (playlist of visiblePlaylists; track playlist.id; let i = $index) {
+                <div style="display: flex; align-items: center;" class="mb-2 mt-2 d-flex justify-content-center" [ngClass]="[ postsService.card_size === 'small' ? 'col-2 small-col' : '', postsService.card_size === 'medium' ? 'col-6 col-lg-4 medium-col' : '', postsService.card_size === 'large' ? 'col-12 large-col' : '' ]">
+                  <app-unified-file-card [ngClass]="downloading_content[playlist.id] ? 'blurred' : ''" [index]="i" [card_size]="postsService.card_size" [locale]="postsService.locale" (goToFile)="goToPlaylist($event)" [file_obj]="playlist" [is_playlist]="true" (editPlaylist)="editPlaylistDialog($event)" (deleteFile)="deletePlaylist($event)" [baseStreamPath]="postsService.path" [jwtString]="postsService.isLoggedIn ? this.postsService.token : ''" [apiKeyString]="!postsService.isLoggedIn ? postsService.auth_token : ''" [loading]="false"></app-unified-file-card>
+                  @if (downloading_content[playlist.id]) {
+                    <mat-spinner class="downloading-spinner" [diameter]="32"></mat-spinner>
+                  }
+                </div>
               }
-            </div>
-          }
-          @if (paged_data.length === 0) {
-            <div>
-              <ng-container i18n="No files found">No files found.</ng-container>
-            </div>
-          }
+              @if (visiblePlaylists.length === 0) {
+                <div class="playlist-empty-state">
+                  <div i18n="No playlists found message">No playlists found.</div>
+                  <button (click)="openCreatePlaylistDialog()" mat-flat-button color="accent" i18n="Create first playlist button">
+                    Create playlist
+                  </button>
+                </div>
+              }
+            }
+
+            @if (!playlistLibraryReceived) {
+              @for (card of playlistLoadingCards; track $index; let i = $index) {
+                <div class="mb-2 mt-2 d-flex justify-content-center" [ngClass]="[ postsService.card_size === 'small' ? 'col-2 small-col' : '', postsService.card_size === 'medium' ? 'col-6 col-lg-4 medium-col' : '', postsService.card_size === 'large' ? 'col-12 large-col' : '' ]">
+                  <app-unified-file-card [index]="i" [card_size]="postsService.card_size" [locale]="postsService.locale" [loading]="true" [theme]="postsService.theme"></app-unified-file-card>
+                </div>
+              }
+            }
+          </div>
+        </div>
+      </mat-tab>
+    </mat-tab-group>
+  } @else {
+    <ng-container [ngTemplateOutlet]="videoLibraryContent"></ng-container>
+  }
+}
+
+<ng-template #videoLibraryContent>
+  <div class="container-fluid library-header" style="max-width: 941px;">
+    <div class="row">
+      <div class="col-12 order-2 col-sm-4 order-sm-1 d-flex justify-content-center">
+        <app-sort-property [(sortProperty)]="sortProperty" [(descendingMode)]="descendingMode" (sortOptionChanged)="sortOptionChanged($event)"></app-sort-property>
+      </div>
+      <div class="col-12 order-1 col-sm-4 order-sm-2 d-flex justify-content-center">
+        @if (showLibraryTabs) {
+          <h4 class="my-videos-title" i18n="Videos library title">Videos</h4>
+        } @else if (!customHeader) {
+          <h4 class="my-videos-title" i18n="My files title">My files</h4>
+        } @else {
+          <h4 class="my-videos-title">{{customHeader}}</h4>
         }
-        <!-- Fake cards -->
-        <ng-container>
-          @for (file of loading_files; track $index; let i = $index) {
-            <div class="mb-2 mt-2 d-flex justify-content-center" [ngClass]="[normal_files_received ? 'hide' : '', postsService.card_size === 'small' ? 'col-2 small-col' : '', postsService.card_size === 'medium' ? 'col-6 col-lg-4 medium-col' : '', postsService.card_size === 'large' ? 'col-12 large-col' : '' ]">
-              <app-unified-file-card [index]="i" [card_size]="postsService.card_size" [locale]="postsService.locale" [loading]="true" [theme]="postsService.theme"></app-unified-file-card>
-            </div>
-          }
-        </ng-container>
+      </div>
+      <div class="col-12 order-3 col-sm-4 order-sm-3 d-flex justify-content-center">
+        <mat-form-field appearance="outline" [ngClass]="searchIsFocused ? 'search-bar-focused' : 'search-bar-unfocused'" class="search-bar" color="accent">
+          <mat-label i18n="Search">Search</mat-label>
+          <input (focus)="searchIsFocused = true" (blur)="searchIsFocused = false" class="search-input" type="text" [(ngModel)]="search_text" (ngModelChange)="onSearchInputChanged($event)" matInput>
+          <mat-icon matSuffix>search</mat-icon>
+        </mat-form-field>
       </div>
     </div>
-  }
-
-  @if (selectMode) {
-    <div>
-      <!-- If selected files e.g. for creating a playlist -->
-      <mat-tab-group [(selectedIndex)]="selectedIndex">
-        <mat-tab label="Order" i18n-label="Order">
-          @if (selected_data.length) {
-            <div>
-              @if (reverse_order === false) {
-                <span i18n="Normal order">Normal order&nbsp;</span>
-              }
-              @if (reverse_order === true) {
-                <span i18n="Reverse order">Reverse order&nbsp;</span>
-              }
-              <button (click)="toggleSelectionOrder()" mat-icon-button><mat-icon>{{!reverse_order ? 'arrow_downward' : 'arrow_upward'}}</mat-icon></button>
-            </div>
-          }
-          <!-- Selection order -->
-          @if (selected_data.length) {
-            <mat-button-toggle-group class="media-list" cdkDropList (cdkDropListDropped)="drop($event)" style="width: 80%; left: 9%" vertical #group="matButtonToggleGroup">
-              <!-- The following for loop can be optimized but it requires a pipe https://stackoverflow.com/a/35703364/8088021 -->
-              @for (file of (reverse_order ? selected_data_objs.slice().reverse() : selected_data_objs); track file.uid; let i = $index) {
-                <mat-button-toggle class="media-box" cdkDrag [checked]="false"><div><div class="playlist-item-text">{{file.title}}</div> <button (click)="removeSelectedFile(i)" class="remove-item-button" mat-icon-button><mat-icon>cancel</mat-icon></button></div></mat-button-toggle>
-              }
-            </mat-button-toggle-group>
-          }
-          @if (!selected_data.length) {
-            <div style="margin-top: 20px;">
-              <h4 style="text-align: center;">No files selected!</h4>
-            </div>
-          }
-        </mat-tab>
-        <mat-tab label="Select files" i18n-label="Select files">
-          @if (normal_files_received) {
-            <mat-selection-list (selectionChange)="fileSelectionChanged($event)">
-              @for (file of paged_data; track file.uid) {
-                <mat-list-option [selected]="selected_data.includes(file.uid)" [value]="file">
-                  <div class="container">
-                    <div class="row justify-content-center">
-                      <div class="col-10 select-file-title">
-                        <mat-icon class="audio-video-icon">{{file.isAudio ? 'audiotrack' : 'movie'}}</mat-icon>
-                        {{file.title}}
-                      </div>
-                      <div class="col-2">{{file.registered | date:'shortDate'}}</div>
-                    </div>
-                  </div>
-                </mat-list-option>
-              }
-            </mat-selection-list>
-          }
-          @if (!normal_files_received && loading_files && loading_files.length > 0) {
-            @if (!normal_files_received) {
-              <mat-selection-list>
-                @for (file of paged_data; track $index) {
-                  <mat-list-option>
-                    <content-loader class="list-ghosts" [backgroundColor]="postsService.theme.ghost_primary" [foregroundColor]="postsService.theme.ghost_secondary" viewBox="0 0 250 8"><svg:rect x="0" y="0" rx="3" ry="3" width="250" height="8" /></content-loader>
-                  </mat-list-option>
-                }
-              </mat-selection-list>
-            }
-          }
-        </mat-tab>
-      </mat-tab-group>
+    <div class="row justify-content-center">
+      <mat-chip-listbox class="filter-list" [value]="selectedFilters" [multiple]="true" (change)="selectedFiltersChanged($event)">
+        @for (filter of fileFilters | keyvalue: originalOrder; track filter.key) {
+          <mat-chip-option [value]="filter.key" [selected]="selectedFilters.includes(filter.key)" color="accent">{{filter.value.label}}</mat-chip-option>
+        }
+      </mat-chip-listbox>
     </div>
-  }
+  </div>
+
+  <div class="container" style="margin-bottom: 16px">
+    <div class="row justify-content-center">
+      @if (normal_files_received && paged_data) {
+        @for (file of paged_data; track file.uid; let i = $index) {
+          <div style="display: flex; align-items: center;" class="mb-2 mt-2 d-flex justify-content-center" [ngClass]="[ postsService.card_size === 'small' ? 'col-2 small-col' : '', postsService.card_size === 'medium' ? 'col-6 col-lg-4 medium-col' : '', postsService.card_size === 'large' ? 'col-12 large-col' : '' ]">
+            <app-unified-file-card [ngClass]="downloading_content[file.uid] ? 'blurred' : ''" [index]="i" [card_size]="postsService.card_size" [locale]="postsService.locale" (goToFile)="goToFile($event)" (goToSubscription)="goToSubscription($event)" (toggleFavorite)="toggleFavorite($event)" [file_obj]="file" [use_youtubedl_archive]="postsService.config['Downloader']['use_youtubedl_archive']" [availablePlaylists]="playlists" (addFileToPlaylist)="addFileToPlaylist($event)" [loading]="false" (deleteFile)="deleteFile($event)" [baseStreamPath]="postsService.path" [jwtString]="postsService.isLoggedIn ? this.postsService.token : ''" [apiKeyString]="!postsService.isLoggedIn ? postsService.auth_token : ''"></app-unified-file-card>
+            @if (downloading_content[file.uid]) {
+              <mat-spinner class="downloading-spinner" [diameter]="32"></mat-spinner>
+            }
+          </div>
+        }
+        @if (paged_data.length === 0) {
+          <div>
+            <ng-container i18n="No files found">No files found.</ng-container>
+          </div>
+        }
+      }
+
+      <ng-container>
+        @for (file of loading_files; track $index; let i = $index) {
+          <div class="mb-2 mt-2 d-flex justify-content-center" [ngClass]="[normal_files_received ? 'hide' : '', postsService.card_size === 'small' ? 'col-2 small-col' : '', postsService.card_size === 'medium' ? 'col-6 col-lg-4 medium-col' : '', postsService.card_size === 'large' ? 'col-12 large-col' : '' ]">
+            <app-unified-file-card [index]="i" [card_size]="postsService.card_size" [locale]="postsService.locale" [loading]="true" [theme]="postsService.theme"></app-unified-file-card>
+          </div>
+        }
+      </ng-container>
+    </div>
+  </div>
 
   @if (usePaginator && selectedIndex > 0) {
     <div style="position: relative;">
@@ -137,4 +143,66 @@
       </mat-paginator>
     </div>
   }
-</div>
+</ng-template>
+
+@if (selectMode) {
+  <div>
+    <mat-tab-group [(selectedIndex)]="selectedIndex">
+      <mat-tab label="Order" i18n-label="Order">
+        @if (selected_data.length) {
+          <div>
+            @if (reverse_order === false) {
+              <span i18n="Normal order">Normal order&nbsp;</span>
+            }
+            @if (reverse_order === true) {
+              <span i18n="Reverse order">Reverse order&nbsp;</span>
+            }
+            <button (click)="toggleSelectionOrder()" mat-icon-button><mat-icon>{{!reverse_order ? 'arrow_downward' : 'arrow_upward'}}</mat-icon></button>
+          </div>
+        }
+        @if (selected_data.length) {
+          <mat-button-toggle-group class="media-list" cdkDropList (cdkDropListDropped)="drop($event)" style="width: 80%; left: 9%" vertical #group="matButtonToggleGroup">
+            @for (file of (reverse_order ? selected_data_objs.slice().reverse() : selected_data_objs); track file.uid; let i = $index) {
+              <mat-button-toggle class="media-box" cdkDrag [checked]="false"><div><div class="playlist-item-text">{{file.title}}</div> <button (click)="removeSelectedFile(i)" class="remove-item-button" mat-icon-button><mat-icon>cancel</mat-icon></button></div></mat-button-toggle>
+            }
+          </mat-button-toggle-group>
+        }
+        @if (!selected_data.length) {
+          <div style="margin-top: 20px;">
+            <h4 style="text-align: center;">No files selected!</h4>
+          </div>
+        }
+      </mat-tab>
+      <mat-tab label="Select files" i18n-label="Select files">
+        @if (normal_files_received) {
+          <mat-selection-list (selectionChange)="fileSelectionChanged($event)">
+            @for (file of paged_data; track file.uid) {
+              <mat-list-option [selected]="selected_data.includes(file.uid)" [value]="file">
+                <div class="container">
+                  <div class="row justify-content-center">
+                    <div class="col-10 select-file-title">
+                      <mat-icon class="audio-video-icon">{{file.isAudio ? 'audiotrack' : 'movie'}}</mat-icon>
+                      {{file.title}}
+                    </div>
+                    <div class="col-2">{{file.registered | date:'shortDate'}}</div>
+                  </div>
+                </div>
+              </mat-list-option>
+            }
+          </mat-selection-list>
+        }
+        @if (!normal_files_received && loading_files && loading_files.length > 0) {
+          @if (!normal_files_received) {
+            <mat-selection-list>
+              @for (file of paged_data; track $index) {
+                <mat-list-option>
+                  <content-loader class="list-ghosts" [backgroundColor]="postsService.theme.ghost_primary" [foregroundColor]="postsService.theme.ghost_secondary" viewBox="0 0 250 8"><svg:rect x="0" y="0" rx="3" ry="3" width="250" height="8" /></content-loader>
+                </mat-list-option>
+              }
+            </mat-selection-list>
+          }
+        }
+      </mat-tab>
+    </mat-tab-group>
+  </div>
+}

--- a/src/app/components/recent-videos/recent-videos.component.scss
+++ b/src/app/components/recent-videos/recent-videos.component.scss
@@ -51,9 +51,63 @@
     top: 12px;
 }
 
+.library-header {
+    padding-top: 8px;
+}
+
+.library-tab-group {
+    margin: 0 auto;
+}
+
+.tab-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 24px;
+    height: 24px;
+    margin-left: 8px;
+    padding: 0 8px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.12);
+    font-size: 12px;
+    line-height: 1;
+}
+
+.create-playlist-button {
+    margin-top: 10px;
+    min-width: 148px;
+    border-radius: 999px;
+}
+
+.playlist-empty-state {
+    width: min(100%, 420px);
+    margin-top: 18px;
+    padding: 28px 24px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 18px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+    text-align: center;
+}
+
 @media (max-width: 576px) {
     .my-videos-title {
         top: 0px;
+    }
+
+    .search-bar {
+        float: none;
+    }
+
+    .search-bar-unfocused,
+    .search-bar-focused {
+        width: min(100%, 280px);
+    }
+
+    .create-playlist-button {
+        margin-top: 0;
     }
 }
 
@@ -126,4 +180,8 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
+}
+
+:host ::ng-deep .library-tab-group .mat-mdc-tab-header {
+    margin-bottom: 12px;
 }

--- a/src/app/components/recent-videos/recent-videos.component.ts
+++ b/src/app/components/recent-videos/recent-videos.component.ts
@@ -1,7 +1,7 @@
 import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { PostsService } from 'app/posts.services';
 import { Router } from '@angular/router';
-import { DatabaseFile, FileType, FileTypeFilter, Sort } from '../../../api-types';
+import { DatabaseFile, FileType, FileTypeFilter, Playlist, Sort } from '../../../api-types';
 import { MatPaginator } from '@angular/material/paginator';
 import { Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, filter, take } from 'rxjs/operators';
@@ -9,6 +9,8 @@ import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 import { MatChipListboxChange } from '@angular/material/chips';
 import { MatSelectionListChange } from '@angular/material/list';
 import { saveAs } from 'file-saver';
+import { MatDialog } from '@angular/material/dialog';
+import { CreatePlaylistComponent } from 'app/create-playlist/create-playlist.component';
 
 @Component({
     selector: 'app-recent-videos',
@@ -18,6 +20,7 @@ import { saveAs } from 'file-saver';
 })
 export class RecentVideosComponent implements OnInit {
   readonly pageSizeStorageKey = 'recent_videos_page_size';
+  readonly libraryTabStorageKey = 'recent_videos_library_tab';
 
   @Input() usePaginator = true;
 
@@ -51,6 +54,9 @@ export class RecentVideosComponent implements OnInit {
   search_text = '';
   searchIsFocused = false;
   descendingMode = true;
+  activeLibraryTab = 0;
+  playlistSearchText = '';
+  playlistSearchIsFocused = false;
 
   fileFilters = {
     video_only: {
@@ -73,14 +79,22 @@ export class RecentVideosComponent implements OnInit {
 
   sortProperty = 'registered';
   
-  playlists = null;
+  playlists: Playlist[] = [];
+  playlistLibraryItems: Playlist[] = [];
+  playlistLibraryReceived = false;
+  playlistLoadingCards = Array(6).fill(0);
 
   @ViewChild('paginator') paginator: MatPaginator
 
-  constructor(public postsService: PostsService, private router: Router) {
+  constructor(public postsService: PostsService, private router: Router, private dialog: MatDialog) {
     const saved_page_size = +localStorage.getItem(this.pageSizeStorageKey);
     if ([5, 10, 25, 100, 250].includes(saved_page_size)) {
       this.pageSize = saved_page_size;
+    }
+
+    const saved_library_tab = +localStorage.getItem(this.libraryTabStorageKey);
+    if ([0, 1].includes(saved_library_tab)) {
+      this.activeLibraryTab = saved_library_tab;
     }
 
     // get cached file count
@@ -120,13 +134,19 @@ export class RecentVideosComponent implements OnInit {
 
     if (this.postsService.initialized) {
       this.getAllFiles();
-      this.getAllPlaylists();
+      this.getAvailablePlaylists();
+      if (this.showLibraryTabs) {
+        this.getPlaylistLibraryItems();
+      }
     } else {
       this.postsService.service_initialized
         .pipe(filter(Boolean), take(1))
         .subscribe(() => {
           this.getAllFiles();
-          this.getAllPlaylists();
+          this.getAvailablePlaylists();
+          if (this.showLibraryTabs) {
+            this.getPlaylistLibraryItems();
+          }
         });
     }
 
@@ -138,7 +158,10 @@ export class RecentVideosComponent implements OnInit {
 
     this.postsService.playlists_changed.subscribe(changed => {
       if (changed) {
-        this.getAllPlaylists();
+        this.getAvailablePlaylists();
+        if (this.showLibraryTabs) {
+          this.getPlaylistLibraryItems();
+        }
       }
     });
 
@@ -156,14 +179,49 @@ export class RecentVideosComponent implements OnInit {
         } else {
           this.search_mode = false;
         }
-        this.getAllFiles();
+        if (!this.showLibraryTabs || this.activeLibraryTab === 0) {
+          this.getAllFiles();
+        }
       });
   }
 
+  get showLibraryTabs(): boolean {
+    return !this.selectMode && !this.sub_id;
+  }
+
   getAllPlaylists(): void {
+    this.getAvailablePlaylists();
+    if (this.showLibraryTabs) {
+      this.getPlaylistLibraryItems();
+    }
+  }
+
+  getAvailablePlaylists(): void {
     this.postsService.getPlaylists().subscribe(res => {
       this.playlists = res['playlists'];
     });
+  }
+
+  getPlaylistLibraryItems(): void {
+    this.playlistLibraryReceived = false;
+    this.postsService.getPlaylists(true).subscribe(res => {
+      this.playlistLibraryItems = res['playlists'];
+      this.playlistLibraryReceived = true;
+    });
+  }
+
+  get visiblePlaylists(): Playlist[] {
+    const normalized_search_text = this.playlistSearchText.trim().toLowerCase();
+    const filtered_playlists = this.playlistLibraryItems.filter(playlist => {
+      if (!normalized_search_text) {
+        return true;
+      }
+
+      const playlist_title = (playlist.name || '').toLowerCase();
+      return playlist_title.includes(normalized_search_text);
+    });
+
+    return filtered_playlists.slice().sort((a, b) => this.comparePlaylistValues(a, b));
   }
 
   // search
@@ -173,13 +231,33 @@ export class RecentVideosComponent implements OnInit {
     this.searchChangedSubject.next(newvalue);
   }
 
+  onPlaylistSearchInputChanged(newvalue: string): void {
+    this.playlistSearchText = newvalue;
+  }
+
+  libraryTabChanged(index: number): void {
+    this.activeLibraryTab = index;
+    localStorage.setItem(this.libraryTabStorageKey, `${index}`);
+
+    if (index === 0) {
+      this.getAllFiles();
+      return;
+    }
+
+    if (this.showLibraryTabs && !this.playlistLibraryReceived) {
+      this.getPlaylistLibraryItems();
+    }
+  }
+
   sortOptionChanged(value: Sort): void {
     localStorage.setItem('sort_property', value['by']);
     localStorage.setItem('recent_videos_sort_order', value['order'] === -1 ? 'descending' : 'ascending');
     this.descendingMode = value['order'] === -1;
     this.sortProperty = value['by'];
     
-    this.getAllFiles();
+    if (!this.showLibraryTabs || this.activeLibraryTab === 0) {
+      this.getAllFiles();
+    }
   }
 
   filterChanged(value: string): void {
@@ -369,15 +447,46 @@ export class RecentVideosComponent implements OnInit {
     const playlist = this.playlists.find(potential_playlist => potential_playlist['id'] === playlist_id);
     this.postsService.addFileToPlaylist(playlist_id, file['uid']).subscribe(res => {
       if (res['success']) {
-        this.postsService.openSnackBar(`Successfully added ${file.title} to ${playlist.title}!`);
+        this.postsService.openSnackBar(`Successfully added ${file.title} to ${playlist?.name || 'playlist'}!`);
         this.postsService.playlists_changed.next(true);
       } else {
-        this.postsService.openSnackBar(`Failed to add ${file.title} to ${playlist.title}! Unknown error.`);
+        this.postsService.openSnackBar(`Failed to add ${file.title} to ${playlist?.name || 'playlist'}! Unknown error.`);
       }
     }, err => {
       console.error(err);
-      this.postsService.openSnackBar(`Failed to add ${file.title} to ${playlist.title}! See browser console for error.`);
+      this.postsService.openSnackBar(`Failed to add ${file.title} to ${playlist?.name || 'playlist'}! See browser console for error.`);
     });
+  }
+
+  comparePlaylistValues(a: Playlist, b: Playlist): number {
+    const direction = this.descendingMode ? -1 : 1;
+
+    let left_value: string | number;
+    let right_value: string | number;
+
+    switch (this.sortProperty) {
+      case 'title':
+        left_value = (a.name || '').toLowerCase();
+        right_value = (b.name || '').toLowerCase();
+        break;
+      case 'duration':
+        left_value = a.duration ?? 0;
+        right_value = b.duration ?? 0;
+        break;
+      case 'registered':
+      default:
+        left_value = a.registered ?? 0;
+        right_value = b.registered ?? 0;
+        break;
+    }
+
+    if (left_value < right_value) {
+      return direction;
+    }
+    if (left_value > right_value) {
+      return -direction;
+    }
+    return 0;
   }
 
   // sorting and filtering
@@ -451,5 +560,103 @@ export class RecentVideosComponent implements OnInit {
   toggleFavorite(file_obj): void {
     file_obj.favorite = !file_obj.favorite;
     this.postsService.updateFile(file_obj.uid, {favorite: file_obj.favorite}).subscribe(res => {});
+  }
+
+  openCreatePlaylistDialog(): void {
+    const dialogRef = this.dialog.open(CreatePlaylistComponent, {
+      data: {
+        create_mode: true
+      },
+      minWidth: '90vw',
+      minHeight: '95vh'
+    });
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.getAllPlaylists();
+        this.postsService.openSnackBar($localize`Successfully created playlist!`);
+      } else if (result === false) {
+        this.postsService.openSnackBar($localize`ERROR: failed to create playlist!`);
+      }
+    });
+  }
+
+  goToPlaylist(info_obj: { file: Playlist; event?: KeyboardEvent | MouseEvent | { ctrlKey?: boolean } }): void {
+    const playlist = info_obj.file;
+    const open_in_new_tab = !!info_obj.event?.ctrlKey;
+
+    if (!playlist) {
+      return;
+    }
+
+    if (this.postsService.config['Extra']['download_only_mode']) {
+      this.downloadPlaylist(playlist.id, playlist.name);
+      return;
+    }
+
+    this.navigateToPlaylist(playlist, open_in_new_tab);
+  }
+
+  navigateToPlaylist(playlist: Playlist, new_tab: boolean): void {
+    localStorage.setItem('player_navigator', this.router.url);
+    const routeParams = this.getPlaylistRouteParams(playlist);
+
+    if (!new_tab) {
+      this.router.navigate(['/player', routeParams]);
+      return;
+    }
+
+    const routeURL = this.router.serializeUrl(this.router.createUrlTree(['/player', routeParams]));
+    window.open(`/#${routeURL}`);
+  }
+
+  getPlaylistRouteParams(playlist: Playlist): Record<string, string> {
+    const routeParams: Record<string, string> = {
+      playlist_id: playlist.id
+    };
+
+    if (playlist.auto) {
+      routeParams['auto'] = `${playlist.auto}`;
+    }
+
+    return routeParams;
+  }
+
+  downloadPlaylist(playlist_id: string, playlist_name: string): void {
+    this.downloading_content[playlist_id] = true;
+    this.postsService.downloadPlaylistFromServer(playlist_id).subscribe(res => {
+      this.downloading_content[playlist_id] = false;
+      const blob: Blob = res;
+      saveAs(blob, playlist_name + '.zip');
+    });
+  }
+
+  deletePlaylist(args: { file: Playlist; index: number; }): void {
+    const playlist = args.file;
+    const playlist_id = playlist.id;
+    this.postsService.removePlaylist(playlist_id).subscribe(res => {
+      if (res['success']) {
+        this.playlistLibraryItems = this.playlistLibraryItems.filter(existing_playlist => existing_playlist.id !== playlist_id);
+        this.playlists = this.playlists.filter(existing_playlist => existing_playlist.id !== playlist_id);
+        this.postsService.openSnackBar($localize`Playlist successfully removed.`);
+      }
+      this.getAllPlaylists();
+    });
+  }
+
+  editPlaylistDialog(args: { playlist: Playlist; }): void {
+    const playlist = args.playlist;
+    const dialogRef = this.dialog.open(CreatePlaylistComponent, {
+      data: {
+        playlist_id: playlist.id,
+        create_mode: false
+      },
+      minWidth: '85vw'
+    });
+
+    dialogRef.afterClosed().subscribe(() => {
+      if (dialogRef.componentInstance.playlist_updated) {
+        this.getAllPlaylists();
+      }
+    });
   }
 }

--- a/src/app/main/main.component.html
+++ b/src/app/main/main.component.html
@@ -246,7 +246,4 @@
 
   @if (cachedFileManagerEnabled || fileManagerEnabled) {
     <app-recent-videos #recentVideos></app-recent-videos>
-    <br/>
-    <h4 style="text-align: center">Custom playlists</h4>
-    <app-custom-playlists></app-custom-playlists>
   }


### PR DESCRIPTION
## Summary
- replace the stacked files + custom playlists sections with a single tabbed library surface
- add a playlists tab with search, local sorting, and an inline new playlist action
- keep video browsing and playlist management wired through the existing unified file cards

## Testing
- npx ng build
- CHROME_BIN=/usr/bin/chromium npx ng test --watch=false --browsers=ChromeHeadless --include='src/app/main/main.component.spec.ts' --include='src/app/components/recent-videos/recent-videos.component.spec.ts'
- npx eslint src/app/components/recent-videos/recent-videos.component.ts src/app/main/main.component.ts