### PR TITLE
Fix timeranged subscription discovery

### DIFF
--- a/backend/subscriptions.js
+++ b/backend/subscriptions.js
@@ -933,25 +933,49 @@ async function generateArgsForSubscription(sub, user_uid, redownload = false, de
     return downloadConfig;
 }
 
-function filterSubscriptionDiscoveryArgs(args = []) {
+function hasSubscriptionDiscoveryDateFilter(args = []) {
+    if (!Array.isArray(args)) return false;
+    return args.some(arg => typeof arg === 'string'
+        && (arg === '--date'
+            || arg.startsWith('--date=')
+            || arg === '--dateafter'
+            || arg.startsWith('--dateafter=')
+            || arg === '--datebefore'
+            || arg.startsWith('--datebefore=')));
+}
+
+function filterSubscriptionDiscoveryArgs(args = [], options = {}) {
     if (!Array.isArray(args)) return [];
 
     const args_without_discovery_side_effects = [];
+    const preserve_download_shaping_args = !!options.preserve_download_shaping_args;
     for (let i = 0; i < args.length; i++) {
         const arg = args[i];
         if (!arg) continue;
 
         if (arg === '-o' || arg === '-f' || arg === '-S' || arg === '--audio-format' || arg === '--audio-quality' || arg === '--merge-output-format') {
-            i += 1;
+            if (preserve_download_shaping_args) {
+                args_without_discovery_side_effects.push(arg);
+                if (i + 1 < args.length) args_without_discovery_side_effects.push(args[++i]);
+            } else {
+                i += 1;
+            }
             continue;
         }
 
         if (arg === '--replace-in-metadata') {
-            i += 3;
+            if (preserve_download_shaping_args) {
+                args_without_discovery_side_effects.push(arg);
+                for (let j = 0; j < 3 && i + 1 < args.length; j++) {
+                    args_without_discovery_side_effects.push(args[++i]);
+                }
+            } else {
+                i += 3;
+            }
             continue;
         }
 
-        if ([
+        const stripped_flag_args = [
             '--dump-json',
             '--print-json',
             '--write-info-json',
@@ -968,10 +992,9 @@ function filterSubscriptionDiscoveryArgs(args = []) {
             '--add-metadata',
             '--xattrs',
             '--no-clean-info-json',
-            '-x',
-            '--windows-filenames',
-            '--restrict-filenames'
-        ].includes(arg)) {
+            ...(preserve_download_shaping_args ? [] : ['-x', '--windows-filenames', '--restrict-filenames'])
+        ];
+        if (stripped_flag_args.includes(arg)) {
             continue;
         }
 
@@ -983,9 +1006,16 @@ function filterSubscriptionDiscoveryArgs(args = []) {
 
 async function generateArgsForSubscriptionDiscovery(sub, user_uid) {
     const download_args = await generateArgsForSubscription(sub, user_uid);
+    // Flat playlist entries often lack upload dates, so yt-dlp cannot reliably
+    // apply date filters until it fetches full entry metadata.
+    const should_use_full_metadata = hasSubscriptionDiscoveryDateFilter(download_args);
+    const discovery_args = filterSubscriptionDiscoveryArgs(download_args, {
+        preserve_download_shaping_args: should_use_full_metadata
+    });
+
     return [
-        ...filterSubscriptionDiscoveryArgs(download_args),
-        '--flat-playlist',
+        ...discovery_args,
+        ...(should_use_full_metadata ? [] : ['--flat-playlist']),
         '--dump-json'
     ];
 }

--- a/backend/test/subscriptions.test.js
+++ b/backend/test/subscriptions.test.js
@@ -285,6 +285,45 @@ describe('Subscriptions', function() {
         assert(sleep_interval_index !== -1);
         assert.strictEqual(captured_args[sleep_interval_index + 1], '2');
     });
+    it('Uses full metadata discovery for timeranged subscriptions so date filters are honored', async function() {
+        const original_runYoutubeDLLineStream = youtubedl_api.runYoutubeDLLineStream;
+        const sub = Object.assign({}, new_sub, {
+            id: uuid(),
+            name: 'timeranged_sub',
+            timerange: 'now-7days'
+        });
+        let captured_args = null;
+
+        youtubedl_api.runYoutubeDLLineStream = async (requested_url, args) => {
+            captured_args = args;
+            return {
+                child_process: {pid: 4321},
+                callback: Promise.resolve({err: null})
+            };
+        };
+
+        try {
+            await subscriptions_api.subscribe(sub, null, true);
+            const started = await subscriptions_api.getVideosForSub(sub.id);
+            assert.strictEqual(started, true);
+
+            const completed = await waitForCondition(async () => {
+                const refreshed_sub = await subscriptions_api.getSubscription(sub.id);
+                return !!(refreshed_sub && !refreshed_sub.downloading);
+            });
+            assert.strictEqual(completed, true);
+        } finally {
+            youtubedl_api.runYoutubeDLLineStream = original_runYoutubeDLLineStream;
+        }
+
+        const dateafter_index = captured_args.indexOf('--dateafter');
+        assert(dateafter_index !== -1);
+        assert.strictEqual(captured_args[dateafter_index + 1], 'now-7days');
+        assert(!captured_args.includes('--flat-playlist'));
+        assert(captured_args.includes('--dump-json'));
+        assert(captured_args.includes('-o'));
+        assert(captured_args.includes('-f'));
+    });
     it('Skips writing metadata for subscriptions without a name', async function() {
         const nameless_sub = Object.assign({}, new_sub, {id: uuid(), name: null});
         const metadata_path = path.join('subscriptions', 'channels', 'null', 'subscription_backup.json');


### PR DESCRIPTION
## Summary
- Detect date filter args during subscription discovery.
- Use full metadata discovery instead of `--flat-playlist` when date filters are present, preserving output/format shaping for prefetched entries.
- Add regression coverage for timeranged subscriptions.

## Context
Follow-up to #152. A malformed custom arg may have contributed in the reported setup, but yt-dlp also exits successfully with empty stdout/stderr when full video lookup is rejected by `--dateafter`. Flat playlist entries can lack upload dates, so this keeps normal subscriptions on the fast path while making date-filtered subscriptions honor the filter during discovery.

## Tests
- `npx mocha test/subscriptions.test.js --exit -s 1000`
- `npm test`