### PR TITLE
fix(downloads): throttle queued download starts

### DIFF
--- a/backend/appdata/default.json
+++ b/backend/appdata/default.json
@@ -17,6 +17,7 @@
       "include_thumbnail": true,
       "include_metadata": true,
       "max_concurrent_downloads": 0,
+      "min_sleep_between_downloads": 0,
       "download_rate_limit": "",
       "playlist_chunk_size": 100
     },

--- a/backend/config.js
+++ b/backend/config.js
@@ -229,6 +229,7 @@ const DEFAULT_CONFIG = {
         "include_thumbnail": true,
         "include_metadata": true,
         "max_concurrent_downloads": 5,
+        "min_sleep_between_downloads": 0,
         "playlist_chunk_size": 20,
         "download_rate_limit": ""
       },

--- a/backend/consts.js
+++ b/backend/consts.js
@@ -66,6 +66,10 @@ exports.CONFIG_ITEMS = {
         'key': 'ytdl_max_concurrent_downloads',
         'path': 'YtdlMaterial.Downloader.max_concurrent_downloads'
     },
+    'ytdl_min_sleep_between_downloads': {
+        'key': 'ytdl_min_sleep_between_downloads',
+        'path': 'YtdlMaterial.Downloader.min_sleep_between_downloads'
+    },
     'ytdl_playlist_chunk_size': {
         'key': 'ytdl_playlist_chunk_size',
         'path': 'YtdlMaterial.Downloader.playlist_chunk_size'

--- a/backend/downloader.js
+++ b/backend/downloader.js
@@ -35,6 +35,7 @@ const ANSI_ESCAPE_SEQUENCE_REGEX = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
 const DEFAULT_INVALID_FILENAME_CHARS = '\\/:*?"<>|';
 const METADATA_FIELDS_FOR_FILENAME_SANITIZATION = 'title,fulltitle,playlist_title,uploader,channel,series,chapter,album,artist';
 let filename_sanitization_non_ytdlp_warned = false;
+let last_download_queue_start_at = 0;
 
 function asFiniteNumber(value, defaultValue = 0) {
     const numeric_value = Number(value);
@@ -1078,6 +1079,29 @@ function hasReachedConcurrentDownloadLimit(maxConcurrentDownloads, runningDownlo
 }
 exports.hasReachedConcurrentDownloadLimit = hasReachedConcurrentDownloadLimit;
 
+function getMinimumSleepBetweenDownloadsMs() {
+    const minimum_sleep_seconds = asFiniteNumber(config_api.getConfigItem('ytdl_min_sleep_between_downloads'), 0);
+    if (minimum_sleep_seconds <= 0) return 0;
+    return Math.floor(minimum_sleep_seconds * 1000);
+}
+exports.getMinimumSleepBetweenDownloadsMs = getMinimumSleepBetweenDownloadsMs;
+
+function getRemainingSleepBeforeNextDownloadStartMs(minimum_sleep_ms = getMinimumSleepBetweenDownloadsMs(), now = Date.now()) {
+    if (!Number.isFinite(minimum_sleep_ms) || minimum_sleep_ms <= 0 || last_download_queue_start_at <= 0) return 0;
+    return Math.max(0, (last_download_queue_start_at + minimum_sleep_ms) - now);
+}
+exports.getRemainingSleepBeforeNextDownloadStartMs = getRemainingSleepBeforeNextDownloadStartMs;
+
+function markDownloadQueueStart(minimum_sleep_ms = getMinimumSleepBetweenDownloadsMs(), now = Date.now()) {
+    if (!Number.isFinite(minimum_sleep_ms) || minimum_sleep_ms <= 0) return;
+    last_download_queue_start_at = now;
+}
+
+function resetDownloadQueueStartThrottle() {
+    last_download_queue_start_at = 0;
+}
+exports.resetDownloadQueueStartThrottle = resetDownloadQueueStartThrottle;
+
 function getExclusivePlaylistConcurrencyLimit() {
     const max_concurrent_downloads = Number(config_api.getConfigItem('ytdl_max_concurrent_downloads'));
     if (Number.isFinite(max_concurrent_downloads) && max_concurrent_downloads >= 0 && max_concurrent_downloads < MAX_EXCLUSIVE_PLAYLIST_CONCURRENCY_CAP) {
@@ -1352,6 +1376,7 @@ async function checkDownloads() {
         ? running_exclusive_downloads.filter(download => getExclusivePlaylistGroupKey(download) === exclusive_playlist_group_key).length
         : 0;
     const exclusive_playlist_concurrency_limit = getExclusivePlaylistConcurrencyLimit();
+    const minimum_sleep_between_downloads_ms = getMinimumSleepBetweenDownloadsMs();
 
     for (let i = 0; i < waiting_downloads.length; i++) {
         const waiting_download = waiting_downloads[i];
@@ -1389,6 +1414,10 @@ async function checkDownloads() {
         }
 
         if (waiting_download['finished_step'] && !waiting_download['finished']) {
+            if (getRemainingSleepBeforeNextDownloadStartMs(minimum_sleep_between_downloads_ms) > 0) {
+                break;
+            }
+
             if (waiting_download['sub_id']) {
                 const sub_missing = !(await db_api.getRecord('subscriptions', {id: waiting_download['sub_id']}));
                 if (sub_missing) {
@@ -1398,6 +1427,7 @@ async function checkDownloads() {
             }
             // move to next step
             running_downloads_count++;
+            markDownloadQueueStart(minimum_sleep_between_downloads_ms);
             if (waiting_download['step_index'] === 0) {
                 exports.collectInfo(waiting_download['uid']);
             } else if (waiting_download['step_index'] === 1) {
@@ -1414,6 +1444,10 @@ async function checkDownloads() {
                 if (running_exclusive_group_count >= exclusive_playlist_concurrency_limit) {
                     break;
                 }
+            }
+
+            if (minimum_sleep_between_downloads_ms > 0) {
+                break;
             }
         }
     }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,7 +15,7 @@
         "archiver": "^7.0.1",
         "async": "^3.2.3",
         "async-mutex": "^0.5.0",
-        "axios": "^1.15.1",
+        "axios": "^1.15.2",
         "bcryptjs": "^3.0.3",
         "body-parser": "^2.2.2",
         "command-exists": "^1.2.9",
@@ -761,9 +761,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
-      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/backend/package.json
+++ b/backend/package.json
@@ -29,7 +29,7 @@
     "archiver": "^7.0.1",
     "async": "^3.2.3",
     "async-mutex": "^0.5.0",
-    "axios": "^1.15.1",
+    "axios": "^1.15.2",
     "bcryptjs": "^3.0.3",
     "body-parser": "^2.2.2",
     "command-exists": "^1.2.9",

--- a/backend/test/downloader.test.js
+++ b/backend/test/downloader.test.js
@@ -98,7 +98,9 @@ describe('Downloader', function() {
         // await db_api.connectToDB();
         await db_api.removeAllRecords('download_queue');
         config_api.setConfigItem('ytdl_allow_playlist_categorization', true);
+        config_api.setConfigItem('ytdl_min_sleep_between_downloads', 0);
         config_api.setConfigItem('ytdl_playlist_chunk_size', 100);
+        downloader_api.resetDownloadQueueStartThrottle();
     });
 
     it('Get file info', async function() {
@@ -1007,6 +1009,63 @@ describe('Downloader', function() {
         } finally {
             downloader_api.collectInfo = original_collect_info;
             config_api.setConfigItem('ytdl_max_concurrent_downloads', original_max_concurrent_downloads);
+        }
+    });
+
+    it('Minimum sleep between downloads throttles queued step starts', async function() {
+        const original_max_concurrent_downloads = config_api.getConfigItem('ytdl_max_concurrent_downloads');
+        const original_min_sleep_between_downloads = config_api.getConfigItem('ytdl_min_sleep_between_downloads');
+        const original_collect_info = downloader_api.collectInfo;
+        const original_download_queued_file = downloader_api.downloadQueuedFile;
+        const original_date_now = Date.now;
+
+        let now = 100000;
+        const started_steps = [];
+
+        downloader_api.collectInfo = async (download_uid) => {
+            started_steps.push(`info:${download_uid}`);
+            await db_api.updateRecord('download_queue', {uid: download_uid}, {
+                step_index: 1,
+                finished_step: true,
+                running: false
+            });
+        };
+        downloader_api.downloadQueuedFile = async (download_uid) => {
+            started_steps.push(`download:${download_uid}`);
+            await db_api.updateRecord('download_queue', {uid: download_uid}, {
+                step_index: 2,
+                finished_step: false,
+                running: true
+            });
+        };
+        Date.now = () => now;
+
+        try {
+            config_api.setConfigItem('ytdl_max_concurrent_downloads', -1);
+            config_api.setConfigItem('ytdl_min_sleep_between_downloads', 5);
+            downloader_api.resetDownloadQueueStartThrottle();
+
+            const first_download = await downloader_api.createDownload(`${url}&sleep_queue=1`, 'video', {ui_uid: uuid()});
+            await downloader_api.createDownload(`${url}&sleep_queue=2`, 'video', {ui_uid: uuid()});
+
+            await downloader_api.checkDownloads();
+            await utils.wait(10);
+            assert.deepStrictEqual(started_steps, [`info:${first_download.uid}`]);
+
+            now += 4999;
+            await downloader_api.checkDownloads();
+            assert.deepStrictEqual(started_steps, [`info:${first_download.uid}`]);
+
+            now += 1;
+            await downloader_api.checkDownloads();
+            assert.deepStrictEqual(started_steps, [`info:${first_download.uid}`, `download:${first_download.uid}`]);
+        } finally {
+            Date.now = original_date_now;
+            downloader_api.collectInfo = original_collect_info;
+            downloader_api.downloadQueuedFile = original_download_queued_file;
+            downloader_api.resetDownloadQueueStartThrottle();
+            config_api.setConfigItem('ytdl_max_concurrent_downloads', original_max_concurrent_downloads);
+            config_api.setConfigItem('ytdl_min_sleep_between_downloads', original_min_sleep_between_downloads);
         }
     });
 

--- a/docker-compose-extended.yml
+++ b/docker-compose-extended.yml
@@ -40,6 +40,7 @@ services:
 
       # Download and playlist behavior (optional)
       # ytdl_playlist_chunk_size: '20'
+      # ytdl_min_sleep_between_downloads: '0'
       # ytdl_warn_on_duplicate: 'false'
       # Caps the number of automatic playlist chunks that may be created.
       # ytdl_max_playlist_chunks: '20'

--- a/docker-environment.md
+++ b/docker-environment.md
@@ -89,6 +89,7 @@ When using env-managed Docker setups with `write_ytdl_config='true'`, you can cl
 ## Download and Playlist Variables
 
 * `ytdl_playlist_chunk_size`: playlist batch size for automatic playlist chunking (default `20`, min `1`)
+* `ytdl_min_sleep_between_downloads`: minimum seconds to wait before starting the next queued download step (default `0`, disabled)
 * `ytdl_warn_on_duplicate`: set to `'true'` to warn on duplicate downloads and reuse existing files in playlists instead of downloading them again (default `'false'`)
 * `ytdl_max_playlist_chunks`: cap automatic playlist chunk creation (default `20`, min `1`)
 

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -206,6 +206,13 @@
             </div>
             <div class="col-12 mt-2 mb-4">
               <mat-form-field class="text-field" color="accent">
+                <mat-label i18n="Minimum sleep between downloads">Minimum sleep between downloads (seconds)</mat-label>
+                <input type="number" min="0" [(ngModel)]="new_config['Downloader']['min_sleep_between_downloads']" matInput>
+                <mat-hint><ng-container i18n="Minimum sleep between downloads input hint">Waits before starting the next queued download step. Use 0 to disable.</ng-container></mat-hint>
+              </mat-form-field>
+            </div>
+            <div class="col-12 mt-2 mb-4">
+              <mat-form-field class="text-field" color="accent">
                 <mat-label i18n="Playlist chunk size">Playlist chunk size</mat-label>
                 <input type="number" [(ngModel)]="new_config['Downloader']['playlist_chunk_size']" matInput>
                 <mat-hint><ng-container i18n="Playlist chunk size input hint">Number of playlist items queued per batch when downloading large playlists. Smaller values start faster.</ng-container></mat-hint>

--- a/src/assets/default.json
+++ b/src/assets/default.json
@@ -17,6 +17,7 @@
       "invalid_filename_chars": "\\/:*?\"<>|",
       "invalid_filename_replacement": "_",
       "max_concurrent_downloads": 5,
+      "min_sleep_between_downloads": 0,
       "playlist_chunk_size": 20,
       "download_rate_limit": ""
     },


### PR DESCRIPTION
## Summary
- Add `ytdl_min_sleep_between_downloads` / Downloader setting for "Minimum sleep between downloads (seconds)"
- Default the value to `0` so current queue behavior is unchanged unless configured
- Apply the delay in the download queue scheduler before starting the next queued step
- Document the Docker/env variable and add focused queue scheduler coverage

Closes #148

## Tests
- `node --check backend/downloader.js`
- `node --check backend/consts.js`
- `node --check backend/config.js`
- `node --check backend/test/downloader.test.js`
- `npm --prefix backend test -- --grep "Playlist/chunk downloads honor|Exclusive playlist mode starts|Capped queue groups|Minimum sleep between downloads"`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npm run lint`
- `CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npm run test:headless`
- `npx ng build --configuration production`
