### PR TITLE
fix(deps): update outdated workflow packages

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -25,7 +25,7 @@
         "express": "^5.2.1",
         "express-rate-limit": "^8.3.2",
         "express-session": "^1.19.0",
-        "feed": "^5.2.0",
+        "feed": "^5.2.1",
         "fluent-ffmpeg": "^2.1.3",
         "fs-extra": "^11.3.4",
         "gotify": "^1.1.0",
@@ -2135,9 +2135,9 @@
       "license": "MIT"
     },
     "node_modules/feed": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/feed/-/feed-5.2.0.tgz",
-      "integrity": "sha512-hgH6CCb+7+0c8PBlakI2KubG6R+Rb1MhpNcdvqUXZTBwBHf32piwY255diAkAmkGZ6AWlywOU88AkOgP9q8Rdw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/feed/-/feed-5.2.1.tgz",
+      "integrity": "sha512-jTynzYPWs9ALjro0GW8j7sv9y7cJBeOdD4Y88kVqYy/eyusIX3g+499JiTDIlD9Ge/unebx57T4Uzo6vpYvMtA==",
       "license": "MIT",
       "dependencies": {
         "xml-js": "^1.6.11"

--- a/backend/package.json
+++ b/backend/package.json
@@ -39,7 +39,7 @@
     "express": "^5.2.1",
     "express-rate-limit": "^8.3.2",
     "express-session": "^1.19.0",
-    "feed": "^5.2.0",
+    "feed": "^5.2.1",
     "fluent-ffmpeg": "^2.1.3",
     "fs-extra": "^11.3.4",
     "gotify": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "core-js": "^3.49.0",
         "crypto-js": "^4.2.0",
         "file-saver": "^2.0.2",
-        "filesize": "^11.0.15",
+        "filesize": "^11.0.16",
         "fs-extra": "^11.3.4",
         "material-icons": "^1.10.8",
         "nan": "^2.26.2",
@@ -9361,9 +9361,9 @@
       "license": "MIT"
     },
     "node_modules/filesize": {
-      "version": "11.0.15",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-11.0.15.tgz",
-      "integrity": "sha512-30TpbYxQxCpi4XdVjkwXYQ37CzZltV38+P7MYroQ+4NK/Dmx9mxixFNrolzcmEIBsjT/uowC9T7kiy2+C12r1A==",
+      "version": "11.0.16",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-11.0.16.tgz",
+      "integrity": "sha512-XMcUu0Zxnh0L8rY5b5vrdKKs0H3l3osTp9vNEBulRmwLqYfuQe5SJCagpA0/sGMJx2KHbD+IWOyd6QsJQuYEkQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 10.8.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "core-js": "^3.49.0",
     "crypto-js": "^4.2.0",
     "file-saver": "^2.0.2",
-    "filesize": "^11.0.15",
+    "filesize": "^11.0.16",
     "fs-extra": "^11.3.4",
     "material-icons": "^1.10.8",
     "nan": "^2.26.2",


### PR DESCRIPTION
## Summary
- update `backend` `feed` from `5.2.0` to `5.2.1`, which was the package flagged in the referenced outdated workflow run
- update root `filesize` from `11.0.15` to `11.0.16` so the current outdated check is also clean on latest `main`
- refresh both lockfiles

## Source
- https://github.com/voc0der/ytdl-material/actions/runs/24641617927/job/72046489036

## Testing
- npm outdated
- npm outdated (in `backend`)
- npm run lint
- npx tsc -p src/tsconfig.app.json --noEmit
- npx tsc -p src/tsconfig.spec.json --noEmit
- CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npm run test:headless
- npx ng build --configuration production