### PR TITLE
fix(media-library): avoid stuck refresh state

### DIFF
--- a/src/app/components/media-library/media-library.component.spec.ts
+++ b/src/app/components/media-library/media-library.component.spec.ts
@@ -1,7 +1,7 @@
 import { NO_ERRORS_SCHEMA, NgZone } from '@angular/core';
 import { ComponentFixture, TestBed, fakeAsync, flushMicrotasks, waitForAsync } from '@angular/core/testing';
 import { Router } from '@angular/router';
-import { BehaviorSubject, of } from 'rxjs';
+import { BehaviorSubject, of, Subject, throwError } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
 import { PostsService } from 'app/posts.services';
 import {
@@ -154,6 +154,68 @@ describe('MediaLibraryComponent', () => {
       null
     );
     expect(component.paged_data.map(file => file.uid)).toEqual(['file-1', 'file-2', 'file-3']);
+  });
+
+  it('should keep the current library visible when a background refresh fails', () => {
+    spyOn(console, 'error');
+    component.normal_files_received = true;
+    component.paged_data = [
+      { uid: 'file-1', duration: 12 } as any
+    ];
+    postsServiceStub.getAllFiles.and.returnValue(throwError(() => new Error('refresh failed')));
+
+    try {
+      component.getAllFiles();
+
+      expect(component.normal_files_received).toBeTrue();
+      expect(component.paged_data.map(file => file.uid)).toEqual(['file-1']);
+    } finally {
+      postsServiceStub.getAllFiles.and.returnValue(of({files: [], file_count: 0}));
+    }
+  });
+
+  it('should queue one follow-up full refresh instead of overlapping concurrent refreshes', () => {
+    const first_response = new Subject<any>();
+    const second_response = new Subject<any>();
+    let request_count = 0;
+    postsServiceStub.getAllFiles.and.callFake(() => {
+      request_count += 1;
+      return request_count === 1 ? first_response.asObservable() : second_response.asObservable();
+    });
+    component.normal_files_received = true;
+    component.paged_data = [];
+    component.file_count = 0;
+
+    try {
+      component.getAllFiles();
+      component.getAllFiles();
+
+      expect(postsServiceStub.getAllFiles).toHaveBeenCalledTimes(1);
+
+      first_response.next({
+        files: [
+          { uid: 'file-1', duration: 12 }
+        ],
+        file_count: 1
+      });
+      first_response.complete();
+
+      expect(postsServiceStub.getAllFiles).toHaveBeenCalledTimes(2);
+
+      second_response.next({
+        files: [
+          { uid: 'file-1', duration: 12 },
+          { uid: 'file-2', duration: 18 }
+        ],
+        file_count: 2
+      });
+      second_response.complete();
+
+      expect(component.paged_data.map(file => file.uid)).toEqual(['file-1', 'file-2']);
+      expect(component.file_count).toBe(2);
+    } finally {
+      postsServiceStub.getAllFiles.and.returnValue(of({files: [], file_count: 0}));
+    }
   });
 
   it('should persist auto page size selection and reset paging', () => {

--- a/src/app/components/media-library/media-library.component.ts
+++ b/src/app/components/media-library/media-library.component.ts
@@ -122,6 +122,9 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
   private pendingScrollRestoreAttempts = 0;
   private pendingNavigationRestoreState: MediaLibraryRestoreState = null;
   private pendingScrollRestoreSnapshot: MediaLibraryRestoreSnapshot = null;
+  private fullFileRefreshInProgress = false;
+  private queuedFullFileRefresh = false;
+  private queuedFullFileRefreshCacheMode = false;
   private readonly destroy$ = new Subject<void>();
   private readonly scrollHandler = () => this.scheduleVirtualVideoWindowUpdate();
 
@@ -698,9 +701,16 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
       return;
     }
 
+    if (!append && this.fullFileRefreshInProgress) {
+      this.queueFullFileRefresh(cache_mode);
+      return;
+    }
+
+    const had_loaded_files = this.normal_files_received;
     if (!append) {
-      this.normal_files_received = cache_mode;
-      if (!cache_mode) {
+      this.fullFileRefreshInProgress = true;
+      this.normal_files_received = cache_mode || had_loaded_files;
+      if (!cache_mode && !had_loaded_files) {
         this.loading_files = Array(this.getLoadingPlaceholderCount()).fill(0);
       }
     } else {
@@ -732,6 +742,10 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
 
       this.normal_files_received = true;
       this.autoPageLoadInProgress = false;
+      if (!append) {
+        this.fullFileRefreshInProgress = false;
+        this.flushQueuedFullFileRefresh();
+      }
       this.scheduleVirtualVideoWindowUpdate(true);
       this.schedulePendingScrollRestore();
     }, err => {
@@ -740,7 +754,34 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
       }
       console.error(err);
       this.autoPageLoadInProgress = false;
+      if (!append) {
+        this.normal_files_received = had_loaded_files;
+        this.fullFileRefreshInProgress = false;
+        this.flushQueuedFullFileRefresh();
+      }
     });
+  }
+
+  private queueFullFileRefresh(cache_mode = false): void {
+    if (!this.queuedFullFileRefresh) {
+      this.queuedFullFileRefresh = true;
+      this.queuedFullFileRefreshCacheMode = cache_mode;
+      return;
+    }
+
+    // Prefer a normal refresh whenever any queued request needs one.
+    this.queuedFullFileRefreshCacheMode = this.queuedFullFileRefreshCacheMode && cache_mode;
+  }
+
+  private flushQueuedFullFileRefresh(): void {
+    if (!this.queuedFullFileRefresh) {
+      return;
+    }
+
+    const queued_cache_mode = this.queuedFullFileRefreshCacheMode;
+    this.queuedFullFileRefresh = false;
+    this.queuedFullFileRefreshCacheMode = false;
+    this.getAllFiles(queued_cache_mode);
   }
 
   // navigation


### PR DESCRIPTION
## Summary
- serialize full media-library refreshes so bursts of `files_changed` updates do not create overlapping `getAllFiles()` races
- keep the current library view visible during background refreshes instead of dropping back to the loading skeleton
- add regression coverage for failed background refreshes and queued follow-up refreshes

## Testing
- npm run lint
- npx tsc -p src/tsconfig.app.json --noEmit
- npx tsc -p src/tsconfig.spec.json --noEmit
- npx ng test --watch=false --browsers ChromiumHeadless --include src/app/components/media-library/media-library.component.spec.ts
- CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npm run test:headless
- npx ng build --configuration production

## Notes
- this follows up on the rare subscription-page stall reported during #139 testing, where the backend kept working but the page needed `F5` to recover
- existing unrelated local changes in backend/appdata/default.json, src/assets/default.json, and the sample media files were left out of this PR
