### PR TITLE
fix(deps): refresh outdated lockfiles

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -757,9 +757,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -294,13 +294,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.2102.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2102.6.tgz",
-      "integrity": "sha512-h4qybKypR7OuwcTHPQI1zRm7abXgmPiV49vI2UeMtVVY/GKzru9gMexcYmWabzEyBY8w6VSfWjV2X+eit2EhDQ==",
+      "version": "0.2102.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2102.7.tgz",
+      "integrity": "sha512-4K/5hln9iaPEt3F/NyYqncNLvYpzSjRslEkHl2xIgZwQsIFHEvhnDRBYj2/oatURQhBqO/Yu15z/icVOYLxuTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "21.2.6",
+        "@angular-devkit/core": "21.2.7",
         "rxjs": "7.8.2"
       },
       "bin": {
@@ -313,17 +313,17 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "21.2.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-21.2.6.tgz",
-      "integrity": "sha512-eUWcWiMOUg01QyJkaO/csyTy8ZecW2HrMvOlgM+IWLagDyqFQVcSwcx9/NJy/42YA+EtpBcCnXPK3vk5NVob7w==",
+      "version": "21.2.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-21.2.7.tgz",
+      "integrity": "sha512-MeAsrvTq3of5x2r5g3cFhWpcb/goHVC5/7BfE+AiWuwClqsgbVoD/HiSXkQ50g2P+JQJ3Qx/DR2cC01H+k6pjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2102.6",
-        "@angular-devkit/build-webpack": "0.2102.6",
-        "@angular-devkit/core": "21.2.6",
-        "@angular/build": "21.2.6",
+        "@angular-devkit/architect": "0.2102.7",
+        "@angular-devkit/build-webpack": "0.2102.7",
+        "@angular-devkit/core": "21.2.7",
+        "@angular/build": "21.2.7",
         "@babel/core": "7.29.0",
         "@babel/generator": "7.29.1",
         "@babel/helper-annotate-as-pure": "7.27.3",
@@ -334,7 +334,7 @@
         "@babel/preset-env": "7.29.0",
         "@babel/runtime": "7.28.6",
         "@discoveryjs/json-ext": "0.6.3",
-        "@ngtools/webpack": "21.2.6",
+        "@ngtools/webpack": "21.2.7",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.27",
         "babel-loader": "10.0.0",
@@ -389,7 +389,7 @@
         "@angular/platform-browser": "^21.0.0",
         "@angular/platform-server": "^21.0.0",
         "@angular/service-worker": "^21.0.0",
-        "@angular/ssr": "^21.2.6",
+        "@angular/ssr": "^21.2.7",
         "@web/test-runner": "^0.20.0",
         "browser-sync": "^3.0.2",
         "jest": "^30.2.0",
@@ -446,13 +446,13 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.2102.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.2102.6.tgz",
-      "integrity": "sha512-IN0xUlFTOmDt+UrW1X7ymYgp94Y/HfMj4zNahplBEbBl72WmqQdJGiDMThGgFY+RzJJMyAbqD7RDyiimsVkfOA==",
+      "version": "0.2102.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.2102.7.tgz",
+      "integrity": "sha512-EANoPney0B0SsbF5LVZvABDkxrSXw0nly7TmGrrV5UNmSLxhmF29IZ14vVGyy7En/zJHOIlQAP7YI39PdtYxqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2102.6",
+        "@angular-devkit/architect": "0.2102.7",
         "rxjs": "7.8.2"
       },
       "engines": {
@@ -466,9 +466,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "21.2.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.2.6.tgz",
-      "integrity": "sha512-u5gPTAY7MC02uACQE39xxiFcm1hslF+ih/f2borMWnhER0JNTpHjLiLRXFkq7or7+VVHU30zfhK4XNAuO4WTIg==",
+      "version": "21.2.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.2.7.tgz",
+      "integrity": "sha512-DONYY5u4IENO2qpd23mODaE4JI2EIohWV1kuJnsU9HIcm5wN714QB2z9WY/s4gLfUiAMIUu/8lpnW/0kOQZAnQ==",
       "license": "MIT",
       "dependencies": {
         "ajv": "8.18.0",
@@ -493,13 +493,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "21.2.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-21.2.6.tgz",
-      "integrity": "sha512-hk2duJlPJyiMaI9MVWA5XpmlpD9C4n8qgquV/MJ7/n+ZRSwW3w1ndL5qUmA1ki+4Da54v/Rc8Wt5tUS955+93w==",
+      "version": "21.2.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-21.2.7.tgz",
+      "integrity": "sha512-LYAjjUI1qM7pR/sd0yYt8OLA6ljOOXjcfzV40I5XQNmhAxq90YYS5xwMcixOmWX+z5zvCYGvPXvJGWjzio6SUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "21.2.6",
+        "@angular-devkit/core": "21.2.7",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.21",
         "ora": "9.3.0",
@@ -512,9 +512,9 @@
       }
     },
     "node_modules/@angular/animations": {
-      "version": "21.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.2.7.tgz",
-      "integrity": "sha512-h8tUjQVSWfi2fohzxXeDDTjCfWABioYlPMrV1j98wCcFJad3FSnKCY0/gq8B4X6V81NGV29nEnhPyV0GinUBpQ==",
+      "version": "21.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.2.8.tgz",
+      "integrity": "sha512-RIqfVmfretQ0x/mXgMXe7Bw0Tpe8+zBV/Mm2OaNVyrmNG+9gYItEn5t/ZnQGcPD5nMNqckgp3+4/ZMc/qkS5ww==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -523,18 +523,18 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "21.2.7"
+        "@angular/core": "21.2.8"
       }
     },
     "node_modules/@angular/build": {
-      "version": "21.2.6",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-21.2.6.tgz",
-      "integrity": "sha512-PJltYl9/INfz8nZ/KHf39nqlmt3c9PR0jJaZt6hhCPENyAf4PwQpm28erkJmbOYO864goIuws41lduYXyDqQ0Q==",
+      "version": "21.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-21.2.7.tgz",
+      "integrity": "sha512-FpSkFqpsJtdN1cROekVYkmeV1QepdP+/d7fyYQEuNmlOlyqXSDh9qJmy4iL9VNbAU0rk+vFCtYM86rO7Pt9cSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2102.6",
+        "@angular-devkit/architect": "0.2102.7",
         "@babel/core": "7.29.0",
         "@babel/helper-annotate-as-pure": "7.27.3",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -558,7 +558,7 @@
         "source-map-support": "0.5.21",
         "tinyglobby": "0.2.15",
         "undici": "7.24.4",
-        "vite": "7.3.1",
+        "vite": "7.3.2",
         "watchpack": "2.5.1"
       },
       "engines": {
@@ -577,7 +577,7 @@
         "@angular/platform-browser": "^21.0.0",
         "@angular/platform-server": "^21.0.0",
         "@angular/service-worker": "^21.0.0",
-        "@angular/ssr": "^21.2.6",
+        "@angular/ssr": "^21.2.7",
         "karma": "^6.4.0",
         "less": "^4.2.0",
         "ng-packagr": "^21.0.0",
@@ -627,9 +627,9 @@
       }
     },
     "node_modules/@angular/cdk": {
-      "version": "21.2.5",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.2.5.tgz",
-      "integrity": "sha512-F1sVqMAGYoiJNYYaR2cerqTo7IqpxQ3ZtMDxR3rtB0rSSd5UPOIQoqpsfSd6uH8FVnuzKaBII8Mg6YrjClFsng==",
+      "version": "21.2.6",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.2.6.tgz",
+      "integrity": "sha512-1PBzFf+um/VZ1dFF6cT72Zsq+9C/ZWF9m5dP0uHJgo4psX3yMBoZlZu5YomBiAQ/ePSkqCuryv1vrelK+yd3Mw==",
       "license": "MIT",
       "dependencies": {
         "parse5": "^8.0.0",
@@ -643,19 +643,19 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "21.2.6",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-21.2.6.tgz",
-      "integrity": "sha512-I5DOFcIT1HKymyy2f78fjgD0Iv6jG46GbBZ/VxejcnhjubFpuN4CwPdugXf9rIDs8KZQqBzDBFUbq11vnk8h0A==",
+      "version": "21.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-21.2.7.tgz",
+      "integrity": "sha512-N/wj8fFRB718efIFYpwnYfy+MecZREZXsUNMTVndFLH6T0jCheb9PVetR6jsyZp6h46USNPOmJYJ/9255lME+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2102.6",
-        "@angular-devkit/core": "21.2.6",
-        "@angular-devkit/schematics": "21.2.6",
+        "@angular-devkit/architect": "0.2102.7",
+        "@angular-devkit/core": "21.2.7",
+        "@angular-devkit/schematics": "21.2.7",
         "@inquirer/prompts": "7.10.1",
         "@listr2/prompt-adapter-inquirer": "3.0.5",
         "@modelcontextprotocol/sdk": "1.26.0",
-        "@schematics/angular": "21.2.6",
+        "@schematics/angular": "21.2.7",
         "@yarnpkg/lockfile": "1.1.0",
         "algoliasearch": "5.48.1",
         "ini": "6.0.0",
@@ -678,9 +678,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "21.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.7.tgz",
-      "integrity": "sha512-YFdnU5z8JloJjLYa52OyCOULQhqEE/ym7vKfABySWDsiVXZr9FNmKMeZi/lUcg7ZO22UbBihqW9a9D6VSHOo+g==",
+      "version": "21.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.8.tgz",
+      "integrity": "sha512-ZvgcxsLPkSG0B1jc2ZXshAWIFBoQ0U9uwIX/zG/RGcfMpoKyEDNAebli6FTIpxIlz/35rtBNV7EGPhinjPTJFQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -689,14 +689,14 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "21.2.7",
+        "@angular/core": "21.2.8",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "21.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.7.tgz",
-      "integrity": "sha512-4J0Nl5gGmr5SKgR3FHK4J6rdG0aP5zAsY3AJU8YXH+D98CeNTjQUD8XHsdD2cTwo08V5mDdFa5VCsREpMPJ5gQ==",
+      "version": "21.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.8.tgz",
+      "integrity": "sha512-Il9KlT6qX8rWmun5jY6wMLx56bCQZpOVIFEyHM4ai2wmxvbqyxgRFKDs4iMRNn1h04Tgupl6cKSqP9lecIvH6w==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -706,9 +706,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "21.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-21.2.7.tgz",
-      "integrity": "sha512-r76vKBM7Wu0N8PTeec7340Gtv1wC7IBQGJOQnukshPgzaabgNKxmUiChGxi+RJNo/Tsdiw9ZfddcBgBjq79ZIg==",
+      "version": "21.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-21.2.8.tgz",
+      "integrity": "sha512-S0W+6QazCsn/4xWZu0V5VmU9zmKIlqFR2FJSsAQUPReVmpA40SuQSP6A/cyMVIMYaHvO/cAXSHJVgpxBzBSL/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -729,7 +729,7 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "21.2.7",
+        "@angular/compiler": "21.2.8",
         "typescript": ">=5.9 <6.1"
       },
       "peerDependenciesMeta": {
@@ -739,9 +739,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "21.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.7.tgz",
-      "integrity": "sha512-4bnskeRNNOZMn3buVw47Zz9Py4B8AZgYHe5xBEMOY5/yrldb7OFje5gWCWls23P18FKwhl+Xx1hgnOEPSs29gw==",
+      "version": "21.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.8.tgz",
+      "integrity": "sha512-hI7n4t8qgFJaVV55LIaNuzcdP+/IeuqQRu3huSLo47Gf6uZAD0Acj4Ye9SC8YNmhUu5/RiImngm9NOlcI2oCJA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -750,7 +750,7 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "21.2.7",
+        "@angular/compiler": "21.2.8",
         "rxjs": "^6.5.3 || ^7.4.0",
         "zone.js": "~0.15.0 || ~0.16.0"
       },
@@ -764,9 +764,9 @@
       }
     },
     "node_modules/@angular/forms": {
-      "version": "21.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.2.7.tgz",
-      "integrity": "sha512-YD/h07cdEeAUs41ysTk6820T0lG/XiQmFiq02d3IsiHYI5Vaj2pg9Ti1wWZYEBM//hVAPTzV0dwdV7Q1Gxju1w==",
+      "version": "21.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.2.8.tgz",
+      "integrity": "sha512-tyQAHjfMHcqETRkKQaZHjYqIK9W8uRenPpY2DF/Jl+S7CwcaX4T8t8TKgzvTynNzQW9QGiLg0pqVosVMKzBXJg==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -776,16 +776,16 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "21.2.7",
-        "@angular/core": "21.2.7",
-        "@angular/platform-browser": "21.2.7",
+        "@angular/common": "21.2.8",
+        "@angular/core": "21.2.8",
+        "@angular/platform-browser": "21.2.8",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/language-service": {
-      "version": "21.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-21.2.7.tgz",
-      "integrity": "sha512-XulGTWSw9S3CbTLmNivZtaqfZC2QJvt0grApV/bPZ1evRmnvO0Ep3EaLN2+zAfBQiD5tg3eTHhsCemL5HD+CWw==",
+      "version": "21.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-21.2.8.tgz",
+      "integrity": "sha512-Eyvoo3ttFhRAAEmPcLkLfbEtTLfKnAxRAbxNoA9eDXozskkgaDDBUAHd9qOC1A6cnVda5nP4aNeUa+I81Q2maw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -793,9 +793,9 @@
       }
     },
     "node_modules/@angular/localize": {
-      "version": "21.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/localize/-/localize-21.2.7.tgz",
-      "integrity": "sha512-EcZHeEuEy9Fr4cWOwdJudPVbjfqso82bAXmnAE0f+Rt5LB3Le8O5RDGgV52EuLo8gzTiWzhVUI7Zg1tYkBqnSQ==",
+      "version": "21.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/localize/-/localize-21.2.8.tgz",
+      "integrity": "sha512-wt1ZIE2c7IL1KOgfJyr7pN5SNoQXy02dB/dswZKQlJWduVWkzG83uftPFPjhfASQeqrlpW7tXhb6PiRkJGlCkg==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "7.29.0",
@@ -812,20 +812,20 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "21.2.7",
-        "@angular/compiler-cli": "21.2.7"
+        "@angular/compiler": "21.2.8",
+        "@angular/compiler-cli": "21.2.8"
       }
     },
     "node_modules/@angular/material": {
-      "version": "21.2.5",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-21.2.5.tgz",
-      "integrity": "sha512-hSil2QUKObjF73EbhUEA5xAZx0/o9r/AFrkRsxa2z9e11jSjlKJHrYuY1tMIFv3SpzK33EYf58IXOBJVwt0iIw==",
+      "version": "21.2.6",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-21.2.6.tgz",
+      "integrity": "sha512-V4hblb5ekgXb5x+UXKRs2yiB0hZUkUJbYwGseMglkCeWQlLM4u6amlsUzP4uOwIWFOkM/ZYl9qz4YGZnvMAyjw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/cdk": "21.2.5",
+        "@angular/cdk": "21.2.6",
         "@angular/common": "^21.0.0 || ^22.0.0",
         "@angular/core": "^21.0.0 || ^22.0.0",
         "@angular/forms": "^21.0.0 || ^22.0.0",
@@ -834,9 +834,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "21.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.2.7.tgz",
-      "integrity": "sha512-nklVhstRZL4wpYg9Cyae/Eyfa7LMpgb0TyD/F//qCuohhM8nM7F+O0ekykGD6H+I34jsvqx6yLS7MicndWVz7Q==",
+      "version": "21.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.2.8.tgz",
+      "integrity": "sha512-4fwmGf7GCuIsjFqx1gqqWC92YjlN9SmGJO17TPPsOm5zUOnDx+h3Bj9XjdXxlcBtugTb2xHk6Auqyv3lzWGlkw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -845,9 +845,9 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "21.2.7",
-        "@angular/common": "21.2.7",
-        "@angular/core": "21.2.7"
+        "@angular/animations": "21.2.8",
+        "@angular/common": "21.2.8",
+        "@angular/core": "21.2.8"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -856,9 +856,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "21.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-21.2.7.tgz",
-      "integrity": "sha512-P7s9ABgJqRyUS5HNRJFRr15xaXbWfSH9KjSxkBYYJbXIA986uGb6qjnHepu+2xMyZDlt2nd9Ms+t4M60/GM+FQ==",
+      "version": "21.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-21.2.8.tgz",
+      "integrity": "sha512-9XeplSHsKnLDm14dvwXG00Ox6WbDrhf7ub7MxxcJ6gCgRm/yqJ3Vrz4a+NBpYnelapqiCCGEdHeyx2xt8vG1qA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -867,16 +867,16 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "21.2.7",
-        "@angular/compiler": "21.2.7",
-        "@angular/core": "21.2.7",
-        "@angular/platform-browser": "21.2.7"
+        "@angular/common": "21.2.8",
+        "@angular/compiler": "21.2.8",
+        "@angular/core": "21.2.8",
+        "@angular/platform-browser": "21.2.8"
       }
     },
     "node_modules/@angular/router": {
-      "version": "21.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-21.2.7.tgz",
-      "integrity": "sha512-Ina6XgtpvXT1OsLAomURHJGQDOkIVGrguWAOZ7+gOjsJEjUfpxTktFter+/K59KMC2yv6yneLvYSn3AswTYx7A==",
+      "version": "21.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-21.2.8.tgz",
+      "integrity": "sha512-KSlUbFHHKY84G6iKlB2FDMmh+lLmGjmpyT1p/kx8qZm1BuxJGOOU+oNgkCfaPJT1R2/muDXuxQ51uc/la6y28g==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -885,9 +885,9 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "21.2.7",
-        "@angular/core": "21.2.7",
-        "@angular/platform-browser": "21.2.7",
+        "@angular/common": "21.2.8",
+        "@angular/core": "21.2.8",
+        "@angular/platform-browser": "21.2.8",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -4476,6 +4476,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4493,6 +4496,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4510,6 +4516,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4527,6 +4536,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4544,6 +4556,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4561,6 +4576,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4578,6 +4596,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4656,9 +4677,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4687,9 +4708,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "21.2.6",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-21.2.6.tgz",
-      "integrity": "sha512-SU6aMvFz/0uM2WhIGrZ/QexEIqT/VdLfcmy7OYAxOd3w7u2wqQao/1uSOEJo+BR+B48QYf7Z5LLpS8t1mWZYKQ==",
+      "version": "21.2.7",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-21.2.7.tgz",
+      "integrity": "sha512-Z4gjCaJbO16VUO8I2QjRNT87uRYxjTKSSImDhzgVgLpV2/stlv/akbLU8dJYa7pK7eIYb/tkNRxGn/AtCiViUQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5081,6 +5102,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5102,6 +5126,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5123,6 +5150,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5144,6 +5174,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5165,6 +5198,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5186,6 +5222,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5522,6 +5561,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5539,6 +5581,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5556,6 +5601,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5573,6 +5621,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5749,6 +5800,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5763,6 +5817,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5777,6 +5834,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5791,6 +5851,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5805,6 +5868,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5819,6 +5885,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5833,6 +5902,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5847,6 +5919,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5861,6 +5936,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5875,6 +5953,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5889,6 +5970,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5903,6 +5987,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5917,6 +6004,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6008,14 +6098,14 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "21.2.6",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-21.2.6.tgz",
-      "integrity": "sha512-KpLD8R2S762jbLdNEepE+b7KjhVOKPFHHdgNqhPv0NiGLdsvXSOx1e63JvFacoCZdmP7n3/gwmyT/utcVvnsag==",
+      "version": "21.2.7",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-21.2.7.tgz",
+      "integrity": "sha512-aqEj3RyBtmH+41HZvrbfrpCo0e+0NzwyQyNSC/wLDShVqoidBtPbEdHU1FZ4+ni41da7rI3F12gUuAHws27kMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "21.2.6",
-        "@angular-devkit/schematics": "21.2.6",
+        "@angular-devkit/core": "21.2.7",
+        "@angular-devkit/schematics": "21.2.7",
         "jsonc-parser": "3.3.1"
       },
       "engines": {


### PR DESCRIPTION
## Summary
- refresh the frontend lockfile to pull the Angular packages flagged by the outdated workflow to their latest allowed versions
- refresh the backend lockfile to pull `axios` to `1.15.0`
- keep the change focused to the two lockfiles so unrelated local modifications stay out of the PR

## Validation
- npm outdated
- (cd backend && npm outdated)
- npm run lint
- npx tsc -p src/tsconfig.app.json --noEmit
- npx tsc -p src/tsconfig.spec.json --noEmit
- CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npm run test:headless
- npx ng build --configuration production

Fixes the failing outdated workflow from actions run 24177615077.