### PR TITLE
feat(downloads): retry failed downloads in bulk

### DIFF
--- a/src/app/components/downloads/downloads.component.html
+++ b/src/app/components/downloads/downloads.component.html
@@ -104,7 +104,7 @@
       <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
     </mat-table>
 
-    <mat-paginator [ngClass]="uids ? 'rounded-bottom' : null" [pageSizeOptions]="[5, 10, 20]"
+    <mat-paginator [ngClass]="uids ? 'rounded-bottom' : null" [pageSizeOptions]="pageSizeOptions" [pageSize]="pageSize" (page)="pageChangeEvent($event)"
       showFirstLastButtons
       aria-label="Select page of downloads">
     </mat-paginator>
@@ -113,6 +113,7 @@
     <div class="downloads-action-button-div">
       <button class="downloads-action-button" [disabled]="!running_download_exists" mat-stroked-button (click)="pauseAllDownloads()"><ng-container i18n="Pause all downloads">Pause all downloads</ng-container></button>
       <button class="downloads-action-button" [disabled]="!paused_download_exists" mat-stroked-button (click)="resumeAllDownloads()"><ng-container i18n="Resume all downloads">Resume all downloads</ng-container></button>
+      <button class="downloads-action-button" [disabled]="!failed_download_exists" mat-stroked-button (click)="retryFailedDownloads()"><ng-container i18n="Retry all failed downloads">Retry all failed</ng-container></button>
       <button class="downloads-action-button" color="warn" mat-stroked-button (click)="clearDownloadsByType()"><ng-container i18n="Clear downloads">Clear downloads</ng-container></button>
     </div>
   }

--- a/src/app/components/downloads/downloads.component.spec.ts
+++ b/src/app/components/downloads/downloads.component.spec.ts
@@ -4,18 +4,25 @@ import { of } from 'rxjs';
 
 describe('DownloadsComponent', () => {
   let component: DownloadsComponent;
+  let posts_service_mock: any;
+  let router_mock: any;
+  let dialog_mock: any;
+  let clipboard_mock: any;
 
   beforeEach(() => {
-    const posts_service_mock: any = {
+    localStorage.removeItem('downloads_page_size');
+
+    posts_service_mock = {
       config: { Extra: { enable_downloads_manager: true } },
       initialized: true,
       service_initialized: of(true),
-      getCurrentDownloads: () => of({downloads: []}),
-      openSnackBar: () => {}
+      getCurrentDownloads: jasmine.createSpy('getCurrentDownloads').and.returnValue(of({downloads: []})),
+      restartDownload: jasmine.createSpy('restartDownload').and.returnValue(of({success: true})),
+      openSnackBar: jasmine.createSpy('openSnackBar')
     };
-    const router_mock: any = { navigate: () => {} };
-    const dialog_mock: any = { open: () => ({}), openDialogs: [] };
-    const clipboard_mock: any = { copy: () => true };
+    router_mock = { navigate: () => {} };
+    dialog_mock = { open: () => ({}), openDialogs: [] };
+    clipboard_mock = { copy: () => true };
 
     component = new DownloadsComponent(posts_service_mock, router_mock, dialog_mock, clipboard_mock);
   });
@@ -73,6 +80,51 @@ describe('DownloadsComponent', () => {
     } as unknown as Download;
 
     expect(component.getNormalizedPercent(download)).toBe('100.00');
+  });
+
+  it('tracks whether failed downloads can be retried', () => {
+    posts_service_mock.getCurrentDownloads.and.returnValue(of({
+      downloads: [
+        {uid: 'download-1', error: 'Network error', cancelled: false},
+        {uid: 'download-2', error: null, cancelled: false}
+      ]
+    }));
+
+    component.getCurrentDownloads();
+
+    expect(component.failed_download_exists).toBeTrue();
+  });
+
+  it('retries failed downloads only', () => {
+    component.raw_downloads = [
+      {uid: 'failed-1', error: 'Network error', finished: true, cancelled: false},
+      {uid: 'complete-1', error: null, finished: true, cancelled: false},
+      {uid: 'cancelled-1', error: 'Cancelled', error_type: 'cancelled', finished: true, cancelled: true}
+    ] as unknown as Download[];
+
+    component.retryFailedDownloads();
+
+    expect(posts_service_mock.restartDownload).toHaveBeenCalledOnceWith('failed-1');
+  });
+
+  it('shows a failure message when retrying failed downloads fails', () => {
+    component.raw_downloads = [
+      {uid: 'failed-1', error: 'Network error', finished: true, cancelled: false}
+    ] as unknown as Download[];
+    posts_service_mock.restartDownload.and.returnValue(of({success: false}));
+
+    component.retryFailedDownloads();
+
+    expect(posts_service_mock.openSnackBar).toHaveBeenCalled();
+  });
+
+  it('persists the downloads page size', () => {
+    component.pageChangeEvent({pageSize: 20} as any);
+
+    const restored_component = new DownloadsComponent(posts_service_mock, router_mock, dialog_mock, clipboard_mock);
+
+    expect(localStorage.getItem(component.pageSizeStorageKey)).toBe('20');
+    expect(restored_component.pageSize).toBe(20);
   });
 
   it('merges chunked playlist progress with global sequential indices', () => {

--- a/src/app/components/downloads/downloads.component.ts
+++ b/src/app/components/downloads/downloads.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, OnDestroy, ViewChild, Input, EventEmitter, HostListe
 import { PostsService } from 'app/posts.services';
 import { trigger, transition, animateChild, stagger, query, style, animate } from '@angular/animations';
 import { Router } from '@angular/router';
-import { MatPaginator } from '@angular/material/paginator';
+import { MatPaginator, PageEvent } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { ConfirmDialogComponent } from 'app/dialogs/confirm-dialog/confirm-dialog.component';
@@ -36,6 +36,10 @@ export class DownloadsComponent implements OnInit, OnDestroy {
 
   paused_download_exists = false;
   running_download_exists = false;
+  failed_download_exists = false;
+  readonly pageSizeStorageKey = 'downloads_page_size';
+  readonly pageSizeOptions = [5, 10, 20];
+  pageSize = 10;
 
   STEP_INDEX_TO_LABEL = {
       0: $localize`Creating download`,
@@ -118,7 +122,12 @@ export class DownloadsComponent implements OnInit, OnDestroy {
     return result;
   }
 
-  constructor(public postsService: PostsService, private router: Router, private dialog: MatDialog, private clipboard: Clipboard) { }
+  constructor(public postsService: PostsService, private router: Router, private dialog: MatDialog, private clipboard: Clipboard) {
+    const saved_page_size = Number(localStorage.getItem(this.pageSizeStorageKey));
+    if (this.pageSizeOptions.includes(saved_page_size)) {
+      this.pageSize = saved_page_size;
+    }
+  }
 
   ngOnInit(): void {
     // Remove sub name as it's not necessary for one-off downloads
@@ -165,6 +174,7 @@ export class DownloadsComponent implements OnInit, OnDestroy {
         this.refreshOpenPlaylistProgressDialog();
         this.paused_download_exists = !!this.raw_downloads.find(download => download['paused'] && !download['error']);
         this.running_download_exists = !!this.raw_downloads.find(download => !download['paused'] && !download['finished']);
+        this.failed_download_exists = this.raw_downloads.some(download => this.isFailedDownload(download));
       }
       this.downloads_retrieved = true;
     });
@@ -250,6 +260,16 @@ export class DownloadsComponent implements OnInit, OnDestroy {
   restartDownload(download: Download): void {
     const target_downloads = this.getActionTargetDownloads(download)
       .filter(target_download => target_download.finished);
+    this.restartDownloads(target_downloads);
+  }
+
+  retryFailedDownloads(): void {
+    const target_downloads = this.raw_downloads.filter(download => this.isFailedDownload(download));
+    this.restartDownloads(target_downloads);
+  }
+
+  private restartDownloads(downloads: Download[]): void {
+    const target_downloads = downloads.filter(download => !!download);
     const target_uids = target_downloads.map(target_download => target_download.uid).filter(uid => !!uid);
     if (target_uids.length === 0) return;
 
@@ -273,6 +293,15 @@ export class DownloadsComponent implements OnInit, OnDestroy {
           .forEach(new_download_uid => this.uids.push(new_download_uid));
       }
     });
+  }
+
+  private isFailedDownload(download: Download): boolean {
+    return !!download && !!download.error && !download.cancelled && download.error_type !== 'cancelled';
+  }
+
+  pageChangeEvent(event: PageEvent): void {
+    this.pageSize = event.pageSize;
+    localStorage.setItem(this.pageSizeStorageKey, `${this.pageSize}`);
   }
 
   cancelDownload(download: Download): void {


### PR DESCRIPTION
## Summary
- Add a Downloads-page button to retry all failed downloads at once
- Reuse the existing per-download restart flow and ignore cancelled downloads
- Remember the Downloads page-size selection like the media library

## Tests
- npm run lint
- npx tsc -p src/tsconfig.app.json --noEmit
- npx tsc -p src/tsconfig.spec.json --noEmit
- CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npm run test:headless
- npx ng build --configuration production

Closes #150
