### PR TITLE
fix(subscriptions): archive skipped failed downloads

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -2702,8 +2702,18 @@ app.post('/api/clearDownloads', optionalJwt, async (req, res) => {
     const clear_errors = req.body.clear_errors;
     let success = true;
     if (clear_finished) success &= await db_api.removeAllRecords('download_queue', {finished: true, ...scoped_filter, error: null});
-    if (clear_paused)   success &= await db_api.removeAllRecords('download_queue', {paused: true, ...scoped_filter});
-    if (clear_errors)   success &= await db_api.removeAllRecords('download_queue', {error: {$ne: null}, ...scoped_filter});
+    if (clear_paused) {
+        const paused_downloads = await db_api.getRecords('download_queue', {paused: true, ...scoped_filter});
+        for (const paused_download of paused_downloads) {
+            success &= await downloader_api.clearDownload(paused_download['uid']);
+        }
+    }
+    if (clear_errors) {
+        const errored_downloads = await db_api.getRecords('download_queue', {error: {$ne: null}, ...scoped_filter});
+        for (const errored_download of errored_downloads) {
+            success &= await downloader_api.clearDownload(errored_download['uid']);
+        }
+    }
     res.send({success: success});
 });
 

--- a/backend/appdata/default.json
+++ b/backend/appdata/default.json
@@ -19,7 +19,8 @@
       "max_concurrent_downloads": 0,
       "min_sleep_between_downloads": 0,
       "download_rate_limit": "",
-      "playlist_chunk_size": 100
+      "playlist_chunk_size": 100,
+      "skip_join_only_videos": false
     },
     "Extra": {
       "title_top": "ytdl-material",

--- a/backend/downloader.js
+++ b/backend/downloader.js
@@ -34,6 +34,19 @@ const FAST_PROGRESS_SIZE_THRESHOLD_BYTES = 100 * 1024 * 1024;
 const ANSI_ESCAPE_SEQUENCE_REGEX = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
 const DEFAULT_INVALID_FILENAME_CHARS = '\\/:*?"<>|';
 const METADATA_FIELDS_FOR_FILENAME_SANITIZATION = 'title,fulltitle,playlist_title,uploader,channel,series,chapter,album,artist';
+const SKIPPABLE_SUBSCRIPTION_DOWNLOAD_ERROR_TYPES = new Set(['join_only', 'no_output', 'no_downloadable_items']);
+const SKIPPABLE_SUBSCRIPTION_DOWNLOAD_ERROR_TEXT = [
+    'join this channel',
+    'members-only',
+    'member-only',
+    'private video',
+    'this video is unavailable',
+    'video unavailable',
+    'has been removed',
+    'premieres in',
+    'this live event will begin',
+    'no output received for video download'
+];
 let filename_sanitization_non_ytdlp_warned = false;
 let last_download_queue_start_at = 0;
 
@@ -60,6 +73,100 @@ function hasArg(args = [], target_arg = '') {
         if (arg === target_arg || arg.startsWith(`${target_arg}=`)) return true;
     }
     return false;
+}
+
+function normalizeArchiveExtractor(value = null) {
+    if (typeof value !== 'string') return null;
+    const normalized_value = value.trim().toLowerCase();
+    if (!normalized_value) return null;
+    return normalized_value.split(':')[0];
+}
+
+function normalizeArchiveId(value = null) {
+    if (value === null || value === undefined) return null;
+    const normalized_value = String(value).trim();
+    return normalized_value || null;
+}
+
+function extractYouTubeVideoId(url = '') {
+    if (typeof url !== 'string' || url.trim() === '') return null;
+
+    try {
+        const parsed_url = new URL(url);
+        const host = parsed_url.hostname.toLowerCase();
+        if (host === 'youtu.be') {
+            return normalizeArchiveId(parsed_url.pathname.split('/').filter(Boolean)[0]);
+        }
+        if (host.includes('youtube.com')) {
+            const watch_id = normalizeArchiveId(parsed_url.searchParams.get('v'));
+            if (watch_id) return watch_id;
+
+            const path_match = parsed_url.pathname.match(/\/(?:embed|shorts|live)\/([^/?#]+)/);
+            if (path_match) return normalizeArchiveId(path_match[1]);
+        }
+    } catch (e) {
+        const watch_match = url.match(/[?&]v=([^&#]+)/);
+        if (watch_match) return normalizeArchiveId(watch_match[1]);
+
+        const short_match = url.match(/youtu\.be\/([^/?#]+)/i);
+        if (short_match) return normalizeArchiveId(short_match[1]);
+    }
+
+    return null;
+}
+
+function isYouTubeLikeValue(value = null) {
+    return typeof value === 'string' && /youtu(?:be\.com|\.be)|youtube/i.test(value);
+}
+
+function getArchiveIdentityFromDownload(download = null) {
+    if (!download || typeof download !== 'object') return null;
+
+    const prefetched_info_items = Array.isArray(download['prefetched_info'])
+        ? download['prefetched_info'].filter(info_item => !!info_item && typeof info_item === 'object')
+        : [];
+    const candidates = [
+        ...prefetched_info_items,
+        {
+            webpage_url: download['url'],
+            url: download['url'],
+            title: download['title']
+        }
+    ];
+
+    for (const candidate of candidates) {
+        const candidate_url = candidate['webpage_url'] || candidate['original_url'] || candidate['url'] || download['url'];
+        let extractor = normalizeArchiveExtractor(candidate['source_extractor'])
+            || normalizeArchiveExtractor(candidate['extractor'])
+            || normalizeArchiveExtractor(candidate['extractor_key'])
+            || normalizeArchiveExtractor(candidate['ie_key']);
+
+        if (!extractor && isYouTubeLikeValue(candidate_url)) extractor = 'youtube';
+
+        let id = normalizeArchiveId(candidate['source_id'])
+            || normalizeArchiveId(candidate['id'])
+            || normalizeArchiveId(candidate['display_id']);
+
+        if (!id && extractor === 'youtube') id = extractYouTubeVideoId(candidate_url);
+
+        if (extractor && id) {
+            return {
+                extractor: extractor,
+                id: id,
+                title: candidate['title'] || download['title'] || null
+            };
+        }
+    }
+
+    return null;
+}
+
+function isSkippableSubscriptionDownloadError(error_message = '', error_type = null) {
+    if (SKIPPABLE_SUBSCRIPTION_DOWNLOAD_ERROR_TYPES.has(error_type)) return true;
+    if (typeof error_message !== 'string') return false;
+
+    const normalized_message = error_message.toLowerCase();
+    return SKIPPABLE_SUBSCRIPTION_DOWNLOAD_ERROR_TEXT.some(error_text => normalized_message.includes(error_text));
 }
 
 function escapeRegexCharacterClassChar(char = '') {
@@ -1309,6 +1416,13 @@ exports.cancelDownload = async (download_uid) => {
 }
 
 exports.clearDownload = async (download_uid) => {
+    const download = await db_api.getRecord('download_queue', {uid: download_uid});
+    const should_archive_subscription_skip = download && download['sub_id']
+        && ((download['paused'] && !download['finished'])
+            || (download['error'] && isSkippableSubscriptionDownloadError(download['error'], download['error_type'])));
+    if (should_archive_subscription_skip) {
+        await archiveSubscriptionDownloadBySource(download, 'after being cleared from the download queue');
+    }
     return await db_api.removeRecord('download_queue', {uid: download_uid});
 }
 
@@ -1316,8 +1430,57 @@ async function handleDownloadError(download_uid, error_message, error_type = nul
     if (!download_uid) return;
     const download = await db_api.getRecord('download_queue', {uid: download_uid});
     if (!download || download['error']) return;
+    await archiveSkippedSubscriptionDownload(download, error_message, error_type);
     notifications_api.sendDownloadErrorNotification(download, download['user_uid'], error_message, error_type);
     await db_api.updateRecord('download_queue', {uid: download['uid']}, {error: error_message, finished: true, running: false, error_type: error_type});
+}
+
+async function archiveSkippedSubscriptionDownload(download = null, error_message = '', error_type = null) {
+    if (!download || !download['sub_id']) return false;
+    if (!isSkippableSubscriptionDownloadError(error_message, error_type)) return false;
+    return await archiveSubscriptionDownloadBySource(download, `after ${error_type || 'download failure'}`);
+}
+
+async function archiveSubscriptionDownloadBySource(download = null, reason = 'after being skipped') {
+    if (!download || !download['sub_id']) return false;
+    const archive_identity = getArchiveIdentityFromDownload(download);
+    if (!archive_identity) {
+        logger.warn(`Could not archive failed subscription download '${download['uid']}' because no source id was available.`);
+        return false;
+    }
+
+    try {
+        await archive_api.addToArchive(
+            archive_identity.extractor,
+            archive_identity.id,
+            download['type'],
+            archive_identity.title,
+            download['user_uid'],
+            download['sub_id']
+        );
+        logger.info(`Archived skipped subscription video ${archive_identity.extractor}:${archive_identity.id} ${reason} for subscription ${download['sub_id']}.`);
+        return true;
+    } catch (e) {
+        logger.warn(`Failed to archive skipped subscription video ${archive_identity.extractor}:${archive_identity.id} for subscription ${download['sub_id']}.`);
+        logger.warn(e);
+        return false;
+    }
+}
+
+function describeDownloadStepError(err = null) {
+    if (!err) return 'Unknown error';
+    if (typeof err === 'string') return err;
+    if (err.message) return err.message;
+    return String(err);
+}
+
+function runDownloadQueueStep(download_uid, step_description, step_runner, error_type) {
+    Promise.resolve().then(() => step_runner(download_uid)).catch(async err => {
+        const error_message = `Unexpected error while ${step_description}: ${describeDownloadStepError(err)}`;
+        logger.error(error_message);
+        if (err && err.stack) logger.debug(err.stack);
+        await handleDownloadError(download_uid, error_message, error_type);
+    });
 }
 
 exports.setupDownloads = async () => {
@@ -1439,9 +1602,9 @@ async function checkDownloads() {
             running_downloads_count++;
             markDownloadQueueStart(minimum_sleep_between_downloads_ms);
             if (waiting_download['step_index'] === 0) {
-                exports.collectInfo(waiting_download['uid']);
+                runDownloadQueueStep(waiting_download['uid'], 'getting download info', exports.collectInfo, 'info_retrieve_failed');
             } else if (waiting_download['step_index'] === 1) {
-                exports.downloadQueuedFile(waiting_download['uid']);
+                runDownloadQueueStep(waiting_download['uid'], 'downloading file', exports.downloadQueuedFile, 'unknown_error');
             }
 
             if (capped_queue_group) {
@@ -1522,7 +1685,7 @@ exports.collectInfo = async (download_uid) => {
         const error_message = `No downloadable items were found while retrieving info for URL ${url}`;
         logger.error(error_message);
         if (download_uid) {
-            await handleDownloadError(download_uid, error_message, 'info_retrieve_failed');
+            await handleDownloadError(download_uid, error_message, 'no_downloadable_items');
         }
         return;
     }

--- a/backend/downloader.js
+++ b/backend/downloader.js
@@ -88,6 +88,10 @@ function normalizeArchiveId(value = null) {
     return normalized_value || null;
 }
 
+function isYouTubeHostname(host = '') {
+    return host === 'youtube.com' || host.endsWith('.youtube.com');
+}
+
 function extractYouTubeVideoId(url = '') {
     if (typeof url !== 'string' || url.trim() === '') return null;
 
@@ -97,7 +101,7 @@ function extractYouTubeVideoId(url = '') {
         if (host === 'youtu.be') {
             return normalizeArchiveId(parsed_url.pathname.split('/').filter(Boolean)[0]);
         }
-        if (host.includes('youtube.com')) {
+        if (isYouTubeHostname(host)) {
             const watch_id = normalizeArchiveId(parsed_url.searchParams.get('v'));
             if (watch_id) return watch_id;
 
@@ -116,7 +120,14 @@ function extractYouTubeVideoId(url = '') {
 }
 
 function isYouTubeLikeValue(value = null) {
-    return typeof value === 'string' && /youtu(?:be\.com|\.be)|youtube/i.test(value);
+    if (typeof value !== 'string' || value.trim() === '') return false;
+    try {
+        const parsed_url = new URL(value);
+        const host = parsed_url.hostname.toLowerCase();
+        return host === 'youtu.be' || isYouTubeHostname(host);
+    } catch (e) {
+        return false;
+    }
 }
 
 function getArchiveIdentityFromDownload(download = null) {

--- a/backend/test/downloader.test.js
+++ b/backend/test/downloader.test.js
@@ -55,6 +55,15 @@ describe('Downloader', function() {
         ui_uid: uuid()
     }
 
+    async function waitForCondition(predicate, timeout_ms = 2000) {
+        const start = Date.now();
+        while (Date.now() - start < timeout_ms) {
+            if (await predicate()) return true;
+            await new Promise(resolve => setTimeout(resolve, 25));
+        }
+        return false;
+    }
+
     async function createCategory(url) {
         // get info
         const args = await downloader_api.generateArgs(url, 'video', options, null, true);
@@ -251,6 +260,136 @@ describe('Downloader', function() {
         }
         const success = await downloader_api.downloadQueuedFile(returned_download['uid'], custom_download_method);
         assert(success);
+    });
+
+    it('Archives no-output subscription downloads so future refreshes skip them', async function() {
+        const prefetched_info = [{
+            _type: 'url',
+            ie_key: 'Youtube',
+            extractor_key: 'Youtube',
+            id: 'bad-subscription-video',
+            webpage_url: 'https://www.youtube.com/watch?v=bad-subscription-video',
+            title: 'Bad subscription video'
+        }];
+        const returned_download = await downloader_api.createDownload(
+            prefetched_info[0].webpage_url,
+            'video',
+            {ui_uid: uuid()},
+            'test_user',
+            sub_id,
+            'Test subscription',
+            prefetched_info
+        );
+        await db_api.updateRecord('download_queue', {uid: returned_download['uid']}, {
+            args: [],
+            finished_step: true,
+            step_index: 1
+        });
+
+        const empty_output_download_method = async (download_url, args, method_options, callback) => {
+            return await callback(null, []);
+        };
+        const success = await downloader_api.downloadQueuedFile(returned_download['uid'], empty_output_download_method);
+        const updated_download = await db_api.getRecord('download_queue', {uid: returned_download['uid']});
+
+        assert.strictEqual(success, false);
+        assert.strictEqual(updated_download.error_type, 'no_output');
+        assert.strictEqual(
+            await archive_api.existsInArchive('youtube', prefetched_info[0].id, 'video', 'test_user', sub_id),
+            true
+        );
+    });
+
+    it('Archives paused subscription downloads when clearing them from the queue', async function() {
+        const prefetched_info = [{
+            _type: 'url',
+            extractor: 'youtube',
+            id: 'cleared-subscription-video',
+            webpage_url: 'https://www.youtube.com/watch?v=cleared-subscription-video',
+            title: 'Cleared subscription video'
+        }];
+        const returned_download = await downloader_api.createDownload(
+            prefetched_info[0].webpage_url,
+            'video',
+            {ui_uid: uuid()},
+            'test_user',
+            sub_id,
+            'Test subscription',
+            prefetched_info,
+            true
+        );
+
+        const success = await downloader_api.clearDownload(returned_download['uid']);
+        const cleared_download = await db_api.getRecord('download_queue', {uid: returned_download['uid']});
+
+        assert.strictEqual(success, true);
+        assert.strictEqual(cleared_download, undefined);
+        assert.strictEqual(
+            await archive_api.existsInArchive('youtube', prefetched_info[0].id, 'video', 'test_user', sub_id),
+            true
+        );
+    });
+
+    it('Archives skippable errored subscription downloads when clearing them from the queue', async function() {
+        const prefetched_info = [{
+            _type: 'url',
+            extractor: 'youtube',
+            id: 'cleared-error-subscription-video',
+            webpage_url: 'https://www.youtube.com/watch?v=cleared-error-subscription-video',
+            title: 'Cleared errored subscription video'
+        }];
+        const returned_download = await downloader_api.createDownload(
+            prefetched_info[0].webpage_url,
+            'video',
+            {ui_uid: uuid()},
+            'test_user',
+            sub_id,
+            'Test subscription',
+            prefetched_info
+        );
+        await db_api.updateRecord('download_queue', {uid: returned_download['uid']}, {
+            error: 'No output received for video download, check if it exists in your archive.',
+            error_type: 'no_output',
+            finished: true,
+            running: false
+        });
+
+        const success = await downloader_api.clearDownload(returned_download['uid']);
+
+        assert.strictEqual(success, true);
+        assert.strictEqual(
+            await archive_api.existsInArchive('youtube', prefetched_info[0].id, 'video', 'test_user', sub_id),
+            true
+        );
+    });
+
+    it('Marks queue-step exceptions as failed downloads instead of leaving them running', async function() {
+        const original_max_concurrent_downloads = config_api.getConfigItem('ytdl_max_concurrent_downloads');
+        const original_collect_info = downloader_api.collectInfo;
+        const returned_download = await downloader_api.createDownload(`${url}&throwing_collect_info=1`, 'video', {ui_uid: uuid()});
+
+        try {
+            config_api.setConfigItem('ytdl_max_concurrent_downloads', 1);
+            downloader_api.collectInfo = () => {
+                throw new Error('synthetic collectInfo failure');
+            };
+
+            await downloader_api.checkDownloads();
+            const failed = await waitForCondition(async () => {
+                const updated_download = await db_api.getRecord('download_queue', {uid: returned_download['uid']});
+                return !!(updated_download && updated_download.finished && updated_download.error);
+            });
+            assert.strictEqual(failed, true);
+        } finally {
+            downloader_api.collectInfo = original_collect_info;
+            config_api.setConfigItem('ytdl_max_concurrent_downloads', original_max_concurrent_downloads);
+        }
+
+        const updated_download = await db_api.getRecord('download_queue', {uid: returned_download['uid']});
+        assert.strictEqual(updated_download.finished, true);
+        assert.strictEqual(updated_download.running, false);
+        assert.strictEqual(updated_download.error_type, 'info_retrieve_failed');
+        assert(updated_download.error.includes('synthetic collectInfo failure'));
     });
 
     it('fixDownloadState only pauses downloads that were actively running', async function() {

--- a/backend/test/downloader.test.js
+++ b/backend/test/downloader.test.js
@@ -330,6 +330,25 @@ describe('Downloader', function() {
         );
     });
 
+    it('Does not archive subscription downloads from YouTube lookalike hostnames', async function() {
+        const returned_download = await downloader_api.createDownload(
+            'https://youtube.com.attacker.test/watch?v=lookalike-video',
+            'video',
+            {ui_uid: uuid()},
+            'test_user',
+            sub_id,
+            'Test subscription',
+            null,
+            true
+        );
+
+        const success = await downloader_api.clearDownload(returned_download['uid']);
+        const archived_items = await db_api.getRecords('archives', {sub_id: sub_id});
+
+        assert.strictEqual(success, true);
+        assert.strictEqual(archived_items.length, 0);
+    });
+
     it('Archives skippable errored subscription downloads when clearing them from the queue', async function() {
         const prefetched_info = [{
             _type: 'url',

--- a/backend/test/subscriptions.test.js
+++ b/backend/test/subscriptions.test.js
@@ -475,6 +475,7 @@ describe('Subscriptions', function() {
     });
     it('Skips join-only flat playlist entries before queueing subscription downloads', async function() {
         const original_runYoutubeDLLineStream = youtubedl_api.runYoutubeDLLineStream;
+        const original_skip_join_only = config_api.getConfigItem('ytdl_skip_join_only_videos');
         const sub = Object.assign({}, new_sub, {id: uuid(), name: 'skip_join_only_sub'});
         const public_output = {
             _type: 'url',
@@ -523,6 +524,7 @@ describe('Subscriptions', function() {
             assert.strictEqual(completed, true);
         } finally {
             youtubedl_api.runYoutubeDLLineStream = original_runYoutubeDLLineStream;
+            config_api.setConfigItem('ytdl_skip_join_only_videos', original_skip_join_only);
         }
 
         const queued_downloads = await db_api.getRecords('download_queue', {sub_id: sub.id});


### PR DESCRIPTION
## Summary
- archive skippable subscription download failures (join-only, no output, unavailable/private/removed, no downloadable items) so future refreshes skip them
- archive paused or skippable errored subscription downloads when clearing them from the queue, including bulk clear paused/errors
- catch queue-step exceptions and mark downloads failed instead of leaving them stuck at creating download
- add the missing skip_join_only_videos default and regression coverage

## Tests
- npm test -- --grep \"Archives no-output|Archives paused|Archives skippable|queue-step|join-only\"
- npm test