### PR TITLE
feat(downloader): delete orphan videos

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1361,6 +1361,12 @@ app.post('/api/killAllDownloads', optionalJwt, async function(req, res) {
     res.send(result_obj);
 });
 
+app.post('/api/deleteOrphanFiles', optionalJwt, async function(req, res) {
+    const user_uid = req.isAuthenticated() ? req.user.uid : null;
+    const result = await files_api.deleteOrphanFiles(user_uid);
+    res.send(result);
+});
+
 app.post('/api/generateArgs', optionalJwt, async function(req, res) {
     const url = req.body.url;
     const type = req.body.type;

--- a/backend/files.js
+++ b/backend/files.js
@@ -991,6 +991,22 @@ exports.deleteFilesInBatches = async (uids = [], blacklistMode = false, user_uid
     return {deleted_count, failed_count};
 }
 
+exports.deleteOrphanFiles = async (user_uid = null) => {
+    const filter_obj = {};
+    if (shouldRestrictToUser(user_uid)) filter_obj['user_uid'] = user_uid;
+    const all_files = await db_api.getRecords('files', filter_obj);
+
+    const orphan_uids = [];
+    for (const file_obj of all_files) {
+        if (!file_obj.path) continue;
+        const exists = await fs.pathExists(path.join(__dirname, file_obj.path));
+        if (!exists) orphan_uids.push(file_obj.uid);
+    }
+
+    if (orphan_uids.length === 0) return {deleted_count: 0, failed_count: 0};
+    return exports.deleteFilesInBatches(orphan_uids, false, user_uid);
+}
+
 // Video ID is basically just the file name without the base path and file extension - this method helps us get away from that
 exports.getVideoUIDByID = async (file_id, uuid = null) => {
     const filter_obj = {id: file_id};

--- a/src/app/posts.services.ts
+++ b/src/app/posts.services.ts
@@ -405,6 +405,10 @@ export class PostsService {
         return this.http.post<SuccessObject>(this.path + 'killAllDownloads', {}, this.httpOptions);
     }
 
+    deleteOrphanFiles() {
+        return this.http.post<{deleted_count: number, failed_count: number}>(this.path + 'deleteOrphanFiles', {}, this.httpOptions);
+    }
+
     restartServer() {
         return this.http.post<SuccessObject>(this.path + 'restartServer', {}, this.httpOptions);
     }

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -237,6 +237,7 @@
           <div class="row">
             <div class="col-12 mt-3">
               <button (click)="killAllDownloads()" mat-stroked-button color="warn"><ng-container i18n="Kill all downloads button">Kill all downloads</ng-container></button>
+              <button class="ml-2" (click)="deleteOrphanFiles()" mat-stroked-button color="warn"><ng-container i18n="Delete orphan videos button">Delete orphan videos</ng-container></button>
             </div>
           </div>
         </div>

--- a/src/app/settings/settings.component.spec.ts
+++ b/src/app/settings/settings.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { EventEmitter } from '@angular/core';
+import { of, throwError } from 'rxjs';
 
 import { SettingsComponent } from './settings.component';
 
@@ -21,5 +23,98 @@ describe('SettingsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+});
+
+describe('SettingsComponent.deleteOrphanFiles', () => {
+  let component: SettingsComponent;
+  let posts_service_mock: any;
+  let dialog_mock: any;
+  let done_emitter: EventEmitter<boolean>;
+
+  beforeEach(() => {
+    done_emitter = new EventEmitter<boolean>();
+
+    posts_service_mock = {
+      initialized: false,
+      service_initialized: of(false),
+      config: null,
+      openSnackBar: jasmine.createSpy('openSnackBar'),
+      deleteOrphanFiles: jasmine.createSpy('deleteOrphanFiles').and.returnValue(
+        of({deleted_count: 3, failed_count: 0})
+      )
+    };
+
+    dialog_mock = {
+      open: jasmine.createSpy('open').and.returnValue({
+        close: jasmine.createSpy('close')
+      })
+    };
+
+    const snack_bar_mock: any = {open: () => {}};
+    const sanitizer_mock: any = {};
+    const router_mock: any = {navigate: () => {}};
+    const route_mock: any = {snapshot: {paramMap: {get: () => null}}};
+
+    component = new SettingsComponent(
+      posts_service_mock,
+      snack_bar_mock,
+      sanitizer_mock,
+      dialog_mock,
+      router_mock,
+      route_mock
+    );
+  });
+
+  it('opens a confirm dialog', () => {
+    component.deleteOrphanFiles();
+    expect(dialog_mock.open).toHaveBeenCalled();
+  });
+
+  it('calls deleteOrphanFiles on the service when confirmed', () => {
+    component.deleteOrphanFiles();
+    const dialog_data = dialog_mock.open.calls.mostRecent().args[1].data;
+    dialog_data.doneEmitter.emit(true);
+    expect(posts_service_mock.deleteOrphanFiles).toHaveBeenCalled();
+  });
+
+  it('does not call the service when the dialog is cancelled', () => {
+    component.deleteOrphanFiles();
+    const dialog_data = dialog_mock.open.calls.mostRecent().args[1].data;
+    dialog_data.doneEmitter.emit(false);
+    expect(posts_service_mock.deleteOrphanFiles).not.toHaveBeenCalled();
+  });
+
+  it('shows a snackbar with the deleted count on success', () => {
+    posts_service_mock.deleteOrphanFiles.and.returnValue(
+      of({deleted_count: 5, failed_count: 0})
+    );
+    component.deleteOrphanFiles();
+    const dialog_data = dialog_mock.open.calls.mostRecent().args[1].data;
+    dialog_data.doneEmitter.emit(true);
+    expect(posts_service_mock.openSnackBar).toHaveBeenCalled();
+    const message: string = posts_service_mock.openSnackBar.calls.mostRecent().args[0];
+    expect(message).toContain('5');
+  });
+
+  it('includes the failed count in the snackbar when some deletions failed', () => {
+    posts_service_mock.deleteOrphanFiles.and.returnValue(
+      of({deleted_count: 2, failed_count: 1})
+    );
+    component.deleteOrphanFiles();
+    const dialog_data = dialog_mock.open.calls.mostRecent().args[1].data;
+    dialog_data.doneEmitter.emit(true);
+    const message: string = posts_service_mock.openSnackBar.calls.mostRecent().args[0];
+    expect(message).toContain('1');
+  });
+
+  it('shows an error snackbar when the API call fails', () => {
+    posts_service_mock.deleteOrphanFiles.and.returnValue(throwError(() => new Error('server error')));
+    component.deleteOrphanFiles();
+    const dialog_data = dialog_mock.open.calls.mostRecent().args[1].data;
+    dialog_data.doneEmitter.emit(true);
+    expect(posts_service_mock.openSnackBar).toHaveBeenCalled();
+    const message: string = posts_service_mock.openSnackBar.calls.mostRecent().args[0];
+    expect(message.toLowerCase()).toContain('failed');
   });
 });

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -342,6 +342,30 @@ export class SettingsComponent implements OnInit {
     });
   }
 
+  deleteOrphanFiles(): void {
+    const done = new EventEmitter<boolean>();
+    const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+      data: {
+        dialogTitle: 'Delete orphan videos',
+        dialogText: 'Are you sure you want to delete all orphan videos? These are videos that exist in your download directories but are not tracked in the database. This cannot be undone.',
+        submitText: 'Delete orphans',
+        doneEmitter: done,
+        warnSubmitColor: true
+      }
+    });
+    done.subscribe(confirmed => {
+      if (confirmed) {
+        this.postsService.deleteOrphanFiles().subscribe(res => {
+          dialogRef.close();
+          this.postsService.openSnackBar($localize`Deleted ${res.deleted_count} orphan(s)${res.failed_count ? ', ' + res.failed_count + ' failed' : ''}.`);
+        }, () => {
+          dialogRef.close();
+          this.postsService.openSnackBar($localize`Failed to delete orphan videos! Check logs for details.`);
+        });
+      }
+    });
+  }
+
   restartServer(): void {
     this.postsService.restartServer().subscribe(() => {
       this.postsService.openSnackBar($localize`Restarting!`);


### PR DESCRIPTION
Closes #171

## Summary

- Adds a **Delete orphan videos** button in **Settings → Downloader**, next to _Kill all downloads_
- A confirm dialog warns before proceeding
- The backend scans all file records in the database, checks each `path` on disk, and deletes any record whose file is missing — these are orphans (files tracked in the DB with no corresponding file on disk)
- Uses the existing `deleteFilesInBatches` path so all cleanup (thumbnails, metadata JSON, sidecar subtitles, archive entries) is handled consistently
- Scoped to the authenticated user in multi-user mode; scans all files when unauthenticated

## Test plan

- [ ] **Delete orphan videos** button appears in Settings → Downloader, to the right of _Kill all downloads_
- [ ] Confirm dialog appears before any deletion
- [ ] Cancelling the dialog makes no changes
- [ ] With no orphans present, snackbar reports `Deleted 0 orphan(s)`
- [ ] With orphaned DB records (file deleted from disk but still in DB), those records are removed and the snackbar reports the correct count
- [ ] Associated thumbnails, `.info.json`, and subtitle sidecars are also removed for each orphan
- [ ] In multi-user mode, each user only affects their own files

## Tests added

6 new unit tests in `settings.component.spec.ts` covering the `deleteOrphanFiles` method: dialog opens, service called on confirm, service skipped on cancel, snackbar shows deleted count, snackbar includes failed count when non-zero, error path shows failure message.