### PR TITLE
fix(deps): override postcss to patched version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13211,9 +13211,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     },
     "flatted": "3.4.2",
     "immutable": "5.1.5",
+    "postcss": "8.5.12",
     "serialize-javascript": "7.0.5",
     "tar": "7.5.11",
     "tmp": "0.2.5",


### PR DESCRIPTION
## Summary
- Add an npm override for postcss 8.5.12 to resolve Dependabot alert 49 / GHSA-qx2v-qp2m-jg93
- Regenerate the root package-lock entry so the Angular build toolchain resolves the patched PostCSS version

## Verification
- npm audit --omit=optional
- npm ls postcss --all
- npm run lint
- npx tsc -p src/tsconfig.app.json --noEmit
- npx tsc -p src/tsconfig.spec.json --noEmit
- CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npm run test:headless
- npx ng build --configuration production

Security alert: https://github.com/voc0der/ytdl-material/security/dependabot/49