### PR TITLE
fix(downloads): only poll unfinished downloads for the active panel

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -2672,6 +2672,8 @@ app.post('/api/downloads', optionalJwt, async (req, res) => {
             return;
         }
         filter_obj['uid'] = {$in: uids};
+    } else {
+        filter_obj['finished'] = false;
     }
     const downloads = await db_api.getRecords('download_queue', filter_obj);
 

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -149,51 +149,27 @@ describe('AppComponent', () => {
     jasmine.clock().uninstall();
   });
 
-  it('emits file refresh when a successful completion is detected after reload polling', () => {
+  it('emits file refresh when a download disappears from the unfinished queue', () => {
     const files_changed_spy = spyOn(files_changed_subject, 'next').and.callThrough();
     (component as any).active_downloads_initialized = true;
-    (component as any).previous_download_states = new Map<string, {finished: boolean, errored: boolean}>([
-      ['download-1', {finished: false, errored: false}]
+    (component as any).previous_download_states = new Map([
+      ['download-1', {finished: false, errored: false, is_playlist: false}]
     ]);
-    posts_service_mock.getCurrentDownloads = () => of({
-      downloads: [
-        createDownload({
-          uid: 'download-1',
-          running: false,
-          finished: true,
-          finished_step: true,
-          percent_complete: 100,
-          file_uids: ['file-1'],
-          container: {uid: 'file-1'}
-        } as any)
-      ]
-    });
+    posts_service_mock.getCurrentDownloads = () => of({downloads: []});
 
     (component as any).refreshActiveDownloads();
 
     expect(files_changed_spy).toHaveBeenCalledWith(true);
   });
 
-  it('emits playlist refresh when a playlist completion is detected after reload polling', () => {
+  it('emits playlist refresh when a playlist download disappears from the unfinished queue', () => {
     const files_changed_spy = spyOn(files_changed_subject, 'next').and.callThrough();
     const playlists_changed_spy = spyOn(playlists_changed_subject, 'next').and.callThrough();
     (component as any).active_downloads_initialized = true;
-    (component as any).previous_download_states = new Map<string, {finished: boolean, errored: boolean}>([
-      ['download-2', {finished: false, errored: false}]
+    (component as any).previous_download_states = new Map([
+      ['download-2', {finished: false, errored: false, is_playlist: true}]
     ]);
-    posts_service_mock.getCurrentDownloads = () => of({
-      downloads: [
-        createDownload({
-          uid: 'download-2',
-          running: false,
-          finished: true,
-          finished_step: true,
-          percent_complete: 100,
-          file_uids: ['file-1', 'file-2'],
-          container: {id: 'playlist-1'}
-        } as any)
-      ]
-    });
+    posts_service_mock.getCurrentDownloads = () => of({downloads: []});
 
     (component as any).refreshActiveDownloads();
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -71,7 +71,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
   private active_downloads_auto_close_timeout_id: number = null;
   private active_downloads_completion_badge_timeout_id: number = null;
   private active_download_uids = new Set<string>();
-  private previous_download_states = new Map<string, {finished: boolean, errored: boolean}>();
+  private previous_download_states = new Map<string, {finished: boolean, errored: boolean, is_playlist: boolean}>();
   private active_downloads_initialized = false;
   private active_downloads_auto_opened = false;
   private active_downloads_opened_manually = false;
@@ -442,7 +442,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
         .filter(download => this.isActiveDownload(download))
         .sort((download1, download2) => Number(download2.timestamp_start) - Number(download1.timestamp_start));
 
-      this.handleCompletedDownloads(completion_summary.completed_downloads);
+      this.handleCompletedDownloads(completion_summary.completed_downloads, completion_summary.playlist_completion_detected);
       this.setActiveDownloads(active_downloads, completion_summary.successful_completion_detected);
       const next_poll_delay = active_downloads.length > 0
         ? this.ACTIVE_DOWNLOADS_POLL_INTERVAL_MS
@@ -572,11 +572,11 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
-  private handleCompletedDownloads(completed_downloads: Download[]): void {
+  private handleCompletedDownloads(completed_downloads: Download[], playlist_completed = false): void {
     if (!Array.isArray(completed_downloads) || completed_downloads.length === 0) return;
 
     this.postsService.files_changed.next(true);
-    if (completed_downloads.some(download => this.isPlaylistCompletion(download))) {
+    if (playlist_completed) {
       this.postsService.playlists_changed.next(true);
     }
   }
@@ -589,30 +589,35 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
     return !!(container && typeof container === 'object' && container['id']);
   }
 
-  private detectSuccessfulCompletion(downloads: Download[]): {successful_completion_detected: boolean, completed_downloads: Download[]} {
-    const current_download_states = new Map<string, {finished: boolean, errored: boolean}>();
+  private detectSuccessfulCompletion(downloads: Download[]): {successful_completion_detected: boolean, completed_downloads: Download[], playlist_completion_detected: boolean} {
+    const current_download_states = new Map<string, {finished: boolean, errored: boolean, is_playlist: boolean}>();
     const completed_downloads: Download[] = [];
     let successful_completion_detected = false;
+    let playlist_completion_detected = false;
 
+    const current_uids = new Set<string>();
     for (const download of downloads) {
       if (!download || !download.uid) continue;
+      current_uids.add(download.uid);
+      current_download_states.set(download.uid, {
+        finished: !!download.finished,
+        errored: !!download.error,
+        is_playlist: this.isPlaylistCompletion(download)
+      });
+    }
 
-      const finished = !!download.finished;
-      const errored = !!download.error;
-      const previous_state = this.previous_download_states.get(download.uid);
-      if (this.active_downloads_initialized && finished && !errored && previous_state && !previous_state.finished) {
-        successful_completion_detected = true;
-        completed_downloads.push(download);
+    if (this.active_downloads_initialized) {
+      for (const [uid, prev_state] of this.previous_download_states) {
+        if (!prev_state.finished && !current_uids.has(uid)) {
+          successful_completion_detected = true;
+          if (prev_state.is_playlist) playlist_completion_detected = true;
+          completed_downloads.push({uid} as unknown as Download);
+        }
       }
-
-      current_download_states.set(download.uid, {finished: finished, errored: errored});
     }
 
     this.previous_download_states = current_download_states;
-    return {
-      successful_completion_detected: successful_completion_detected,
-      completed_downloads: completed_downloads
-    };
+    return {successful_completion_detected, completed_downloads, playlist_completion_detected};
   }
 
   private refreshOpenPlaylistProgressDialog(): void {


### PR DESCRIPTION
Closes #172

## Problem

`/api/downloads` returned every record in `download_queue` with no filter. After a large subscription catch-up (hundreds of videos), the panel polled all of them every second, causing the UI to lag.

## Fix

**Backend** — when the active-downloads panel polls `/api/downloads` without a specific UID list, add `finished: false` to the query filter. Only in-flight/queued/paused downloads are returned; completed and errored records (which accumulate indefinitely) are excluded.

**Frontend** — completion detection previously relied on seeing a `finished: true` download transition in the response. Since finished downloads no longer appear, detection now watches for downloads that *disappear* from the unfinished set between polls. The `is_playlist` flag is tracked in `previous_download_states` so playlist completions still trigger a playlist refresh correctly.

## What is preserved

- Active download count and progress display
- Auto-open panel when a new download starts
- Green completion badge when all downloads finish
- `files_changed` / `playlists_changed` refresh signals on completion
- UID-targeted lookups (specific `uids` array in request body) still return any record regardless of `finished` state

## Tests

Updated 2 existing completion-detection tests to match the new "disappeared from set" detection model. All 191 tests pass.