### PR TITLE
fix(subscriptions): avoid flat-playlist info regressions

### DIFF
--- a/backend/downloader.js
+++ b/backend/downloader.js
@@ -1388,6 +1388,11 @@ function killActiveDownload(download) {
     }
 }
 
+function getDownloadableInfoItems(info = []) {
+    if (!Array.isArray(info)) return [];
+    return info.filter(info_obj => info_obj && info_obj['_filename']);
+}
+
 exports.collectInfo = async (download_uid) => {
     const download = await db_api.getRecord('download_queue', {uid: download_uid});
     if (download['paused']) {
@@ -1409,14 +1414,26 @@ exports.collectInfo = async (download_uid) => {
     let args = await exports.generateArgs(url, type, options, download['user_uid']);
 
     // get video info prior to download
-    let info = download['prefetched_info'] ? download['prefetched_info'] : await exports.getVideoInfoByURL(url, args, download_uid, options);
+    const has_prefetched_info = Array.isArray(download['prefetched_info']) && download['prefetched_info'].length > 0;
+    let info = has_prefetched_info ? download['prefetched_info'] : await exports.getVideoInfoByURL(url, args, download_uid, options);
 
     if (!info || info.length === 0) {
         // info failed, error presumably already recorded
         return;
     }
 
-    info = info.filter(info_obj => info_obj && info_obj['_filename']);
+    let downloadable_info = getDownloadableInfoItems(info);
+    if (downloadable_info.length === 0 && has_prefetched_info) {
+        // Flat-playlist subscription discovery queues minimal metadata. Fall back
+        // to a normal info lookup when the prefetched payload is not downloadable.
+        info = await exports.getVideoInfoByURL(url, args, download_uid, options);
+        if (!info || info.length === 0) {
+            return;
+        }
+        downloadable_info = getDownloadableInfoItems(info);
+    }
+
+    info = downloadable_info;
     if (info.length === 0) {
         const error_message = `No downloadable items were found while retrieving info for URL ${url}`;
         logger.error(error_message);

--- a/backend/subscriptions.js
+++ b/backend/subscriptions.js
@@ -440,6 +440,12 @@ function createSubscriptionRefreshStreamProcessor(sub, user_uid, refresh_tracker
     };
 }
 
+function getSubscriptionPrefetchedInfoForDownload(file_to_download = null) {
+    if (!file_to_download || typeof file_to_download !== 'object') return null;
+    if (!file_to_download['_filename']) return null;
+    return [file_to_download];
+}
+
 exports.subscribe = async (sub, user_uid = null, skip_get_info = false) => {
     const result_obj = {
         success: false,
@@ -777,11 +783,12 @@ async function handleOutputJSON(output_jsons, sub, user_uid, refresh_tracker = n
     const files_to_download = await getFilesToDownload(sub, filtered_output_jsons, effective_queue_context.download_context);
 
     for (const file_to_download of files_to_download) {
-        if (Array.isArray(file_to_download['formats'])) {
+        const prefetched_info = getSubscriptionPrefetchedInfoForDownload(file_to_download);
+        if (prefetched_info && Array.isArray(file_to_download['formats'])) {
             // Keep subscription queue payloads small when full info is available.
             file_to_download['formats'] = utils.stripPropertiesFromObject(file_to_download['formats'], ['format_id', 'filesize', 'filesize_approx']);
         }
-        await downloader_api.createDownload(file_to_download['webpage_url'], sub.type || 'video', effective_queue_context.base_download_options, user_uid, sub.id, sub.name, [file_to_download]);
+        await downloader_api.createDownload(file_to_download['webpage_url'], sub.type || 'video', effective_queue_context.base_download_options, user_uid, sub.id, sub.name, prefetched_info);
         effective_queue_context.queued_count += 1;
         if (refresh_tracker) {
             refresh_tracker.refresh_status.queued_count = effective_queue_context.queued_count;

--- a/backend/test/downloader.test.js
+++ b/backend/test/downloader.test.js
@@ -316,6 +316,37 @@ describe('Downloader', function() {
         }
     });
 
+    it('Collect info falls back to live info retrieval when prefetched metadata is not downloadable', async function() {
+        const original_get_video_info = downloader_api.getVideoInfoByURL;
+        let get_video_info_calls = 0;
+
+        try {
+            downloader_api.getVideoInfoByURL = async () => {
+                get_video_info_calls += 1;
+                return fixture_single;
+            };
+
+            const returned_download = await downloader_api.createDownload(url, 'video', {ui_uid: uuid()}, null, null, null, [{
+                webpage_url: url,
+                extractor: 'youtube',
+                id: 'flat-playlist-only',
+                title: 'Flat Playlist Entry'
+            }]);
+            await downloader_api.collectInfo(returned_download['uid']);
+            const updated_download = await db_api.getRecord('download_queue', {uid: returned_download['uid']});
+
+            assert.strictEqual(get_video_info_calls, 1);
+            assert.strictEqual(updated_download.error, null);
+            assert.strictEqual(updated_download.finished, false);
+            assert.strictEqual(updated_download.running, false);
+            assert.strictEqual(updated_download.finished_step, true);
+            assert(Array.isArray(updated_download.files_to_check_for_progress));
+            assert.strictEqual(updated_download.files_to_check_for_progress.length, 1);
+        } finally {
+            downloader_api.getVideoInfoByURL = original_get_video_info;
+        }
+    });
+
     it('Collect info skips duplicate single downloads without starting yt-dlp', async function() {
         const original_find_existing_duplicate = files_api.findExistingDuplicateByInfo;
         const original_warn_on_duplicate = config_api.getConfigItem('ytdl_warn_on_duplicate');

--- a/backend/test/subscriptions.test.js
+++ b/backend/test/subscriptions.test.js
@@ -196,6 +196,7 @@ describe('Subscriptions', function() {
 
             const queued_downloads = await db_api.getRecords('download_queue', {sub_id: sub.id});
             assert.strictEqual(queued_downloads.length, fake_outputs.length);
+            assert(queued_downloads.every(download => download.prefetched_info === null));
 
             const refreshed_sub = await subscriptions_api.getSubscription(sub.id);
             assert(refreshed_sub);


### PR DESCRIPTION
## Summary
- stop subscription refreshes from queueing flat-playlist discovery entries as downloadable prefetched info
- make `collectInfo()` fall back to a normal info lookup when older queued items only have incomplete prefetched metadata
- add regression tests for both the subscription queue path and the downloader fallback path

## Testing
- npm test -- test/downloader.test.js test/subscriptions.test.js
- npm run lint
- npx tsc -p src/tsconfig.app.json --noEmit
- npx tsc -p src/tsconfig.spec.json --noEmit
- CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npm run test:headless
- npx ng build --configuration production
- node --check backend/downloader.js
- node --check backend/subscriptions.js

Fixes the subscription refresh regression reported in #139.