### PR TITLE
fix(downloads): cap refresh bursts after crashes

### DIFF
--- a/backend/downloader.js
+++ b/backend/downloader.js
@@ -583,6 +583,23 @@ function getExclusivePlaylistGroupKey(download = null) {
 }
 exports.getExclusivePlaylistGroupKey = getExclusivePlaylistGroupKey;
 
+function getCappedQueueGroup(download = null) {
+    if (!download || typeof download !== 'object') return null;
+    const options = download.options && typeof download.options === 'object' ? download.options : {};
+
+    const group_key = typeof options.concurrentQueueGroupKey === 'string'
+        ? options.concurrentQueueGroupKey.trim()
+        : '';
+    const group_limit = Math.max(0, asFiniteNumber(options.concurrentQueueGroupLimit, 0));
+    if (!group_key || group_limit <= 0) return null;
+
+    return {
+        key: `queue-group:${group_key}`,
+        limit: group_limit
+    };
+}
+exports.getCappedQueueGroup = getCappedQueueGroup;
+
 function getPlaylistBatchBaseTitle(download = null) {
     if (!download || typeof download !== 'object') return 'Playlist';
     const options = download.options && typeof download.options === 'object' ? download.options : {};
@@ -1277,7 +1294,7 @@ exports.setupDownloads = async () => {
 async function fixDownloadState() {
     const downloads = await db_api.getRecords('download_queue');
     downloads.sort((download1, download2) => download1.timestamp_start - download2.timestamp_start);
-    const running_downloads = downloads.filter(download => !download['finished'] && !download['error']);
+    const running_downloads = downloads.filter(download => download['running'] && !download['finished'] && !download['error']);
     for (let i = 0; i < running_downloads.length; i++) {
         const running_download = running_downloads[i];
         const update_obj = {finished_step: true, paused: true, running: false};
@@ -1287,6 +1304,7 @@ async function fixDownloadState() {
         await db_api.updateRecord('download_queue', {uid: running_download['uid']}, update_obj);
     }
 }
+exports.fixDownloadState = fixDownloadState;
 
 async function checkDownloads() {
     if (!should_check_downloads) return;
@@ -1307,6 +1325,15 @@ async function checkDownloads() {
     let running_downloads_count = downloads.filter(download => download['running']).length;
     const waiting_downloads = downloads.filter(download => !download['paused'] && download['finished_step'] && !download['finished']);
     const running_downloads = downloads.filter(download => download['running']);
+    const running_capped_queue_group_counts = new Map();
+
+    for (const running_download of running_downloads) {
+        const capped_queue_group = getCappedQueueGroup(running_download);
+        if (!capped_queue_group) continue;
+
+        const existing_group_count = running_capped_queue_group_counts.get(capped_queue_group.key) || 0;
+        running_capped_queue_group_counts.set(capped_queue_group.key, existing_group_count + 1);
+    }
 
     const running_exclusive_downloads = running_downloads
         .filter(download => isExclusivePlaylistDownload(download))
@@ -1353,6 +1380,14 @@ async function checkDownloads() {
             if (hasReachedConcurrentDownloadLimit(max_concurrent_downloads, running_downloads_count)) break;
         }
 
+        const capped_queue_group = getCappedQueueGroup(waiting_download);
+        if (capped_queue_group) {
+            const running_group_count = running_capped_queue_group_counts.get(capped_queue_group.key) || 0;
+            if (running_group_count >= capped_queue_group.limit) {
+                continue;
+            }
+        }
+
         if (waiting_download['finished_step'] && !waiting_download['finished']) {
             if (waiting_download['sub_id']) {
                 const sub_missing = !(await db_api.getRecord('subscriptions', {id: waiting_download['sub_id']}));
@@ -1367,6 +1402,11 @@ async function checkDownloads() {
                 exports.collectInfo(waiting_download['uid']);
             } else if (waiting_download['step_index'] === 1) {
                 exports.downloadQueuedFile(waiting_download['uid']);
+            }
+
+            if (capped_queue_group) {
+                const updated_group_count = (running_capped_queue_group_counts.get(capped_queue_group.key) || 0) + 1;
+                running_capped_queue_group_counts.set(capped_queue_group.key, updated_group_count);
             }
 
             if (exclusive_playlist_group_key && waiting_download_group_key === exclusive_playlist_group_key) {

--- a/backend/subscriptions.js
+++ b/backend/subscriptions.js
@@ -308,7 +308,11 @@ async function ensureSubscriptionRefreshQueueContext(sub, user_uid, refresh_trac
 
     const created_queue_context = {
         download_context: await createSubscriptionDownloadContext(sub),
-        base_download_options: exports.generateOptionsForSubscriptionDownload(sub, user_uid),
+        base_download_options: {
+            ...exports.generateOptionsForSubscriptionDownload(sub, user_uid),
+            concurrentQueueGroupKey: 'subscription-downloads',
+            concurrentQueueGroupLimit: downloader_api.getExclusivePlaylistConcurrencyLimit()
+        },
         queued_count: 0
     };
 

--- a/backend/test/downloader.test.js
+++ b/backend/test/downloader.test.js
@@ -229,6 +229,32 @@ describe('Downloader', function() {
         assert(success);
     });
 
+    it('fixDownloadState only pauses downloads that were actively running', async function() {
+        const running_download = await downloader_api.createDownload(`${url}&running_recovery=1`, 'video', {ui_uid: uuid()});
+        const waiting_download = await downloader_api.createDownload(`${url}&waiting_recovery=1`, 'video', {ui_uid: uuid()});
+
+        await db_api.updateRecord('download_queue', {uid: running_download['uid']}, {
+            step_index: 1,
+            finished_step: false,
+            running: true
+        });
+
+        await downloader_api.fixDownloadState();
+
+        const recovered_running_download = await db_api.getRecord('download_queue', {uid: running_download['uid']});
+        const recovered_waiting_download = await db_api.getRecord('download_queue', {uid: waiting_download['uid']});
+
+        assert.strictEqual(recovered_running_download.paused, true);
+        assert.strictEqual(recovered_running_download.running, false);
+        assert.strictEqual(recovered_running_download.finished_step, true);
+        assert.strictEqual(recovered_running_download.step_index, 0);
+
+        assert.strictEqual(recovered_waiting_download.paused, false);
+        assert.strictEqual(recovered_waiting_download.running, false);
+        assert.strictEqual(recovered_waiting_download.finished_step, true);
+        assert.strictEqual(recovered_waiting_download.step_index, 0);
+    });
+
     it('Downloader - categorize', async function() {
         this.timeout(300000);
         await createCategory(url);
@@ -939,6 +965,47 @@ describe('Downloader', function() {
             assert.strictEqual(downloader_api.getEffectivePlaylistChunkSize(10, 1, true), 1);
             assert.strictEqual(downloader_api.getEffectivePlaylistChunkSize(10, 20, false), 20);
         } finally {
+            config_api.setConfigItem('ytdl_max_concurrent_downloads', original_max_concurrent_downloads);
+        }
+    });
+
+    it('Capped queue groups limit subscription-style bursts when the global cap is unbounded', async function() {
+        const original_max_concurrent_downloads = config_api.getConfigItem('ytdl_max_concurrent_downloads');
+        const original_collect_info = downloader_api.collectInfo;
+
+        const started_download_uids = [];
+        downloader_api.collectInfo = async (download_uid) => {
+            started_download_uids.push(download_uid);
+            await db_api.updateRecord('download_queue', {uid: download_uid}, {step_index: 1, finished_step: false, running: true});
+        };
+
+        try {
+            config_api.setConfigItem('ytdl_max_concurrent_downloads', -1);
+
+            const grouped_downloads = [];
+            for (let i = 0; i < 6; i++) {
+                grouped_downloads.push(await downloader_api.createDownload(`${url}&subscription_group=${i}`, 'video', {
+                    ui_uid: uuid(),
+                    concurrentQueueGroupKey: 'subscription-downloads',
+                    concurrentQueueGroupLimit: 5
+                }));
+            }
+
+            await downloader_api.checkDownloads();
+            assert.deepStrictEqual(started_download_uids, grouped_downloads.slice(0, 5).map(download => download.uid));
+            assert(!started_download_uids.includes(grouped_downloads[5].uid));
+
+            await db_api.updateRecord('download_queue', {uid: grouped_downloads[0].uid}, {
+                finished: true,
+                running: false,
+                finished_step: true,
+                step_index: 3
+            });
+
+            await downloader_api.checkDownloads();
+            assert(started_download_uids.includes(grouped_downloads[5].uid));
+        } finally {
+            downloader_api.collectInfo = original_collect_info;
             config_api.setConfigItem('ytdl_max_concurrent_downloads', original_max_concurrent_downloads);
         }
     });

--- a/backend/test/subscriptions.test.js
+++ b/backend/test/subscriptions.test.js
@@ -2,6 +2,7 @@
 const { assert, path, fs, uuid, db_api, subscriptions_api, youtubedl_api, config_api } = require('./test-shared');
 
 describe('Subscriptions', function() {
+    const downloader_api = require('../downloader');
     const new_sub = {
         name: 'test_sub',
         url: 'https://www.youtube.com/channel/UCzofo-P8yMMCOv8rsPfIR-g',
@@ -197,6 +198,8 @@ describe('Subscriptions', function() {
             const queued_downloads = await db_api.getRecords('download_queue', {sub_id: sub.id});
             assert.strictEqual(queued_downloads.length, fake_outputs.length);
             assert(queued_downloads.every(download => download.prefetched_info === null));
+            assert(queued_downloads.every(download => download.options.concurrentQueueGroupKey === 'subscription-downloads'));
+            assert(queued_downloads.every(download => download.options.concurrentQueueGroupLimit === downloader_api.getExclusivePlaylistConcurrencyLimit()));
 
             const refreshed_sub = await subscriptions_api.getSubscription(sub.id);
             assert(refreshed_sub);


### PR DESCRIPTION
## Summary
- cap subscription/channel refresh downloads with a dedicated queue-group limit so large refreshes do not fan out unbounded work
- only pause downloads that were actually marked running during startup recovery, so queued items are not left stuck after a crash/restart
- add regression coverage for both the capped refresh burst and the recovery path

## Testing
- npm test -- test/downloader.test.js test/subscriptions.test.js
- node --check backend/downloader.js
- node --check backend/subscriptions.js
- node --check backend/test/downloader.test.js
- node --check backend/test/subscriptions.test.js
- npm run lint
- npx tsc -p src/tsconfig.app.json --noEmit
- npx tsc -p src/tsconfig.spec.json --noEmit
- CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npm run test:headless
- npx ng build --configuration production

## Notes
- this addresses the recent channel/subscription crash + post-restart limbo behavior reported around #139
- existing unrelated local changes in backend/appdata/default.json, src/assets/default.json, and the sample media files were left out of this PR
