### PR TITLE
Fix subscription retry and metadata edge cases

### DIFF
--- a/backend/downloader.js
+++ b/backend/downloader.js
@@ -1275,7 +1275,17 @@ exports.resumeDownload = async (download_uid) => {
 exports.restartDownload = async (download_uid) => {
     const download = await db_api.getRecord('download_queue', {uid: download_uid});
     await exports.clearDownload(download_uid);
-    const new_download = await exports.createDownload(download['url'], download['type'], download['options'], download['user_uid']);
+    const new_download = await exports.createDownload(
+        download['url'],
+        download['type'],
+        download['options'],
+        download['user_uid'],
+        download['sub_id'],
+        download['sub_name'],
+        download['prefetched_info'],
+        false,
+        download['title']
+    );
     
     should_check_downloads = true;
     return new_download;
@@ -1521,7 +1531,7 @@ exports.collectInfo = async (download_uid) => {
     const useYoutubeDLArchive = config_api.getConfigItem('ytdl_use_youtubedl_archive');
     if (useYoutubeDLArchive && !options.ignoreArchive && info.length === 1) {
         const info_obj = info[0];
-        const exists_in_archive = await archive_api.existsInArchive(info['extractor'], info_obj['id'], type, download['user_uid'], download['sub_id']);
+        const exists_in_archive = await archive_api.existsInArchive(info_obj['extractor'], info_obj['id'], type, download['user_uid'], download['sub_id']);
         if (exists_in_archive) {
             const error = `File '${info_obj['title']}' already exists in archive! Disable the archive or override to continue downloading.`;
             logger.warn(error);
@@ -1655,6 +1665,7 @@ exports.downloadQueuedFile = async(download_uid, customDownloadHandler = null) =
         } finally {
             clearInterval(download_checker);
             detach_output_progress_listeners();
+            delete download_to_child_process[download['uid']];
         }
         let end_time = Date.now();
         let difference = (end_time - start_time)/1000;

--- a/backend/subscriptions.js
+++ b/backend/subscriptions.js
@@ -59,6 +59,15 @@ function applyCustomArgs(downloadConfig = [], args_string = '') {
     return utils.injectArgs(downloadConfig, custom_args);
 }
 
+function describeSubscriptionInfoError(err) {
+    const fallback_error = 'downloader returned no JSON output and did not provide stderr.';
+    if (!err) return fallback_error;
+    if (typeof err === 'string') return err.trim() || fallback_error;
+    if (err.stderr) return String(err.stderr).trim();
+    if (err.message) return String(err.message).trim();
+    return String(err).trim() || fallback_error;
+}
+
 function normalizeSubscriptionRefreshStatus(refresh_status = null) {
     const normalized_refresh_status = {
         active: false,
@@ -501,7 +510,10 @@ exports.subscribe = async (sub, user_uid = null, skip_get_info = false) => {
 
 async function getSubscriptionInfo(sub) {
     // get videos
-    let downloadConfig = ['--dump-json', '--playlist-end', '1'];
+    let downloadConfig = ['--dump-json'];
+    downloadConfig = applyCustomArgs(downloadConfig, config_api.getConfigItem('ytdl_custom_args'));
+    downloadConfig = applyCustomArgs(downloadConfig, sub.custom_args);
+    downloadConfig = utils.injectArgs(downloadConfig, ['--playlist-end', '1']);
     let useCookies = config_api.getConfigItem('ytdl_use_cookies');
     if (useCookies) {
         if (await fs.pathExists(path.join(__dirname, 'appdata', 'cookies.txt'))) {
@@ -517,7 +529,11 @@ async function getSubscriptionInfo(sub) {
     let {callback} = await youtubedl_api.runYoutubeDL(sub.url, downloadConfig);
     const {parsed_output, err} = await callback;
     if (err) {
-        logger.error(err.stderr);
+        logger.error(`Subscribe: failed to retrieve info for subscription ${sub.id}: ${describeSubscriptionInfoError(err)}`);
+        return false;
+    }
+    if (!Array.isArray(parsed_output) || parsed_output.length === 0) {
+        logger.error(`Subscribe: failed to retrieve info for subscription ${sub.id}: ${describeSubscriptionInfoError(err)}`);
         return false;
     }
     logger.verbose('Subscribe: got info for subscription ' + sub.id);

--- a/backend/test/downloader.test.js
+++ b/backend/test/downloader.test.js
@@ -12,6 +12,7 @@ const {
     utils,
     subscriptions_api,
     files_api,
+    archive_api,
     youtubedl_api,
     config_api,
     generateEmptyVideoFile,
@@ -97,6 +98,7 @@ describe('Downloader', function() {
     beforeEach(async function() {
         // await db_api.connectToDB();
         await db_api.removeAllRecords('download_queue');
+        await db_api.removeAllRecords('archives');
         config_api.setConfigItem('ytdl_allow_playlist_categorization', true);
         config_api.setConfigItem('ytdl_min_sleep_between_downloads', 0);
         config_api.setConfigItem('ytdl_playlist_chunk_size', 100);
@@ -277,6 +279,46 @@ describe('Downloader', function() {
         assert.strictEqual(recovered_waiting_download.step_index, 0);
     });
 
+    it('Restart download preserves subscription metadata', async function() {
+        const prefetched_info = [{
+            webpage_url: url,
+            extractor: 'youtube',
+            id: 'prefetched-video',
+            title: 'Prefetched subscription video'
+        }];
+        const sub_name = 'test_sub';
+        const user_uid = 'test-user';
+        const original_download = await downloader_api.createDownload(
+            url,
+            'video',
+            {...options, customFileFolderPath: 'subscriptions/channels/test_sub/'},
+            user_uid,
+            sub_id,
+            sub_name,
+            prefetched_info,
+            false,
+            'Subscription retry title'
+        );
+
+        await db_api.updateRecord('download_queue', {uid: original_download['uid']}, {
+            error: 'Previous failure',
+            finished: true,
+            error_type: 'info_retrieve_failed'
+        });
+
+        const restarted_download = await downloader_api.restartDownload(original_download['uid']);
+        const cleared_download = await db_api.getRecord('download_queue', {uid: original_download['uid']});
+        const stored_restarted_download = await db_api.getRecord('download_queue', {uid: restarted_download['uid']});
+
+        assert(!cleared_download);
+        assert.strictEqual(stored_restarted_download['sub_id'], sub_id);
+        assert.strictEqual(stored_restarted_download['sub_name'], sub_name);
+        assert.strictEqual(stored_restarted_download['user_uid'], user_uid);
+        assert.deepStrictEqual(stored_restarted_download['prefetched_info'], prefetched_info);
+        assert.strictEqual(stored_restarted_download['title'], 'Subscription retry title');
+        assert.strictEqual(stored_restarted_download['error'], null);
+    });
+
     it('Downloader - categorize', async function() {
         this.timeout(300000);
         await createCategory(url);
@@ -392,6 +434,31 @@ describe('Downloader', function() {
             assert.strictEqual(updated_download.files_to_check_for_progress.length, 1);
         } finally {
             downloader_api.getVideoInfoByURL = original_get_video_info;
+        }
+    });
+
+    it('Collect info rejects archived single downloads using the info extractor', async function() {
+        const original_use_archive = config_api.getConfigItem('ytdl_use_youtubedl_archive');
+
+        try {
+            config_api.setConfigItem('ytdl_use_youtubedl_archive', true);
+            await archive_api.addToArchive(
+                fixture_single[0].extractor,
+                fixture_single[0].id,
+                'video',
+                fixture_single[0].title
+            );
+
+            const returned_download = await downloader_api.createDownload(url, 'video', {ui_uid: uuid()});
+            await downloader_api.collectInfo(returned_download['uid']);
+            const updated_download = await db_api.getRecord('download_queue', {uid: returned_download['uid']});
+
+            assert.strictEqual(updated_download['finished'], true);
+            assert.strictEqual(updated_download['running'], false);
+            assert.strictEqual(updated_download['error_type'], 'exists_in_archive');
+            assert(updated_download['error'].includes('already exists in archive'));
+        } finally {
+            config_api.setConfigItem('ytdl_use_youtubedl_archive', original_use_archive);
         }
     });
 

--- a/backend/test/subscriptions.test.js
+++ b/backend/test/subscriptions.test.js
@@ -33,6 +33,44 @@ describe('Subscriptions', function() {
         const sub_exists = await db_api.getRecord('subscriptions', {id: new_sub['id']});
         assert(sub_exists);
     });
+    it('Applies custom args when retrieving subscription metadata', async function () {
+        const original_runYoutubeDL = youtubedl_api.runYoutubeDL;
+        const sub = Object.assign({}, new_sub, {
+            id: uuid(),
+            name: null,
+            custom_args: '--sleep-interval,,2,,--playlist-end,,250'
+        });
+        let captured_args = null;
+
+        youtubedl_api.runYoutubeDL = async (requested_url, args) => {
+            captured_args = args;
+            return {
+                callback: Promise.resolve({
+                    parsed_output: [{
+                        uploader: 'metadata_args_sub',
+                        playlist_title: 'metadata_args_sub'
+                    }],
+                    err: null
+                })
+            };
+        };
+
+        try {
+            config_api.setConfigItem('ytdl_custom_args', '--resize-buffer');
+            const result = await subscriptions_api.subscribe(sub, null, false);
+            assert.strictEqual(result.success, true);
+        } finally {
+            youtubedl_api.runYoutubeDL = original_runYoutubeDL;
+        }
+
+        const sleep_interval_index = captured_args.indexOf('--sleep-interval');
+        const playlist_end_index = captured_args.indexOf('--playlist-end');
+        assert(captured_args.includes('--resize-buffer'));
+        assert(sleep_interval_index !== -1);
+        assert.strictEqual(captured_args[sleep_interval_index + 1], '2');
+        assert(playlist_end_index !== -1);
+        assert.strictEqual(captured_args[playlist_end_index + 1], '1');
+    });
     it('Unsubscribe', async function () {
         await subscriptions_api.subscribe(new_sub, null, true);
         await subscriptions_api.unsubscribe(new_sub);


### PR DESCRIPTION
## Summary
- apply global and per-subscription custom args when fetching initial subscription metadata, while still forcing `--playlist-end 1`
- preserve subscription metadata when retrying failed downloads so retried subscription downloads stay tied to their subscription
- fix single-item archive duplicate checks to use the extracted item's `extractor`, and clean finished child process handles

## Validation
- `node --check backend/subscriptions.js && node --check backend/downloader.js && node --check backend/test/subscriptions.test.js && node --check backend/test/downloader.test.js`
- `npx mocha test/subscriptions.test.js test/downloader.test.js --exit -s 1000`
- `npm test` from `backend/`
- `npm run lint`
- `git diff --check`

## Notes
This follows up the recent subscription issues (#153, #152, #148) by hardening adjacent paths found during a deeper subscription-flow review.
