### PR TITLE
feat(duplicates): add oldest removal choice

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1497,6 +1497,14 @@ app.post('/api/removeNewestDuplicates', optionalJwt, async function (req, res) {
     res.send(result);
 });
 
+app.post('/api/removeDuplicates', optionalJwt, async function (req, res) {
+    const duplicate_key = req.body.duplicate_key;
+    const removal_mode = req.body.removal_mode;
+    const user_uid = req.isAuthenticated() ? req.user.uid : null;
+    const result = await files_api.removeDuplicates(duplicate_key, removal_mode, user_uid);
+    res.send(result);
+});
+
 app.post('/api/updateFile', optionalJwt, async function (req, res) {
     const uid = req.body.uid;
     const change_obj = req.body.change_obj;

--- a/backend/files.js
+++ b/backend/files.js
@@ -545,11 +545,16 @@ async function ensureArchiveExistsForFile(file_obj = null) {
     }
 }
 
-exports.removeNewestDuplicates = async (duplicate_key, user_uid = null) => {
+function normalizeDuplicateRemovalMode(removal_mode = 'newest') {
+    return removal_mode === 'oldest' ? 'oldest' : 'newest';
+}
+
+exports.removeDuplicates = async (duplicate_key, removal_mode = 'newest', user_uid = null) => {
     const normalized_duplicate_key = normalizeSourceValue(duplicate_key);
     if (!normalized_duplicate_key) {
         return {success: false, removed_uids: []};
     }
+    const normalized_removal_mode = normalizeDuplicateRemovalMode(removal_mode);
 
     const filter_obj = {duplicate_key: normalized_duplicate_key};
     if (shouldRestrictToUser(user_uid)) filter_obj['user_uid'] = user_uid;
@@ -559,8 +564,8 @@ exports.removeNewestDuplicates = async (duplicate_key, user_uid = null) => {
         return {success: true, removed_uids: []};
     }
 
-    const kept_file = duplicate_files[0];
-    const files_to_remove = duplicate_files.slice(1);
+    const kept_file = normalized_removal_mode === 'oldest' ? duplicate_files[duplicate_files.length - 1] : duplicate_files[0];
+    const files_to_remove = normalized_removal_mode === 'oldest' ? duplicate_files.slice(0, duplicate_files.length - 1) : duplicate_files.slice(1);
     const removed_uids = [];
 
     for (const file_obj of files_to_remove) {
@@ -573,6 +578,14 @@ exports.removeNewestDuplicates = async (duplicate_key, user_uid = null) => {
         success: removed_uids.length === files_to_remove.length,
         removed_uids: removed_uids
     };
+}
+
+exports.removeNewestDuplicates = async (duplicate_key, user_uid = null) => {
+    return exports.removeDuplicates(duplicate_key, 'newest', user_uid);
+}
+
+exports.removeOldestDuplicates = async (duplicate_key, user_uid = null) => {
+    return exports.removeDuplicates(duplicate_key, 'oldest', user_uid);
 }
 
 exports.findExistingDuplicateByInfo = async (info_obj = null, type = 'video', user_uid = null) => {

--- a/backend/test/files.test.js
+++ b/backend/test/files.test.js
@@ -191,6 +191,50 @@ describe('Files', function() {
         }
     });
 
+    it('removeDuplicates removes newest or oldest duplicate files based on mode', async function() {
+        const original_get_records = db_api.getRecords;
+        const original_delete_file = files_api.deleteFile;
+        const duplicate_files = [
+            {uid: 'oldest', duplicate_key: 'duplicate-key', registered: 100, isAudio: false},
+            {uid: 'middle', duplicate_key: 'duplicate-key', registered: 200, isAudio: false},
+            {uid: 'newest', duplicate_key: 'duplicate-key', registered: 300, isAudio: false}
+        ];
+        const get_records_calls = [];
+        let deleted_uids = [];
+
+        try {
+            db_api.getRecords = async (table, filter_obj, return_count, sort) => {
+                get_records_calls.push({table, filter_obj, return_count, sort});
+                return duplicate_files.slice();
+            };
+            files_api.deleteFile = async (uid, blacklistMode, user_uid) => {
+                assert.strictEqual(blacklistMode, false);
+                assert.strictEqual(user_uid, 'user-1');
+                deleted_uids.push(uid);
+                return true;
+            };
+
+            const newest_output = await files_api.removeDuplicates('duplicate-key', 'newest', 'user-1');
+
+            assert.deepStrictEqual(newest_output, {success: true, removed_uids: ['middle', 'newest']});
+            assert.deepStrictEqual(deleted_uids, ['middle', 'newest']);
+
+            deleted_uids = [];
+            const oldest_output = await files_api.removeDuplicates('duplicate-key', 'oldest', 'user-1');
+
+            assert.deepStrictEqual(oldest_output, {success: true, removed_uids: ['oldest', 'middle']});
+            assert.deepStrictEqual(deleted_uids, ['oldest', 'middle']);
+            assert.strictEqual(get_records_calls.length, 2);
+            assert.strictEqual(get_records_calls[0].table, 'files');
+            assert.strictEqual(get_records_calls[0].filter_obj.duplicate_key, 'duplicate-key');
+            assert.strictEqual(get_records_calls[0].return_count, false);
+            assert.deepStrictEqual(get_records_calls[0].sort, {by: 'registered', order: 1});
+        } finally {
+            db_api.getRecords = original_get_records;
+            files_api.deleteFile = original_delete_file;
+        }
+    });
+
     it('uses regex title filtering for PostgreSQL-style text search', async function() {
         const original_get_records = db_api.getRecords;
         const original_is_using_local_db = db_api.isUsingLocalDB;

--- a/src/app/components/duplicates/duplicates.component.html
+++ b/src/app/components/duplicates/duplicates.component.html
@@ -41,9 +41,9 @@
               <button
                 mat-icon-button
                 [disabled]="removing_duplicate_key === element.duplicate_key"
-                matTooltip="Remove newest duplicates"
-                i18n-matTooltip="Remove newest duplicates tooltip"
-                (click)="removeNewestDuplicates(element)">
+                matTooltip="Remove duplicates"
+                i18n-matTooltip="Remove duplicates tooltip"
+                (click)="openRemoveDuplicatesDialog(element)">
                 <mat-icon>cleaning_services</mat-icon>
               </button>
             </span>

--- a/src/app/components/duplicates/duplicates.component.ts
+++ b/src/app/components/duplicates/duplicates.component.ts
@@ -6,7 +6,7 @@ import { MatSort } from '@angular/material/sort';
 import { MatDialog } from '@angular/material/dialog';
 import { filter, take } from 'rxjs/operators';
 import { ConfirmDialogComponent } from 'app/dialogs/confirm-dialog/confirm-dialog.component';
-import { DuplicateGroup, PostsService } from 'app/posts.services';
+import { DuplicateGroup, DuplicateRemovalMode, PostsService } from 'app/posts.services';
 
 @Component({
     selector: 'app-duplicates',
@@ -119,34 +119,40 @@ export class DuplicatesComponent implements OnInit, OnDestroy {
     return group && group.isAudio ? $localize`Audio` : $localize`Video`;
   }
 
-  removeNewestDuplicates(group: DuplicateGroup): void {
+  private isRemovalMode(value: string): value is DuplicateRemovalMode {
+    return value === 'newest' || value === 'oldest';
+  }
+
+  openRemoveDuplicatesDialog(group: DuplicateGroup): void {
     if (!group || !group.duplicate_key || this.removing_duplicate_key) return;
 
     const dialog_ref = this.dialog.open(ConfirmDialogComponent, {
       data: {
-        dialogTitle: $localize`Remove newest duplicates`,
-        dialogText: $localize`This will remove ${group.duplicate_count}:duplicate count: duplicate download(s) for ${this.getGroupTitle(group)}:duplicate title:.`,
-        submitText: $localize`Remove`,
-        warnSubmitColor: true
+        dialogTitle: $localize`Remove duplicates`,
+        dialogText: $localize`This will keep one copy and remove ${group.duplicate_count}:duplicate count: matching download(s) for ${this.getGroupTitle(group)}:duplicate title:. Choose whether to remove the newest downloads or the oldest downloads.`,
+        submitActions: [
+          {text: $localize`Remove Newest`, value: 'newest', warnSubmitColor: true},
+          {text: $localize`Remove Oldest`, value: 'oldest', warnSubmitColor: true}
+        ]
       }
     });
 
-    dialog_ref.afterClosed().subscribe(confirmed => {
-      if (!confirmed) return;
+    dialog_ref.afterClosed().subscribe(removal_mode => {
+      if (!this.isRemovalMode(removal_mode)) return;
 
       this.removing_duplicate_key = group.duplicate_key;
-      this.postsService.removeNewestDuplicates(group.duplicate_key).subscribe(res => {
+      this.postsService.removeDuplicates(group.duplicate_key, removal_mode).subscribe(res => {
         this.removing_duplicate_key = null;
         if (res && res.success) {
-          this.postsService.openSnackBar($localize`Newest duplicates removed.`);
+          this.postsService.openSnackBar(removal_mode === 'oldest' ? $localize`Oldest duplicates removed.` : $localize`Newest duplicates removed.`);
           this.postsService.files_changed.next(true);
           this.getDuplicates();
         } else {
-          this.postsService.openSnackBar($localize`Failed to remove newest duplicates.`);
+          this.postsService.openSnackBar(removal_mode === 'oldest' ? $localize`Failed to remove oldest duplicates.` : $localize`Failed to remove newest duplicates.`);
         }
       }, () => {
         this.removing_duplicate_key = null;
-        this.postsService.openSnackBar($localize`Failed to remove newest duplicates.`);
+        this.postsService.openSnackBar(removal_mode === 'oldest' ? $localize`Failed to remove oldest duplicates.` : $localize`Failed to remove newest duplicates.`);
       });
     });
   }

--- a/src/app/dialogs/confirm-dialog/confirm-dialog.component.html
+++ b/src/app/dialogs/confirm-dialog/confirm-dialog.component.html
@@ -18,7 +18,13 @@
 </mat-dialog-content>
 <mat-dialog-actions>
   <!-- The mat-dialog-close directive optionally accepts a value as a result for the dialog. -->
-  <button [disabled]="dialogType === 'selection_list' && selected_items.length === 0" [color]="warnSubmitColor ? 'warn' : 'primary'" mat-flat-button type="submit" (click)="confirmClicked()">{{submitText}}</button>
+  @if (submitActions && submitActions.length > 0) {
+    @for (submitAction of submitActions; track submitAction.value) {
+      <button [disabled]="dialogType === 'selection_list' && selected_items.length === 0" [color]="submitAction.warnSubmitColor ? 'warn' : 'primary'" mat-flat-button type="submit" (click)="confirmClicked(submitAction.value)">{{submitAction.text}}</button>
+    }
+  } @else {
+    <button [disabled]="dialogType === 'selection_list' && selected_items.length === 0" [color]="warnSubmitColor ? 'warn' : 'primary'" mat-flat-button type="submit" (click)="confirmClicked()">{{submitText}}</button>
+  }
   @if (submitClicked) {
     <div class="mat-spinner">
       <mat-spinner [diameter]="25"></mat-spinner>

--- a/src/app/dialogs/confirm-dialog/confirm-dialog.component.ts
+++ b/src/app/dialogs/confirm-dialog/confirm-dialog.component.ts
@@ -1,6 +1,12 @@
 import { Component, OnInit, Inject, EventEmitter } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 
+interface ConfirmDialogAction {
+  text: string;
+  value: boolean | string;
+  warnSubmitColor?: boolean;
+}
+
 @Component({
     selector: 'app-confirm-dialog',
     templateUrl: './confirm-dialog.component.html',
@@ -14,12 +20,13 @@ export class ConfirmDialogComponent implements OnInit {
   dialogText = 'Would you like to confirm?';
   submitText = 'Yes'
   cancelText = $localize`Cancel`;
+  submitActions: ConfirmDialogAction[] = [];
   list: { key: string, title: string }[] = [];
   selected_items = [];
   submitClicked = false;
   closeOnSubmit = true;
 
-  doneEmitter: EventEmitter<boolean> = null;
+  doneEmitter: EventEmitter<boolean | string> = null;
   onlyEmitOnDone = false;
 
   warnSubmitColor = false;
@@ -30,6 +37,7 @@ export class ConfirmDialogComponent implements OnInit {
     if (this.data.dialogText      !== undefined) { this.dialogText      = this.data.dialogText }
     if (this.data.list            !== undefined) { this.list            = this.data.list }
     if (this.data.submitText      !== undefined) { this.submitText      = this.data.submitText }
+    if (this.data.submitActions   !== undefined) { this.submitActions   = this.data.submitActions }
     if (this.data.cancelText      !== undefined) { this.cancelText      = this.data.cancelText }
     if (this.data.warnSubmitColor !== undefined) { this.warnSubmitColor = this.data.warnSubmitColor }
     if (this.data.warnSubmitColor !== undefined) { this.warnSubmitColor = this.data.warnSubmitColor }
@@ -42,12 +50,12 @@ export class ConfirmDialogComponent implements OnInit {
     }
   }
 
-  confirmClicked(): void {
+  confirmClicked(value: boolean | string = true): void {
     if (this.onlyEmitOnDone) {
-      this.doneEmitter.emit(true);
+      this.doneEmitter.emit(value);
       if (this.closeOnSubmit) this.submitClicked = true;
     } else {
-      if (this.closeOnSubmit) this.dialogRef.close(true);
+      if (this.closeOnSubmit) this.dialogRef.close(value);
     }
   }
 

--- a/src/app/posts.services.ts
+++ b/src/app/posts.services.ts
@@ -142,7 +142,9 @@ export interface GetDuplicatesResponse {
     duplicates: DuplicateGroup[];
 }
 
-export interface RemoveNewestDuplicatesResponse {
+export type DuplicateRemovalMode = 'newest' | 'oldest';
+
+export interface RemoveDuplicatesResponse {
     success: boolean;
     removed_uids: string[];
 }
@@ -459,8 +461,12 @@ export class PostsService {
         return this.http.post<GetDuplicatesResponse>(this.path + 'getDuplicates', {}, this.httpOptions);
     }
 
+    removeDuplicates(duplicate_key: string, removal_mode: DuplicateRemovalMode) {
+        return this.http.post<RemoveDuplicatesResponse>(this.path + 'removeDuplicates', {duplicate_key: duplicate_key, removal_mode: removal_mode}, this.httpOptions);
+    }
+
     removeNewestDuplicates(duplicate_key: string) {
-        return this.http.post<RemoveNewestDuplicatesResponse>(this.path + 'removeNewestDuplicates', {duplicate_key: duplicate_key}, this.httpOptions);
+        return this.removeDuplicates(duplicate_key, 'newest');
     }
 
     updateFile(uid: string, change_obj: object) {


### PR DESCRIPTION
## Summary
- Add backend duplicate removal modes for newest and oldest cleanup.
- Update the duplicates dialog to offer Remove Newest and Remove Oldest choices with clearer wording.
- Add backend coverage for both removal modes.

Closes #167

## Tests
- npm run lint
- npx tsc -p src/tsconfig.app.json --noEmit
- npx tsc -p src/tsconfig.spec.json --noEmit
- CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npm run test:headless
- npx ng build --configuration production
- node --check backend/app.js
- node --check backend/files.js
- node --check backend/test/files.test.js
- npm --prefix backend test -- --grep removeDuplicates