### PR TITLE
fix(subscriptions): align backup path with download folder

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -656,9 +656,10 @@ exports.getFileDirectoriesAndDBs = async () => {
             // TODO: Remove subscription as it'll never complete
             continue;
         }
+        const subscription_path_name = utils.getSubscriptionPathName(subscription_to_check);
         dirs_to_check.push({
-            basePath: subscription_to_check.user_uid ? path.join(usersFileFolder, subscription_to_check.user_uid, 'subscriptions', subscription_to_check.isPlaylist ? 'playlists/' : 'channels/', subscription_to_check.name)
-                                      : path.join(subscriptions_base_path, subscription_to_check.isPlaylist ? 'playlists/' : 'channels/', subscription_to_check.name),
+            basePath: subscription_to_check.user_uid ? path.join(usersFileFolder, subscription_to_check.user_uid, 'subscriptions', subscription_to_check.isPlaylist ? 'playlists' : 'channels', subscription_path_name)
+                                      : path.join(subscriptions_base_path, subscription_to_check.isPlaylist ? 'playlists' : 'channels', subscription_path_name),
             user_uid: subscription_to_check.user_uid,
             type: subscription_to_check.type,
             sub_id: subscription_to_check['id'],

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@discordjs/builders": "^1.14.1",
         "@discordjs/core": "^2.4.0",
-        "@scalar/express-api-reference": "^0.9.9",
+        "@scalar/express-api-reference": "^0.9.10",
         "archiver": "^7.0.1",
         "async": "^3.2.3",
         "async-mutex": "^0.5.0",
@@ -407,45 +407,45 @@
       }
     },
     "node_modules/@scalar/client-side-rendering": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@scalar/client-side-rendering/-/client-side-rendering-0.1.2.tgz",
-      "integrity": "sha512-gX2QIc+lpErO9RWkJmt02sBZoCOjyZ7EiLLEyGj7x9UKkk7E4zj6Wbk1eUPo6i3oIwhtZ+Vybj/xzexCK2bxwA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@scalar/client-side-rendering/-/client-side-rendering-0.1.3.tgz",
+      "integrity": "sha512-rUI5EQA8y0xivzqc/AwExZYW8HRfQSFxPxvvuLjHTCATpKz0xcQBGVJQIPOmp78NJyO8mnQmltE1AxIdtvdPGg==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/types": "0.9.1"
+        "@scalar/types": "0.9.2"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/express-api-reference": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/@scalar/express-api-reference/-/express-api-reference-0.9.9.tgz",
-      "integrity": "sha512-YE/ZvEtchsM2Jc4wDq2bhMcXicueVVOWmh+nnG3PlvB2LprLMgR+TikBcYD94vWaSakS5D3dgieEifVwejIsCw==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@scalar/express-api-reference/-/express-api-reference-0.9.10.tgz",
+      "integrity": "sha512-udv4u0nz6NDXG3qyGOzp/uVKZn0ksLdVr5D3R5nx+XhO1ZYdNNZoZYjX80Q5NXL68XJAVNMVl+4SObjuwbBTag==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/client-side-rendering": "0.1.2"
+        "@scalar/client-side-rendering": "0.1.3"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/helpers": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.5.1.tgz",
-      "integrity": "sha512-9VvPfv8b+YZVIFwR3SWeq4Y8ij/kU3/kf2M6NKcbf2iVyh63d8s0ssap5m/nOhiz/Puidv/29MAJlJCA0LRssA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.5.2.tgz",
+      "integrity": "sha512-Pi1GAl8jO6ungmGj2sjDfCfqiBNrKW6HXDZmminV94ybGU/KtRLOqHwd0n9FIhY3j0RYGpGC0VCuniCICfQPHg==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/types": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.9.1.tgz",
-      "integrity": "sha512-3EbkhtQc+XuDE8Ur1MPosM3YTACFIFNba4M3vGulqv8jcvhMXT+KWPvGUJxq0CDvySqjGa8cE6w85v8T+MjDng==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.9.2.tgz",
+      "integrity": "sha512-aLn7QTHafpjrN/whup7U5/CHaoPPaYMNtz4L/2yfN5GDSy3AbDM7kV1q8s3nMQIhvC1uscxfriV+KhEND+xHvA==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.5.1",
+        "@scalar/helpers": "0.5.2",
         "nanoid": "^5.1.6",
         "type-fest": "^5.3.1",
         "zod": "^4.3.5"

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@discordjs/builders": "^1.14.1",
     "@discordjs/core": "^2.4.0",
-    "@scalar/express-api-reference": "^0.9.9",
+    "@scalar/express-api-reference": "^0.9.10",
     "archiver": "^7.0.1",
     "async": "^3.2.3",
     "async-mutex": "^0.5.0",

--- a/backend/subscriptions.js
+++ b/backend/subscriptions.js
@@ -904,7 +904,7 @@ exports.generateOptionsForSubscriptionDownload = (sub, user_uid) => {
         maxHeight: sub.maxQuality && sub.maxQuality !== 'best' ? sub.maxQuality : null,
         customFileFolderPath: getAppendedBasePath(sub, basePath),
         customOutput: sub.custom_output ? `${sub.custom_output}` : `${default_output}`,
-        customArchivePath: path.join(basePath, 'archives', sub.name),
+        customArchivePath: path.join(basePath, 'archives', utils.getSubscriptionPathName(sub)),
         additionalArgs: sub.custom_args
     }
 
@@ -1351,5 +1351,5 @@ async function checkVideoIfBetterExists(file_obj, sub, user_uid) {
 // helper functions
 
 function getAppendedBasePath(sub, base_path) {
-    return path.join(base_path, (sub.isPlaylist ? 'playlists/' : 'channels/'), sub.name);
+    return path.join(base_path, sub.isPlaylist ? 'playlists' : 'channels', utils.getSubscriptionPathName(sub));
 }

--- a/backend/test/subscriptions.test.js
+++ b/backend/test/subscriptions.test.js
@@ -19,6 +19,9 @@ describe('Subscriptions', function() {
         await db_api.removeAllRecords('files');
         config_api.setConfigItem('ytdl_subscriptions_redownload_fresh_uploads', false);
         config_api.setConfigItem('ytdl_custom_args', '');
+        config_api.setConfigItem('ytdl_replace_invalid_filename_chars', false);
+        config_api.setConfigItem('ytdl_invalid_filename_chars', '\\/:*?"<>|');
+        config_api.setConfigItem('ytdl_invalid_filename_replacement', '_');
     });
 
     async function waitForCondition(predicate, timeout_ms = 2000) {
@@ -280,6 +283,65 @@ describe('Subscriptions', function() {
         if (fs.existsSync(metadata_path)) fs.unlinkSync(metadata_path);
         await subscriptions_api.subscribe(new_sub, null, true);
         assert(fs.existsSync(metadata_path));
+    });
+    it('Writes subscription metadata into the sanitized folder used for downloads', async function() {
+        const sub = Object.assign({}, new_sub, {
+            id: uuid(),
+            name: 'Full Documentaries | FRONTLINE',
+            isPlaylist: true
+        });
+        const expected_subscription_path = path.join('subscriptions', 'playlists', 'Full Documentaries - FRONTLINE');
+        const raw_subscription_path = path.join('subscriptions', 'playlists', 'Full Documentaries | FRONTLINE');
+        const metadata_path = path.join(expected_subscription_path, 'subscription_backup.json');
+
+        config_api.setConfigItem('ytdl_replace_invalid_filename_chars', true);
+        config_api.setConfigItem('ytdl_invalid_filename_replacement', '-');
+
+        try {
+            await fs.remove(expected_subscription_path);
+            await fs.remove(raw_subscription_path);
+
+            const success = subscriptions_api.writeSubscriptionMetadata(sub);
+            const download_options = subscriptions_api.generateOptionsForSubscriptionDownload(sub, null);
+            await db_api.insertRecordIntoTable('subscriptions', sub);
+            const subscription_dir = (await db_api.getFileDirectoriesAndDBs()).find(dir => dir.sub_id === sub.id);
+
+            assert.strictEqual(success, true);
+            assert.strictEqual(fs.existsSync(metadata_path), true);
+            assert.strictEqual(fs.existsSync(path.join(raw_subscription_path, 'subscription_backup.json')), false);
+            assert.strictEqual(download_options.customFileFolderPath, expected_subscription_path);
+            assert.strictEqual(download_options.customArchivePath, path.join('subscriptions', 'archives', 'Full Documentaries - FRONTLINE'));
+            assert(subscription_dir);
+            assert.strictEqual(subscription_dir.basePath, expected_subscription_path);
+            assert.strictEqual(subscription_dir.archive_path, path.join('subscriptions', 'archives', 'Full Documentaries - FRONTLINE'));
+        } finally {
+            await fs.remove(expected_subscription_path);
+            await fs.remove(raw_subscription_path);
+        }
+    });
+    it('Does not let path separators split subscription metadata folders', async function() {
+        const sub = Object.assign({}, new_sub, {
+            id: uuid(),
+            name: 'Folder/Playlist',
+            isPlaylist: true
+        });
+        const expected_subscription_path = path.join('subscriptions', 'playlists', 'Folder_Playlist');
+        const nested_subscription_path = path.join('subscriptions', 'playlists', 'Folder');
+        const metadata_path = path.join(expected_subscription_path, 'subscription_backup.json');
+
+        try {
+            await fs.remove(expected_subscription_path);
+            await fs.remove(nested_subscription_path);
+
+            const success = subscriptions_api.writeSubscriptionMetadata(sub);
+
+            assert.strictEqual(success, true);
+            assert.strictEqual(fs.existsSync(metadata_path), true);
+            assert.strictEqual(fs.existsSync(path.join(nested_subscription_path, 'Playlist', 'subscription_backup.json')), false);
+        } finally {
+            await fs.remove(expected_subscription_path);
+            await fs.remove(nested_subscription_path);
+        }
     });
     it('Streams subscription videos with flat playlist metadata and queues them in batches before discovery completes', async function() {
         const original_runYoutubeDLLineStream = youtubedl_api.runYoutubeDLLineStream;

--- a/backend/utils.js
+++ b/backend/utils.js
@@ -11,6 +11,49 @@ const logger = require('./logger');
 const CONSTS = require('./consts');
 
 const is_windows = process.platform === 'win32';
+const DEFAULT_INVALID_FILENAME_CHARS = '\\/:*?"<>|';
+
+function getSafeFilenameReplacement() {
+    const configured_replacement = config_api.getConfigItem('ytdl_invalid_filename_replacement');
+    const replacement = configured_replacement === undefined || configured_replacement === null ? '_' : String(configured_replacement);
+    return replacement.replace(/[\\/\0]/g, '');
+}
+
+function getUniqueChars(chars = '') {
+    const unique_chars = [];
+    for (const char of chars) {
+        if (!unique_chars.includes(char)) unique_chars.push(char);
+    }
+    return unique_chars;
+}
+
+exports.sanitizePathSegment = (segment, fallback = 'file') => {
+    const replacement = getSafeFilenameReplacement();
+    const configured_invalid_chars = config_api.getConfigItem('ytdl_invalid_filename_chars');
+    const invalid_chars = ['\\', '/', '\0'];
+
+    if (config_api.getConfigItem('ytdl_replace_invalid_filename_chars')) {
+        invalid_chars.push(...(typeof configured_invalid_chars === 'string' && configured_invalid_chars.length > 0 ? configured_invalid_chars : DEFAULT_INVALID_FILENAME_CHARS));
+    }
+
+    let sanitized_segment = segment === undefined || segment === null ? '' : String(segment);
+    sanitized_segment = sanitized_segment.trim();
+
+    for (const char of getUniqueChars(invalid_chars.join(''))) {
+        sanitized_segment = sanitized_segment.split(char).join(replacement);
+    }
+
+    sanitized_segment = sanitized_segment.replace(/[\r\n\t]/g, ' ').replace(/\s+/g, ' ').trim();
+    if (!sanitized_segment || sanitized_segment === '.' || sanitized_segment === '..') {
+        return fallback || 'file';
+    }
+    return sanitized_segment;
+}
+
+exports.getSubscriptionPathName = (sub = {}) => {
+    const fallback = sub && sub.id ? String(sub.id) : 'subscription';
+    return exports.sanitizePathSegment(sub && sub.name, fallback);
+}
 
 // replaces .webm with appropriate extension
 exports.getTrueFileName = (unfixed_path, type, force_ext = null) => {
@@ -618,13 +661,13 @@ exports.getArchiveFolder = (type, user_uid = null, sub = null) => {
 
     if (user_uid) {
         if (sub) {
-            return path.join(usersFolderPath, user_uid, 'subscriptions', 'archives', sub.name);
+            return path.join(usersFolderPath, user_uid, 'subscriptions', 'archives', exports.getSubscriptionPathName(sub));
         } else {
             return path.join(usersFolderPath, user_uid, type, 'archives');
         }
     } else {
         if (sub) {
-            return path.join(subsFolderPath, 'archives', sub.name);
+            return path.join(subsFolderPath, 'archives', exports.getSubscriptionPathName(sub));
         } else {
             return path.join('appdata', 'archives');
         }


### PR DESCRIPTION
## Summary
- add a shared subscription path segment sanitizer that respects the configured invalid filename replacement
- use the normalized subscription folder for backup metadata, subscription downloads, archive paths, and filesystem import scans
- cover playlist names with configured invalid characters and path separators so `subscription_backup.json` stays with the subscription folder

Closes #165

## Update impact
Most users should not have trouble after updating. This does not change subscription names, database IDs, or existing file records. It only changes future filesystem path selection for subscription names that include path separators or characters configured for filename replacement.

For subscriptions already affected by this bug, the old incorrectly split/extra directory may remain on disk. Existing downloaded files stay usable through their stored database paths, but a manual cleanup/move may be needed if someone rebuilds the DB purely from filesystem folders.

## Tests
- `node --check backend/db.js && node --check backend/subscriptions.js && node --check backend/utils.js && node --check backend/test/subscriptions.test.js`
- `npm run lint`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npm run test:headless`
- `npx ng build --configuration production`
- `npx mocha test/subscriptions.test.js --exit -s 1000`
- `npm test` in `backend/`
