### PR TITLE
fix(media-library): apply upload date sort selections

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -34,6 +34,7 @@ const tables = {
         field_types: {
             uid: 'text',
             registered: 'numeric',
+            upload_date: 'text',
             user_uid: 'text',
             sub_id: 'text',
             isAudio: 'boolean',
@@ -50,8 +51,10 @@ const tables = {
         },
         indexes: [
             { keys: { registered: -1 } },
+            { keys: { upload_date: -1 } },
             { keys: { user_uid: 1, registered: -1 } },
             { keys: { sub_id: 1, registered: -1 } },
+            { keys: { sub_id: 1, upload_date: -1 } },
             { keys: { isAudio: 1, registered: -1 } },
             { keys: { duplicate_key: 1, registered: 1 } },
             { keys: { user_uid: 1, duplicate_key: 1, registered: 1 } },
@@ -765,12 +768,65 @@ exports.getRecord = async (table, filter_obj) => {
     return await mongo_database.collection(table).findOne(filter_obj);
 }
 
+function normalizeUploadDateSortValue(value) {
+    if (value === null || value === undefined) return null;
+
+    const normalized = String(value).trim();
+    if (!normalized || normalized.toUpperCase() === 'N/A') return null;
+
+    const iso_date_match = normalized.match(/^(\d{4})-(\d{2})-(\d{2})/);
+    if (iso_date_match) return `${iso_date_match[1]}-${iso_date_match[2]}-${iso_date_match[3]}`;
+
+    const compact_date_match = normalized.match(/^(\d{4})(\d{2})(\d{2})$/);
+    if (compact_date_match) return `${compact_date_match[1]}-${compact_date_match[2]}-${compact_date_match[3]}`;
+
+    const slash_date_match = normalized.match(/^(\d{1,2})\/(\d{1,2})\/(\d{2}|\d{4})$/);
+    if (slash_date_match) {
+        const month = slash_date_match[1].padStart(2, '0');
+        const day = slash_date_match[2].padStart(2, '0');
+        const raw_year = slash_date_match[3];
+        const year_number = raw_year.length === 2
+            ? Number(raw_year) + (Number(raw_year) >= 70 ? 1900 : 2000)
+            : Number(raw_year);
+        return `${year_number}-${month}-${day}`;
+    }
+
+    const parsed_timestamp = Date.parse(normalized);
+    if (!Number.isNaN(parsed_timestamp)) {
+        return new Date(parsed_timestamp).toISOString().slice(0, 10);
+    }
+
+    return normalized;
+}
+
+function normalizeLocalSortValue(sort_by, value) {
+    if (sort_by === 'upload_date') {
+        return normalizeUploadDateSortValue(value);
+    }
+
+    return value === undefined ? null : value;
+}
+
+function compareLocalSortValues(sort, record_a, record_b) {
+    const sort_by = sort['by'];
+    const sort_order = sort['order'] === -1 ? -1 : 1;
+    const value_a = normalizeLocalSortValue(sort_by, record_a[sort_by]);
+    const value_b = normalizeLocalSortValue(sort_by, record_b[sort_by]);
+
+    if (value_a === null && value_b === null) return 0;
+    if (value_a === null) return 1;
+    if (value_b === null) return -1;
+    if (value_a < value_b) return -sort_order;
+    if (value_a > value_b) return sort_order;
+    return 0;
+}
+
 exports.getRecords = async (table, filter_obj = null, return_count = false, sort = null, range = null) => {
     // local db override
     if (using_local_db) {
         let cursor = filter_obj ? exports.applyFilterLocalDB(local_db.get(table), filter_obj, 'filter').value() : local_db.get(table).value();
         if (sort) {
-            cursor = cursor.sort((a, b) => (a[sort['by']] > b[sort['by']] ? sort['order'] : sort['order']*-1));
+            cursor = cursor.sort((a, b) => compareLocalSortValues(sort, a, b));
         }
         if (range) {
             cursor = cursor.slice(range[0], range[1]);

--- a/backend/test/database.test.js
+++ b/backend/test/database.test.js
@@ -214,6 +214,33 @@ describe('Database', async function() {
                     assert(stats);
                 });
 
+                it('Sorts upload dates in chronological order', async function() {
+                    const test_records = [
+                        {uid: 'upload-date-sort-1', upload_date: '6/26/17'},
+                        {uid: 'upload-date-sort-2', upload_date: '2021-07-06'},
+                        {uid: 'upload-date-sort-3', upload_date: '20200423'},
+                        {uid: 'upload-date-sort-4', upload_date: 'N/A'}
+                    ];
+                    const success = await db_api.bulkInsertRecordsIntoTable('test', test_records);
+                    assert(success);
+
+                    const descending_records = await db_api.getRecords('test', null, false, {by: 'upload_date', order: -1});
+                    assert.deepStrictEqual(descending_records.map(record => record.uid), [
+                        'upload-date-sort-2',
+                        'upload-date-sort-3',
+                        'upload-date-sort-1',
+                        'upload-date-sort-4'
+                    ]);
+
+                    const ascending_records = await db_api.getRecords('test', null, false, {by: 'upload_date', order: 1});
+                    assert.deepStrictEqual(ascending_records.map(record => record.uid), [
+                        'upload-date-sort-1',
+                        'upload-date-sort-3',
+                        'upload-date-sort-2',
+                        'upload-date-sort-4'
+                    ]);
+                });
+
                 it.skip('Query speed', async function() {
                     this.timeout(120000); 
                     const NUM_RECORDS_TO_ADD = 300004; // max batch ops is 1000

--- a/backend/test/files.test.js
+++ b/backend/test/files.test.js
@@ -222,4 +222,25 @@ describe('Files', function() {
             db_api.isUsingMongoDB = original_is_using_mongo_db;
         }
     });
+
+    it('passes upload date sort options through to the database layer', async function() {
+        const original_get_records = db_api.getRecords;
+        const captured_sorts = [];
+
+        try {
+            db_api.getRecords = async (table, filter_obj, return_count, sort) => {
+                captured_sorts.push({return_count, sort});
+                return return_count ? 0 : [];
+            };
+
+            await files_api.getAllFiles({by: 'upload_date', order: -1}, [0, 20], null, 'both', false, null, null);
+
+            assert.deepStrictEqual(captured_sorts, [
+                {return_count: false, sort: {by: 'upload_date', order: -1}},
+                {return_count: true, sort: undefined}
+            ]);
+        } finally {
+            db_api.getRecords = original_get_records;
+        }
+    });
 });

--- a/src/app/components/sort-property/sort-property.component.html
+++ b/src/app/components/sort-property/sort-property.component.html
@@ -1,6 +1,6 @@
 <div class="sort-property">
   <mat-form-field appearance="outline" class="sort-property-field">
-    <mat-select [(ngModel)]="this.sortProperty" (selectionChange)="emitSortOptionChanged()">
+    <mat-select [(ngModel)]="this.sortProperty" (selectionChange)="emitSortOptionChanged($event.value)">
       @for (sortOption of sortProperties | keyvalue; track sortOption) {
         <mat-option [value]="sortOption.key">
           {{sortOption['value']['label']}}

--- a/src/app/components/sort-property/sort-property.component.spec.ts
+++ b/src/app/components/sort-property/sort-property.component.spec.ts
@@ -20,4 +20,26 @@ describe('SortPropertyComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should emit the selected sort property when changed', () => {
+    const sort_property_spy = spyOn(component.sortPropertyChange, 'emit');
+    const sort_option_spy = spyOn(component.sortOptionChanged, 'emit');
+
+    component.emitSortOptionChanged('upload_date');
+
+    expect(component.sortProperty).toBe('upload_date');
+    expect(sort_property_spy).toHaveBeenCalledWith('upload_date');
+    expect(sort_option_spy).toHaveBeenCalledWith({by: 'upload_date', order: -1});
+  });
+
+  it('should emit descending mode changes when toggled', () => {
+    const descending_mode_spy = spyOn(component.descendingModeChange, 'emit');
+    const sort_option_spy = spyOn(component.sortOptionChanged, 'emit');
+
+    component.toggleModeChange();
+
+    expect(component.descendingMode).toBeFalse();
+    expect(descending_mode_spy).toHaveBeenCalledWith(false);
+    expect(sort_option_spy).toHaveBeenCalledWith({by: 'registered', order: 1});
+  });
 });

--- a/src/app/components/sort-property/sort-property.component.ts
+++ b/src/app/components/sort-property/sort-property.component.ts
@@ -43,10 +43,13 @@ export class SortPropertyComponent {
     this.emitSortOptionChanged();
   }
 
-  emitSortOptionChanged(): void {
+  emitSortOptionChanged(sortProperty = this.sortProperty): void {
+    this.sortProperty = sortProperty;
     if (!this.sortProperty || !this.sortProperties[this.sortProperty]) {
       return;
     }
+    this.sortPropertyChange.emit(this.sortProperty);
+    this.descendingModeChange.emit(this.descendingMode);
     this.sortOptionChanged.emit({
       by: this.sortProperty,
       order: this.descendingMode ? -1 : 1


### PR DESCRIPTION
## Summary
- Emit the selected sort property and direction explicitly from the sort control so the media library request state stays in sync with the dropdown.
- Normalize local DB upload-date sort values before comparing them, including ISO, compact, and short slash date forms, with missing dates sorted last.
- Add coverage for sort-control emits, upload-date DB ordering, and the getAllFiles sort handoff.

Refs #157

## Testing
- node --check backend/db.js
- cd backend && npm test -- --grep "Database|Files"
- npm run lint
- npx tsc -p src/tsconfig.app.json --noEmit
- npx tsc -p src/tsconfig.spec.json --noEmit
- CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npm run test:headless
- npx ng build --configuration production