### PR TITLE
fix(subscription): apply global custom args

### DIFF
--- a/backend/downloader.js
+++ b/backend/downloader.js
@@ -2085,6 +2085,28 @@ function filterInfoLookupArgs(args = []) {
     return filtered_args;
 }
 
+function describeInfoLookupError(err, downloader_fork = 'downloader') {
+    const details = [];
+    const addDetail = (detail) => {
+        if (detail === null || detail === undefined) return;
+        const detail_text = String(detail).trim();
+        if (detail_text && !details.includes(detail_text)) details.push(detail_text);
+    };
+
+    if (typeof err === 'string') {
+        addDetail(err);
+    } else if (err && typeof err === 'object') {
+        addDetail(err.message);
+        addDetail(err.stderr);
+        addDetail(err.stdout ? `stdout: ${err.stdout}` : null);
+    } else {
+        addDetail(err);
+    }
+
+    if (details.length > 0) return details.join('\n\n');
+    return `${downloader_fork} returned no JSON output and did not provide stderr.`;
+}
+
 exports.getVideoInfoByURL = async (url, args = [], download_uid = null, options = {}) => {
     logger.debug('getVideoInfoByURL called');
     const downloader_fork = getPreferredDownloaderFork(options);
@@ -2111,8 +2133,8 @@ exports.getVideoInfoByURL = async (url, args = [], download_uid = null, options 
     const {parsed_output, err} = await callback;
     logger.debug(`Callback resolved. parsed_output length: ${parsed_output ? parsed_output.length : 'null'}`);
     if (!parsed_output || parsed_output.length === 0) {
-        let error_message = `Error while retrieving info on video with URL ${url} with the following message: ${err}`;
-        if (err.stderr) error_message += `\n\n${err.stderr}`;
+        const error_details = describeInfoLookupError(err, downloader_fork);
+        const error_message = `Error while retrieving info on video with URL ${url} with the following message: ${error_details}`;
         logger.error(error_message);
         if (download_uid) {
             await handleDownloadError(download_uid, error_message, 'info_retrieve_failed');

--- a/backend/postgres-store.js
+++ b/backend/postgres-store.js
@@ -446,12 +446,17 @@ function tryBuildAggregateQuery(tables, tableName, pipeline = []) {
     return { queryText, params };
 }
 
+function stringifyJSONForQuery(value) {
+    const json_value = JSON.stringify(value);
+    return json_value === undefined ? 'null' : json_value;
+}
+
 function buildUpdatedDocExpression(tableMeta, updateObj = {}, params = [], docRef = 'doc') {
     let currentExpr = docRef;
     for (const [fieldPath, value] of Object.entries(updateObj)) {
         if (fieldPath === '_id') continue;
         const pathPlaceholder = `${addParam(params, getFieldPathParts(fieldPath))}::text[]`;
-        const valuePlaceholder = addParam(params, JSON.stringify(value));
+        const valuePlaceholder = addParam(params, stringifyJSONForQuery(value));
         currentExpr = `jsonb_set(${currentExpr}, ${pathPlaceholder}, ${valuePlaceholder}::jsonb, true)`;
     }
     return currentExpr;

--- a/backend/subscriptions.js
+++ b/backend/subscriptions.js
@@ -48,6 +48,17 @@ function normalizeNullableString(value) {
     return normalized_value !== '' ? normalized_value : null;
 }
 
+function parseDelimitedArgs(args_string = '') {
+    if (typeof args_string !== 'string' || args_string.trim() === '') return [];
+    return args_string.split(',,').map(arg => arg.trim()).filter(arg => arg !== '');
+}
+
+function applyCustomArgs(downloadConfig = [], args_string = '') {
+    const custom_args = parseDelimitedArgs(args_string);
+    if (custom_args.length === 0) return downloadConfig;
+    return utils.injectArgs(downloadConfig, custom_args);
+}
+
 function normalizeSubscriptionRefreshStatus(refresh_status = null) {
     const normalized_refresh_status = {
         active: false,
@@ -867,15 +878,8 @@ async function generateArgsForSubscription(sub, user_uid, redownload = false, de
         downloadConfig.push('--download-archive', archive_path);
     }
 
-    if (sub.custom_args) {
-        const customArgsArray = sub.custom_args.split(',,');
-        if (customArgsArray.indexOf('-f') !== -1) {
-            // if custom args has a custom quality, replce the original quality with that of custom args
-            const original_output_index = downloadConfig.indexOf('-f');
-            downloadConfig.splice(original_output_index, 2);
-        }
-        downloadConfig.push(...customArgsArray);
-    }
+    downloadConfig = applyCustomArgs(downloadConfig, config_api.getConfigItem('ytdl_custom_args'));
+    downloadConfig = applyCustomArgs(downloadConfig, sub.custom_args);
 
     const default_downloader = config_api.getConfigItem('ytdl_default_downloader');
     downloadConfig = downloader_api.appendFilenameSanitizationArgs(downloadConfig, default_downloader);

--- a/backend/test/downloader.test.js
+++ b/backend/test/downloader.test.js
@@ -144,6 +144,26 @@ describe('Downloader', function() {
         assert(!captured_args.includes('--no-simulate'));
     });
 
+    it('Get file info records a useful error when the downloader returns no output', async function() {
+        const original_runYoutubeDL = youtubedl_api.runYoutubeDL;
+        const returned_download = await downloader_api.createDownload(url, 'video', options);
+
+        youtubedl_api.runYoutubeDL = async () => ({
+            callback: Promise.resolve({parsed_output: null, err: ''})
+        });
+
+        try {
+            const info = await _originalGetVideoInfoByURL(url, [], returned_download.uid);
+            assert.strictEqual(info, null);
+        } finally {
+            youtubedl_api.runYoutubeDL = original_runYoutubeDL;
+        }
+
+        const failed_download = await db_api.getRecord('download_queue', {uid: returned_download.uid});
+        assert(failed_download.error.includes('returned no JSON output and did not provide stderr.'));
+        assert.strictEqual(failed_download.error_type, 'info_retrieve_failed');
+    });
+
     it('Get file info uses yt-dlp when an audio language is requested', async function() {
         let captured_fork = null;
         const original_runYoutubeDL = youtubedl_api.runYoutubeDL;

--- a/backend/test/postgres-db.test.js
+++ b/backend/test/postgres-db.test.js
@@ -233,6 +233,31 @@ describe('PostgreSQL backend integration points', function() {
         assert.deepStrictEqual(capturedParams, [['finished'], 'false']);
     });
 
+    it('serializes undefined update values as JSON null for PostgreSQL updates', async function() {
+        let capturedQuery = null;
+        let capturedParams = null;
+        const fakePool = {
+            query: async (queryText, params) => {
+                capturedQuery = queryText;
+                capturedParams = params;
+                return { rowCount: 1 };
+            }
+        };
+
+        await postgres_store.updateRecord(fakePool, {
+            tasks: {
+                primary_key: 'key',
+                field_types: {
+                    key: 'text'
+                }
+            }
+        }, 'tasks', {key: 'missing_files_check'}, {data: undefined, running: false});
+
+        assert(capturedQuery.includes('jsonb_set'));
+        assert(!capturedParams.includes(undefined));
+        assert(capturedParams.includes('null'));
+    });
+
     it('uses hashed text predicates for string equality filters', async function() {
         let capturedQuery = null;
         let capturedParams = null;

--- a/backend/test/subscriptions.test.js
+++ b/backend/test/subscriptions.test.js
@@ -16,6 +16,7 @@ describe('Subscriptions', function() {
         await db_api.removeAllRecords('subscriptions');
         await db_api.removeAllRecords('download_queue');
         config_api.setConfigItem('ytdl_subscriptions_redownload_fresh_uploads', false);
+        config_api.setConfigItem('ytdl_custom_args', '');
     });
 
     async function waitForCondition(predicate, timeout_ms = 2000) {
@@ -208,6 +209,43 @@ describe('Subscriptions', function() {
         } finally {
             youtubedl_api.runYoutubeDLLineStream = original_runYoutubeDLLineStream;
         }
+    });
+    it('Applies global custom args when discovering subscription videos', async function() {
+        const original_runYoutubeDLLineStream = youtubedl_api.runYoutubeDLLineStream;
+        const sub = Object.assign({}, new_sub, {
+            id: uuid(),
+            name: 'global_args_sub',
+            custom_args: '--sleep-interval,,2'
+        });
+        let captured_args = null;
+
+        youtubedl_api.runYoutubeDLLineStream = async (requested_url, args) => {
+            captured_args = args;
+            return {
+                child_process: {pid: 4321},
+                callback: Promise.resolve({err: null})
+            };
+        };
+
+        try {
+            config_api.setConfigItem('ytdl_custom_args', '--resize-buffer');
+            await subscriptions_api.subscribe(sub, null, true);
+            const started = await subscriptions_api.getVideosForSub(sub.id);
+            assert.strictEqual(started, true);
+
+            const completed = await waitForCondition(async () => {
+                const refreshed_sub = await subscriptions_api.getSubscription(sub.id);
+                return !!(refreshed_sub && !refreshed_sub.downloading);
+            });
+            assert.strictEqual(completed, true);
+        } finally {
+            youtubedl_api.runYoutubeDLLineStream = original_runYoutubeDLLineStream;
+        }
+
+        const sleep_interval_index = captured_args.indexOf('--sleep-interval');
+        assert(captured_args.includes('--resize-buffer'));
+        assert(sleep_interval_index !== -1);
+        assert.strictEqual(captured_args[sleep_interval_index + 1], '2');
     });
     it('Skips writing metadata for subscriptions without a name', async function() {
         const nameless_sub = Object.assign({}, new_sub, {id: uuid(), name: null});

--- a/src/app/dialogs/edit-subscription-dialog/edit-subscription-dialog.component.html
+++ b/src/app/dialogs/edit-subscription-dialog/edit-subscription-dialog.component.html
@@ -49,7 +49,7 @@
           <input [(ngModel)]="new_sub.custom_args" matInput>
           <button class="args-edit-button" (click)="openArgsModifierDialog()" mat-icon-button><mat-icon>edit</mat-icon></button>
           <mat-hint>
-            <ng-container i18n="Custom args hint">These are added after the standard args.</ng-container>
+            <ng-container i18n="Custom args hint">These are added after the standard and global args.</ng-container>
           </mat-hint>
         </mat-form-field>
       </div>

--- a/src/app/dialogs/subscribe-dialog/subscribe-dialog.component.html
+++ b/src/app/dialogs/subscribe-dialog/subscribe-dialog.component.html
@@ -62,7 +62,7 @@
           <input [(ngModel)]="customArgs" matInput>
           <button class="args-edit-button" (click)="openArgsModifierDialog()" mat-icon-button><mat-icon>edit</mat-icon></button>
           <mat-hint>
-            <ng-container i18n="Custom args hint">These are added after the standard args.</ng-container>
+            <ng-container i18n="Custom args hint">These are added after the standard and global args.</ng-container>
           </mat-hint>
         </mat-form-field>
       </div>

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -142,7 +142,7 @@
               <mat-form-field class="text-field" style="margin-right: 12px;" color="accent">
                 <mat-label i18n="Global custom args">Global custom args</mat-label>
                 <textarea matInput [(ngModel)]="new_config['Downloader']['custom_args']"></textarea>
-                <mat-hint><ng-container i18n="Custom args setting input hint">Global custom args for downloads on the home page. (Set args for subscriptions for each subscriptions separately!) Args are delimited using two commas like so: ,,</ng-container></mat-hint>
+                <mat-hint><ng-container i18n="Custom args setting input hint">Global custom args for home page and subscription downloads. Args are delimited using two commas like so: ,,</ng-container></mat-hint>
                 <button class="args-edit-button" (click)="openArgsModifierDialog()" mat-icon-button><mat-icon>edit</mat-icon></button>
               </mat-form-field>
             </div>


### PR DESCRIPTION
## Summary
- Apply global downloader custom args to subscription discovery, then apply per-subscription args afterward
- Improve blank info-retrieval failures so downloads store a useful fallback error message
- Serialize undefined PostgreSQL JSON update values as JSON null to avoid not-null doc update failures
- Update UI hints and add focused regression coverage

Fixes #153
Fixes #152

## Validation
- npm run lint
- npx tsc -p src/tsconfig.app.json --noEmit
- npx tsc -p src/tsconfig.spec.json --noEmit
- CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npm run test:headless
- npx ng build --configuration production
- npm test (from backend)
- node --check on touched backend JS files
- git diff --check
