### PR TITLE
feat(subscriptions): skip join-only videos

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -231,7 +231,8 @@ const DEFAULT_CONFIG = {
         "max_concurrent_downloads": 5,
         "min_sleep_between_downloads": 0,
         "playlist_chunk_size": 20,
-        "download_rate_limit": ""
+        "download_rate_limit": "",
+        "skip_join_only_videos": false
       },
       "Extra": {
         "title_top": "ytdl-material",

--- a/backend/consts.js
+++ b/backend/consts.js
@@ -78,6 +78,10 @@ exports.CONFIG_ITEMS = {
         'key': 'ytdl_download_rate_limit',
         'path': 'YtdlMaterial.Downloader.download_rate_limit'
     },
+    'ytdl_skip_join_only_videos': {
+        'key': 'ytdl_skip_join_only_videos',
+        'path': 'YtdlMaterial.Downloader.skip_join_only_videos'
+    },
 
     // Extra
     'ytdl_title_top': {

--- a/backend/downloader.js
+++ b/backend/downloader.js
@@ -2145,16 +2145,32 @@ exports.getVideoInfoByURL = async (url, args = [], download_uid = null, options 
     logger.debug(`Callback resolved. parsed_output length: ${parsed_output ? parsed_output.length : 'null'}`);
     if (!parsed_output || parsed_output.length === 0) {
         const error_details = describeInfoLookupError(err, downloader_fork);
+        const is_join_only = error_details.includes('Join this channel to get access to members-only content');
+        const error_type = is_join_only ? 'join_only' : 'info_retrieve_failed';
         const error_message = `Error while retrieving info on video with URL ${url} with the following message: ${error_details}`;
         logger.error(error_message);
         if (download_uid) {
-            await handleDownloadError(download_uid, error_message, 'info_retrieve_failed');
+            await handleDownloadError(download_uid, error_message, error_type);
+            if (is_join_only && config_api.getConfigItem('ytdl_skip_join_only_videos')) {
+                await archiveJoinOnlyVideo(download_uid, error_details);
+            }
         }
         return null;
     }
 
     logger.debug(`getVideoInfoByURL returning successfully for URL: ${url}`);
     return parsed_output;
+}
+
+async function archiveJoinOnlyVideo(download_uid, error_details) {
+    const download = await db_api.getRecord('download_queue', {uid: download_uid});
+    if (!download || !download['sub_id']) return;
+    const match = error_details.match(/\[([^\]]+)\]\s+([a-zA-Z0-9_-]+):\s+Join this channel/);
+    if (!match) return;
+    const extractor = match[1];
+    const video_id = match[2];
+    await archive_api.addToArchive(extractor, video_id, download['type'], null, download['user_uid'], download['sub_id']);
+    logger.info(`Archived join-only video ${extractor}:${video_id} for subscription ${download['sub_id']}.`);
 }
 
 function filterArgs(args, isAudio) {

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -187,8 +187,11 @@
             <div class="col-12 mt-2">
               <mat-checkbox color="accent" [(ngModel)]="new_config['Downloader']['include_thumbnail']"><ng-container i18n="Include thumbnail setting">Include thumbnail</ng-container></mat-checkbox>
             </div>
-            <div class="col-12 mt-2 mb-2">
+            <div class="col-12 mt-2">
               <mat-checkbox color="accent" [(ngModel)]="new_config['Downloader']['include_metadata']"><ng-container i18n="Include metadata setting">Include metadata</ng-container></mat-checkbox>
+            </div>
+            <div class="col-12 mt-2 mb-2">
+              <mat-checkbox color="accent" [(ngModel)]="new_config['Downloader']['skip_join_only_videos']"><ng-container i18n="Skip join-only videos setting">Skip join-only videos</ng-container></mat-checkbox>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Closes #175

## Summary

- Adds a **Skip join-only videos** checkbox to **Settings → Downloader** (below _Include metadata_), defaulting to off
- When enabled, any subscription video whose info-retrieval fails with yt-dlp's _"Join this channel to get access to members-only content"_ message is assigned the new `join_only` error type and immediately added to the archive so it is never retried on future subscription runs
- When the setting is off, the video still appears as a failed download in the queue using the existing `info_retrieve_failed` error type

## Test plan

- [ ] **Skip join-only videos** checkbox appears in Settings → Downloader, below _Include metadata_
- [ ] Setting **off**: join-only video produces a failed download with `error_type = 'info_retrieve_failed'`, no archive entry created
- [ ] Setting **on**: join-only video produces `error_type = 'join_only'` and an archive entry is created — video is skipped on the next subscription refresh
- [ ] Non-join-only info-retrieval failures continue to use `info_retrieve_failed` regardless of the setting