### PR TITLE
feat(subscriptions): redownload subscription files

### DIFF
--- a/Public API v1.yaml
+++ b/Public API v1.yaml
@@ -314,6 +314,27 @@ paths:
                 $ref: '#/components/schemas/SuccessObject'
       security:
         - Auth query parameter: []
+  /api/redownloadSubscription:
+    post:
+      tags:
+        - subscriptions
+      summary: Delete and redownload all videos for a subscription
+      description: Deletes files associated with the selected subscription and queues that subscription again using its current settings
+      operationId: post-api-redownloadSubscription
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CheckSubscriptionRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessObject'
+      security:
+        - Auth query parameter: []
   /api/cancelCheckSubscription:
     post:
       tags:

--- a/backend/app.js
+++ b/backend/app.js
@@ -1877,6 +1877,14 @@ app.post('/api/checkSubscription', optionalJwt, async (req, res) => {
     });
 });
 
+app.post('/api/redownloadSubscription', optionalJwt, async (req, res) => {
+    let sub_id = req.body.sub_id;
+    let user_uid = req.isAuthenticated() ? req.user.uid : null;
+
+    const result = await subscriptions_api.redownloadSubscription(sub_id, user_uid);
+    res.send(result);
+});
+
 app.post('/api/cancelCheckSubscription', optionalJwt, async (req, res) => {
     let sub_id = req.body.sub_id;
     let user_uid = req.isAuthenticated() ? req.user.uid : null;

--- a/backend/subscriptions.js
+++ b/backend/subscriptions.js
@@ -4,6 +4,7 @@ const path = require('path');
 const youtubedl_api = require('./youtube-dl');
 const config_api = require('./config');
 const archive_api = require('./archive');
+const files_api = require('./files');
 const utils = require('./utils');
 const logger = require('./logger');
 const CONSTS = require('./consts');
@@ -681,6 +682,62 @@ exports.deleteSubscriptionFile = async (sub, file, deleteForever, file_uid = nul
     }
 }
 
+exports.redownloadSubscription = async (sub_id, user_uid = null) => {
+    const sub = await exports.getSubscription(sub_id, user_uid);
+    if (!sub) {
+        return {
+            success: false,
+            error: 'Subscription not found or not owned by the current user.'
+        };
+    }
+
+    if (sub['downloading'] || sub['child_process'] || sub['refresh_status']?.active) {
+        await exports.cancelCheckSubscription(sub.id, user_uid);
+    }
+    await killSubDownloads(sub.id, true);
+
+    const sub_files_filter = {sub_id: sub.id};
+    if (shouldRestrictToUser(user_uid)) sub_files_filter['user_uid'] = user_uid;
+    const sub_files = await db_api.getRecords('files', sub_files_filter);
+
+    let deleted_count = 0;
+    let failed_count = 0;
+    for (const sub_file of sub_files) {
+        try {
+            const deleted = await files_api.deleteFile(sub_file.uid, false, user_uid);
+            if (deleted) {
+                deleted_count += 1;
+            } else {
+                failed_count += 1;
+            }
+        } catch (e) {
+            failed_count += 1;
+            logger.error(`Failed to delete subscription file '${sub_file.uid}' before redownload.`);
+            logger.error(e);
+        }
+    }
+
+    if (failed_count > 0) {
+        return {
+            success: false,
+            deleted_count: deleted_count,
+            failed_count: failed_count,
+            refresh_started: false,
+            error: `Failed to delete ${failed_count} subscription file${failed_count === 1 ? '' : 's'} before redownload.`
+        };
+    }
+
+    const refresh_started = await exports.getVideosForSub(sub.id, user_uid);
+    const result = {
+        success: refresh_started,
+        deleted_count: deleted_count,
+        failed_count: failed_count,
+        refresh_started: refresh_started
+    };
+    if (!refresh_started) result.error = 'Failed to start subscription refresh.';
+    return result;
+}
+
 let current_sub_index = 0; // To keep track of the current subscription
 exports.watchSubscriptionsInterval = async () => {
     const subscriptions_check_interval = config_api.getConfigItem('ytdl_subscriptions_check_interval');
@@ -798,7 +855,10 @@ async function _getVideosForSub(sub) {
             await fs.unlink(archive_path);
         }
 
-        await updateSubscriptionProperty(sub, {downloading: false, child_process: null}, user_uid);
+        const current_refresh_tracker = active_subscription_refresh_trackers.get(sub.id);
+        if (!current_refresh_tracker || current_refresh_tracker === refresh_tracker) {
+            await updateSubscriptionProperty(sub, {downloading: false, child_process: null}, user_uid);
+        }
     }
 }
 

--- a/backend/test/subscriptions.test.js
+++ b/backend/test/subscriptions.test.js
@@ -3,6 +3,7 @@ const { assert, path, fs, uuid, db_api, subscriptions_api, youtubedl_api, config
 
 describe('Subscriptions', function() {
     const downloader_api = require('../downloader');
+    const files_api = require('../files');
     const new_sub = {
         name: 'test_sub',
         url: 'https://www.youtube.com/channel/UCzofo-P8yMMCOv8rsPfIR-g',
@@ -15,6 +16,7 @@ describe('Subscriptions', function() {
     beforeEach(async function() {
         await db_api.removeAllRecords('subscriptions');
         await db_api.removeAllRecords('download_queue');
+        await db_api.removeAllRecords('files');
         config_api.setConfigItem('ytdl_subscriptions_redownload_fresh_uploads', false);
         config_api.setConfigItem('ytdl_custom_args', '');
     });
@@ -79,6 +81,128 @@ describe('Subscriptions', function() {
     });
     it('Delete subscription file', async function () {
         
+    });
+    it('Deletes subscription files and starts a fresh redownload', async function () {
+        const original_deleteFile = files_api.deleteFile;
+        const original_getVideosForSub = subscriptions_api.getVideosForSub;
+        const sub = Object.assign({}, new_sub, {id: uuid(), name: 'redownload_sub'});
+        const file_one = {uid: uuid(), sub_id: sub.id, url: 'https://example.com/video-1', path: 'subscriptions/video-1.mp4'};
+        const file_two = {uid: uuid(), sub_id: sub.id, url: 'https://example.com/video-2', path: 'subscriptions/video-2.mp4'};
+        const queued_download = {
+            uid: uuid(),
+            sub_id: sub.id,
+            url: 'https://example.com/video-queued',
+            running: false,
+            finished: false,
+            error: null
+        };
+        const deleted_files = [];
+        let refresh_sub_id = null;
+
+        files_api.deleteFile = async (uid, blacklistMode, user_uid) => {
+            deleted_files.push({uid, blacklistMode, user_uid});
+            return true;
+        };
+        subscriptions_api.getVideosForSub = async (sub_id, user_uid) => {
+            refresh_sub_id = sub_id;
+            assert.strictEqual(user_uid, null);
+            return true;
+        };
+
+        try {
+            await db_api.insertRecordIntoTable('subscriptions', sub);
+            await db_api.insertRecordIntoTable('files', file_one);
+            await db_api.insertRecordIntoTable('files', file_two);
+            await db_api.insertRecordIntoTable('download_queue', queued_download);
+
+            const result = await subscriptions_api.redownloadSubscription(sub.id);
+
+            assert.strictEqual(result.success, true);
+            assert.strictEqual(result.deleted_count, 2);
+            assert.strictEqual(result.failed_count, 0);
+            assert.strictEqual(result.refresh_started, true);
+            assert.strictEqual(refresh_sub_id, sub.id);
+            assert.deepStrictEqual(deleted_files.map(file => file.uid).sort(), [file_one.uid, file_two.uid].sort());
+            assert(deleted_files.every(file => file.blacklistMode === false));
+
+            const remaining_downloads = await db_api.getRecords('download_queue', {sub_id: sub.id});
+            assert.strictEqual(remaining_downloads.length, 0);
+        } finally {
+            files_api.deleteFile = original_deleteFile;
+            subscriptions_api.getVideosForSub = original_getVideosForSub;
+        }
+    });
+    it('Does not start redownload refresh when deleting a subscription file fails', async function () {
+        const original_deleteFile = files_api.deleteFile;
+        const original_getVideosForSub = subscriptions_api.getVideosForSub;
+        const sub = Object.assign({}, new_sub, {id: uuid(), name: 'redownload_failure_sub'});
+        const file_one = {uid: uuid(), sub_id: sub.id, url: 'https://example.com/video-1', path: 'subscriptions/video-1.mp4'};
+        const file_two = {uid: uuid(), sub_id: sub.id, url: 'https://example.com/video-2', path: 'subscriptions/video-2.mp4'};
+        let refresh_started = false;
+
+        files_api.deleteFile = async (uid) => uid === file_one.uid;
+        subscriptions_api.getVideosForSub = async () => {
+            refresh_started = true;
+            return true;
+        };
+
+        try {
+            await db_api.insertRecordIntoTable('subscriptions', sub);
+            await db_api.insertRecordIntoTable('files', file_one);
+            await db_api.insertRecordIntoTable('files', file_two);
+
+            const result = await subscriptions_api.redownloadSubscription(sub.id);
+
+            assert.strictEqual(result.success, false);
+            assert.strictEqual(result.deleted_count, 1);
+            assert.strictEqual(result.failed_count, 1);
+            assert.strictEqual(result.refresh_started, false);
+            assert.strictEqual(refresh_started, false);
+        } finally {
+            files_api.deleteFile = original_deleteFile;
+            subscriptions_api.getVideosForSub = original_getVideosForSub;
+        }
+    });
+    it('Does not redownload a missing subscription', async function () {
+        const result = await subscriptions_api.redownloadSubscription(uuid());
+
+        assert.strictEqual(result.success, false);
+        assert(result.error.includes('Subscription not found'));
+    });
+    it('Cancels active subscription work before redownloading', async function () {
+        const original_cancelCheckSubscription = subscriptions_api.cancelCheckSubscription;
+        const original_getVideosForSub = subscriptions_api.getVideosForSub;
+        const sub = Object.assign({}, new_sub, {
+            id: uuid(),
+            name: 'active_redownload_sub',
+            downloading: true
+        });
+        let cancelled_sub_id = null;
+        let refresh_sub_id = null;
+
+        subscriptions_api.cancelCheckSubscription = async (sub_id, user_uid) => {
+            cancelled_sub_id = sub_id;
+            assert.strictEqual(user_uid, null);
+            return true;
+        };
+        subscriptions_api.getVideosForSub = async (sub_id, user_uid) => {
+            refresh_sub_id = sub_id;
+            assert.strictEqual(user_uid, null);
+            return true;
+        };
+
+        try {
+            await db_api.insertRecordIntoTable('subscriptions', sub);
+
+            const result = await subscriptions_api.redownloadSubscription(sub.id);
+
+            assert.strictEqual(result.success, true);
+            assert.strictEqual(cancelled_sub_id, sub.id);
+            assert.strictEqual(refresh_sub_id, sub.id);
+        } finally {
+            subscriptions_api.cancelCheckSubscription = original_cancelCheckSubscription;
+            subscriptions_api.getVideosForSub = original_getVideosForSub;
+        }
     });
     it('Get subscription by name', async function () {
         await subscriptions_api.subscribe(new_sub, null, true);

--- a/src/app/posts.services.ts
+++ b/src/app/posts.services.ts
@@ -654,6 +654,11 @@ export class PostsService {
         return this.http.post<SuccessObject>(this.path + 'checkSubscription', body, this.httpOptions);
     }
 
+    redownloadSubscription(sub_id: string) {
+        const body: CheckSubscriptionRequest = {sub_id: sub_id};
+        return this.http.post<SuccessObject>(this.path + 'redownloadSubscription', body, this.httpOptions);
+    }
+
     cancelCheckSubscription(sub_id: string) {
         const body: CheckSubscriptionRequest = {sub_id: sub_id};
         return this.http.post<SuccessObject>(this.path + 'cancelCheckSubscription', body, this.httpOptions);

--- a/src/app/subscriptions/subscriptions.component.html
+++ b/src/app/subscriptions/subscriptions.component.html
@@ -22,6 +22,9 @@
         }
       </a>
       <div style="pointer-events: auto; color: unset" matListItemMeta>
+        <button matTooltip="Delete and redownload" i18n-matTooltip="Delete and redownload subscription files" mat-icon-button [disabled]="isRedownloadDisabled(sub)" (click)="confirmRedownloadSubscription(sub)">
+          <mat-icon>restore</mat-icon>
+        </button>
         <button matTooltip="Edit" i18n-matTooltip="Edit" mat-icon-button (click)="editSubscription(sub)">
           <mat-icon>edit</mat-icon>
         </button>
@@ -56,6 +59,9 @@
         }
       </a>
       <div style="pointer-events: auto; color: unset" matListItemMeta>
+        <button matTooltip="Delete and redownload" i18n-matTooltip="Delete and redownload subscription files" mat-icon-button [disabled]="isRedownloadDisabled(sub)" (click)="confirmRedownloadSubscription(sub)">
+          <mat-icon>restore</mat-icon>
+        </button>
         <button matTooltip="Edit" i18n-matTooltip="Edit" mat-icon-button (click)="editSubscription(sub)">
           <mat-icon>edit</mat-icon>
         </button>

--- a/src/app/subscriptions/subscriptions.component.spec.ts
+++ b/src/app/subscriptions/subscriptions.component.spec.ts
@@ -1,25 +1,71 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { BehaviorSubject, of } from 'rxjs';
 
 import { SubscriptionsComponent } from './subscriptions.component';
 
 describe('SubscriptionsComponent', () => {
   let component: SubscriptionsComponent;
-  let fixture: ComponentFixture<SubscriptionsComponent>;
-
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [ SubscriptionsComponent ]
-    })
-    .compileComponents();
-  }));
+  let dialog: any;
+  let postsService: any;
+  let router: any;
+  let snackBar: any;
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(SubscriptionsComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    dialog = {
+      open: jasmine.createSpy('open')
+    };
+    postsService = {
+      initialized: false,
+      service_initialized: new BehaviorSubject<boolean>(false),
+      files_changed: new BehaviorSubject<boolean>(false),
+      getAllSubscriptions: jasmine.createSpy('getAllSubscriptions').and.returnValue(of({subscriptions: []})),
+      getSubscriptionByID: jasmine.createSpy('getSubscriptionByID'),
+      redownloadSubscription: jasmine.createSpy('redownloadSubscription'),
+      reloadSubscriptions: jasmine.createSpy('reloadSubscriptions')
+    };
+    router = {
+      navigate: jasmine.createSpy('navigate')
+    };
+    snackBar = {
+      open: jasmine.createSpy('open')
+    };
+
+    component = new SubscriptionsComponent(dialog, postsService, router, snackBar);
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('confirms before redownloading subscription files', () => {
+    const sub = {id: 'sub-1', name: 'Test subscription'} as any;
+    dialog.open.and.returnValue({afterClosed: () => of(true)});
+    postsService.redownloadSubscription.and.returnValue(of({success: true}));
+    spyOn(postsService.files_changed, 'next');
+
+    component.confirmRedownloadSubscription(sub);
+
+    expect(dialog.open).toHaveBeenCalled();
+    expect(postsService.redownloadSubscription).toHaveBeenCalledWith('sub-1');
+    expect(postsService.getAllSubscriptions).toHaveBeenCalled();
+    expect(postsService.reloadSubscriptions).toHaveBeenCalled();
+    expect(postsService.files_changed.next).toHaveBeenCalledWith(true);
+    expect(snackBar.open).toHaveBeenCalledWith('Redownload started for Test subscription', '', {duration: 2000});
+  });
+
+  it('does not redownload when the confirmation is dismissed', () => {
+    const sub = {id: 'sub-1', name: 'Test subscription'} as any;
+    dialog.open.and.returnValue({afterClosed: () => of(false)});
+
+    component.confirmRedownloadSubscription(sub);
+
+    expect(postsService.redownloadSubscription).not.toHaveBeenCalled();
+  });
+
+  it('keeps redownload available for active subscriptions', () => {
+    expect(component.isRedownloadDisabled({id: 'sub-1', name: 'Test subscription', downloading: true} as any)).toBeFalse();
+  });
+
+  it('disables redownload until a subscription has a name', () => {
+    expect(component.isRedownloadDisabled({id: 'sub-1', name: null} as any)).toBeTrue();
   });
 });

--- a/src/app/subscriptions/subscriptions.component.ts
+++ b/src/app/subscriptions/subscriptions.component.ts
@@ -6,6 +6,8 @@ import { PostsService } from 'app/posts.services';
 import { Router } from '@angular/router';
 import { SubscriptionInfoDialogComponent } from 'app/dialogs/subscription-info-dialog/subscription-info-dialog.component';
 import { EditSubscriptionDialogComponent } from 'app/dialogs/edit-subscription-dialog/edit-subscription-dialog.component';
+import { ConfirmDialogComponent } from 'app/dialogs/confirm-dialog/confirm-dialog.component';
+import { Subscription } from 'api-types';
 
 @Component({
     selector: 'app-subscriptions',
@@ -15,9 +17,10 @@ import { EditSubscriptionDialogComponent } from 'app/dialogs/edit-subscription-d
 })
 export class SubscriptionsComponent implements OnInit {
 
-  playlist_subscriptions = [];
-  channel_subscriptions = [];
-  subscriptions = null;
+  playlist_subscriptions: Subscription[] = [];
+  channel_subscriptions: Subscription[] = [];
+  subscriptions: Subscription[] = null;
+  redownloading_subscriptions: {[sub_id: string]: boolean} = {};
 
   subscriptions_loading = false;
 
@@ -112,6 +115,48 @@ export class SubscriptionsComponent implements OnInit {
     });
     dialogRef.afterClosed().subscribe(() => {
       this.getSubscriptions(false);
+    });
+  }
+
+  isRedownloadDisabled(sub: Subscription): boolean {
+    return !sub?.name || !!this.redownloading_subscriptions[sub.id];
+  }
+
+  confirmRedownloadSubscription(sub: Subscription): void {
+    const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+      data: {
+        dialogTitle: $localize`Delete and redownload ${sub.name}:subscription name:`,
+        dialogText: $localize`This will delete every downloaded video in ${sub.name}:subscription name: and queue that subscription again using its current settings. Other videos are not affected.`,
+        submitText: $localize`Delete and redownload`,
+        warnSubmitColor: true
+      }
+    });
+    dialogRef.afterClosed().subscribe(confirmed => {
+      if (confirmed) {
+        this.redownloadSubscription(sub);
+      }
+    });
+  }
+
+  redownloadSubscription(sub: Subscription): void {
+    if (this.isRedownloadDisabled(sub)) return;
+
+    this.redownloading_subscriptions[sub.id] = true;
+    this.postsService.redownloadSubscription(sub.id).subscribe(res => {
+      this.redownloading_subscriptions[sub.id] = false;
+      if (res['success']) {
+        this.openSnackBar($localize`Redownload started for ${sub.name}:subscription name:`);
+        this.getSubscriptions(false);
+        this.postsService.reloadSubscriptions();
+        this.postsService.files_changed.next(true);
+      } else {
+        const error = res['error'] ? ` ${res['error']}` : '';
+        this.openSnackBar($localize`ERROR: Failed to start redownload for ${sub.name}:subscription name:.` + error, 'OK.');
+      }
+    }, err => {
+      console.error(err);
+      this.redownloading_subscriptions[sub.id] = false;
+      this.openSnackBar($localize`ERROR: Failed to start redownload for ${sub.name}:subscription name:.`, 'OK.');
     });
   }
 


### PR DESCRIPTION
## Summary
- add a subscription-list action to delete and redownload every downloaded video for the selected channel or playlist only
- add a destructive confirmation dialog warning that other videos are not affected
- add a backend redownload endpoint that clears that subscription's queued work, removes files from DB/disk/archive, and starts a fresh subscription check

Related to #160

## Tests
- npm run lint
- npx tsc -p src/tsconfig.app.json --noEmit
- npx tsc -p src/tsconfig.spec.json --noEmit
- CHROMIUM_BIN="/usr/bin/chromium" npm run test:headless
- npx ng build --configuration production
- node --check backend/subscriptions.js
- node --check backend/app.js
- npm test -- --grep "Subscriptions"
- npm test