### PR TITLE
fix(subscriptions): skip archived pending entries

### DIFF
--- a/Public API v1.yaml
+++ b/Public API v1.yaml
@@ -2107,6 +2107,9 @@ components:
         name:
           type: string
           description: Subscription name
+        include_videos:
+          type: boolean
+          description: Include completed subscription files in the response
     GetSubscriptionResponse:
       required:
         - files
@@ -2914,7 +2917,6 @@ components:
         - type
         - user_uid
         - isPlaylist
-        - videos
       type: object
       properties:
         name:
@@ -2946,6 +2948,8 @@ components:
           type: boolean
         refresh_status:
           $ref: '#/components/schemas/SubscriptionRefreshStatus'
+        file_count:
+          type: number
         videos:
           type: array
           items:

--- a/backend/app.js
+++ b/backend/app.js
@@ -1817,6 +1817,7 @@ app.post('/api/deleteSubscriptionFile', optionalJwt, async (req, res) => {
 app.post('/api/getSubscription', optionalJwt, async (req, res) => {
     let subID = req.body.id;
     let subName = req.body.name; // if included, subID is optional
+    const include_videos = req.body.include_videos !== false;
     let user_uid = req.isAuthenticated() ? req.user.uid : null;
 
     // get sub from db
@@ -1838,18 +1839,29 @@ app.post('/api/getSubscription', optionalJwt, async (req, res) => {
     // get sub videos
     if (subscription.name) {
         const sub_files_filter = {sub_id: subscription.id, ...getScopedFilterByUser(user_uid)};
-        var parsed_files = files_api.attachFileChaptersCollection(await db_api.getRecords('files', sub_files_filter)); // subscription.videos;
-        subscription['videos'] = parsed_files;
-        // loop through files for extra processing
-        for (let i = 0; i < parsed_files.length; i++) {
-            const file = parsed_files[i];
-            // check if chat exists for twitch videos
-            if (file && file['url'].includes('twitch.tv')) file['chat_exists'] = fs.existsSync(file['path'].substring(0, file['path'].length - 4) + '.twitch_chat.json');
+        const file_count = await db_api.getRecords('files', sub_files_filter, true);
+        subscription['file_count'] = file_count;
+
+        if (include_videos) {
+            var parsed_files = files_api.attachFileChaptersCollection(await db_api.getRecords('files', sub_files_filter)); // subscription.videos;
+            subscription['videos'] = parsed_files;
+            // loop through files for extra processing
+            for (let i = 0; i < parsed_files.length; i++) {
+                const file = parsed_files[i];
+                // check if chat exists for twitch videos
+                if (file && file['url'].includes('twitch.tv')) file['chat_exists'] = fs.existsSync(file['path'].substring(0, file['path'].length - 4) + '.twitch_chat.json');
+            }
+
+            res.send({
+                subscription: subscription,
+                files: parsed_files
+            });
+            return;
         }
 
         res.send({
             subscription: subscription,
-            files: parsed_files
+            files: []
         });
     } else {
         res.sendStatus(500);

--- a/backend/subscriptions.js
+++ b/backend/subscriptions.js
@@ -60,6 +60,19 @@ function normalizeStringForComparison(value) {
     return normalized_value.replace(/^['"]|['"]$/g, '').trim().toLowerCase();
 }
 
+function normalizeArchiveSourceValue(value) {
+    if (value === null || value === undefined) return null;
+    const normalized_value = String(value).trim();
+    return normalized_value === '' ? null : normalized_value;
+}
+
+function getArchiveKey(extractor = null, id = null) {
+    const normalized_extractor = normalizeStringForComparison(extractor);
+    const normalized_id = normalizeArchiveSourceValue(id);
+    if (!normalized_extractor || !normalized_id) return null;
+    return `${normalized_extractor}:${normalized_id}`;
+}
+
 function parseDelimitedArgs(args_string = '') {
     if (typeof args_string !== 'string' || args_string.trim() === '') return [];
     return args_string.split(',,').map(arg => arg.trim()).filter(arg => arg !== '');
@@ -141,6 +154,75 @@ function getSubscriptionOutputArchiveExtractor(output_json = null) {
 
     if (isYouTubeSubscriptionOutput(output_json)) return 'youtube';
     return null;
+}
+
+function getSubscriptionOutputArchiveIdentity(output_json = null, type = 'video') {
+    if (!output_json || typeof output_json !== 'object') return null;
+
+    const source_metadata = files_api.extractSourceMetadataFromInfo(output_json, type)
+        || files_api.extractSourceMetadataFromUrl(output_json.webpage_url || output_json.original_url || output_json.url, type);
+    const extractor = getSubscriptionOutputArchiveExtractor(output_json)
+        || (source_metadata && source_metadata.source_extractor);
+    const id = normalizeArchiveSourceValue(output_json.source_id)
+        || normalizeArchiveSourceValue(output_json.id)
+        || normalizeArchiveSourceValue(output_json.display_id)
+        || normalizeArchiveSourceValue(source_metadata && source_metadata.source_id);
+
+    if (!extractor || !id) return null;
+    return {
+        extractor: extractor,
+        id: id,
+        title: output_json.title || null
+    };
+}
+
+function getSubscriptionOutputArchiveKey(output_json = null, type = 'video') {
+    const archive_identity = getSubscriptionOutputArchiveIdentity(output_json, type);
+    return archive_identity ? getArchiveKey(archive_identity.extractor, archive_identity.id) : null;
+}
+
+function getSubscriptionFileArchiveKey(file_obj = null, type = 'video') {
+    if (!file_obj || typeof file_obj !== 'object') return null;
+
+    const source_extractor = normalizeArchiveSourceValue(file_obj.source_extractor);
+    const source_id = normalizeArchiveSourceValue(file_obj.source_id);
+    const key_from_source_metadata = getArchiveKey(source_extractor, source_id);
+    if (key_from_source_metadata) return key_from_source_metadata;
+
+    const source_metadata = files_api.extractSourceMetadataFromUrl(file_obj.url, type);
+    return source_metadata ? getArchiveKey(source_metadata.source_extractor, source_metadata.source_id) : null;
+}
+
+function getSubscriptionDownloadArchiveKey(download = null, type = 'video') {
+    if (!download || typeof download !== 'object') return null;
+
+    const prefetched_info_items = Array.isArray(download.prefetched_info)
+        ? download.prefetched_info.filter(info_item => !!info_item && typeof info_item === 'object')
+        : [];
+    const candidates = [
+        ...prefetched_info_items,
+        {
+            webpage_url: download.url,
+            url: download.url,
+            title: download.title
+        }
+    ];
+
+    for (const candidate of candidates) {
+        const archive_key = getSubscriptionOutputArchiveKey(candidate, type);
+        if (archive_key) return archive_key;
+    }
+
+    return null;
+}
+
+function getSubscriptionArchiveFilter(sub = null) {
+    const filter = {sub_id: sub && sub.id};
+    if (sub && sub.type) filter.type = sub.type;
+    if (config_api.getConfigItem('ytdl_multi_user_mode')) {
+        filter.user_uid = sub ? sub.user_uid : null;
+    }
+    return filter;
 }
 
 function parseAvailabilityMatchCondition(condition = '') {
@@ -264,20 +346,20 @@ function isJoinOnlySubscriptionOutput(output_json = null) {
 }
 
 async function archiveSkippedJoinOnlySubscriptionOutput(output_json = null, sub = null) {
-    if (!output_json || !sub || !output_json.id) return false;
+    if (!output_json || !sub) return false;
 
-    const extractor = getSubscriptionOutputArchiveExtractor(output_json);
-    if (!extractor) return false;
+    const archive_identity = getSubscriptionOutputArchiveIdentity(output_json, sub.type);
+    if (!archive_identity) return false;
 
     await archive_api.addToArchive(
-        extractor,
-        output_json.id,
+        archive_identity.extractor,
+        archive_identity.id,
         sub.type,
-        output_json.title || null,
+        archive_identity.title,
         sub.user_uid,
         sub.id
     );
-    logger.info(`Archived join-only video ${extractor}:${output_json.id} for subscription ${sub.id}.`);
+    logger.info(`Archived join-only video ${archive_identity.extractor}:${archive_identity.id} for subscription ${sub.id}.`);
     return true;
 }
 
@@ -594,6 +676,66 @@ async function ensureSubscriptionRefreshQueueContext(sub, user_uid, refresh_trac
     }
 
     return created_queue_context;
+}
+
+async function removeArchivedPendingSubscriptionDownloads(sub, pending_downloads = null) {
+    if (!sub || !sub.id) return 0;
+
+    const effective_pending_downloads = Array.isArray(pending_downloads)
+        ? pending_downloads
+        : await db_api.getRecords('download_queue', {sub_id: sub.id, finished: false});
+    if (effective_pending_downloads.length === 0) return 0;
+
+    const archive_items = await db_api.getRecords('archives', getSubscriptionArchiveFilter(sub));
+    const archived_output_keys = new Set(
+        archive_items
+            .map(archive_item => getArchiveKey(archive_item.extractor, archive_item.id))
+            .filter(Boolean)
+    );
+    if (archived_output_keys.size === 0) return 0;
+
+    let removed_count = 0;
+
+    for (const pending_download of effective_pending_downloads) {
+        if (!pending_download || pending_download.finished) continue;
+
+        const pending_archive_key = getSubscriptionDownloadArchiveKey(pending_download, pending_download.type || sub.type);
+        if (!pending_archive_key || !archived_output_keys.has(pending_archive_key)) continue;
+
+        if (pending_download.running) {
+            await downloader_api.cancelDownload(pending_download.uid).catch(error => {
+                logger.warn(`Failed to cancel archived pending subscription download '${pending_download.uid}' before cleanup.`);
+                logger.warn(error);
+            });
+        }
+
+        await db_api.removeRecord('download_queue', {uid: pending_download.uid});
+        removed_count += 1;
+        logger.info(`Removed archived pending subscription download ${pending_archive_key} from subscription ${sub.id}.`);
+    }
+
+    return removed_count;
+}
+
+function adjustRefreshStatusAfterPendingCleanup(refresh_status, removed_pending_count = 0, pending_download_count = 0, running_download_count = 0) {
+    const normalized_refresh_status = normalizeSubscriptionRefreshStatus(refresh_status);
+    if (removed_pending_count <= 0) return normalized_refresh_status;
+
+    const adjusted_queued_count = Math.max(0, normalized_refresh_status.queued_count - removed_pending_count);
+    const adjusted_new_items_count = normalized_refresh_status.new_items_count === null
+        ? null
+        : Math.max(0, normalized_refresh_status.new_items_count - removed_pending_count);
+    const should_mark_complete = normalized_refresh_status.phase === SUBSCRIPTION_REFRESH_PHASES.QUEUED
+        && adjusted_queued_count === 0
+        && pending_download_count === 0
+        && running_download_count === 0;
+
+    return normalizeSubscriptionRefreshStatus({
+        ...normalized_refresh_status,
+        phase: should_mark_complete ? SUBSCRIPTION_REFRESH_PHASES.COMPLETE : normalized_refresh_status.phase,
+        new_items_count: adjusted_new_items_count,
+        queued_count: adjusted_queued_count
+    });
 }
 
 async function finalizeSubscriptionRefreshSuccess(sub, tracker, queue_context = null) {
@@ -1326,15 +1468,42 @@ async function generateArgsForSubscriptionDiscovery(sub, user_uid) {
 }
 
 async function createSubscriptionDownloadContext(sub) {
-    const [existing_sub_files, pending_sub_downloads] = await Promise.all([
+    const [existing_sub_files, pending_sub_downloads, archive_items] = await Promise.all([
         db_api.getRecords('files', {sub_id: sub.id}),
-        db_api.getRecords('download_queue', {sub_id: sub.id, error: null, finished: false})
+        db_api.getRecords('download_queue', {sub_id: sub.id, error: null, finished: false}),
+        db_api.getRecords('archives', getSubscriptionArchiveFilter(sub))
     ]);
+    const archived_output_keys = new Set(
+        archive_items
+            .map(archive_item => getArchiveKey(archive_item.extractor, archive_item.id))
+            .filter(Boolean)
+    );
+    const active_pending_sub_downloads = [];
+
+    for (const pending_download of pending_sub_downloads) {
+        const pending_archive_key = getSubscriptionDownloadArchiveKey(pending_download, pending_download.type || sub.type);
+        if (pending_archive_key && archived_output_keys.has(pending_archive_key)) {
+            if (pending_download.running) {
+                await downloader_api.cancelDownload(pending_download.uid).catch(error => {
+                    logger.warn(`Failed to cancel archived pending subscription download '${pending_download.uid}' before cleanup.`);
+                    logger.warn(error);
+                });
+            }
+            await db_api.removeRecord('download_queue', {uid: pending_download.uid});
+            logger.info(`Removed archived pending subscription download ${pending_archive_key} from subscription ${sub.id}.`);
+            continue;
+        }
+
+        active_pending_sub_downloads.push(pending_download);
+    }
 
     return {
         urls_with_existing_files: new Set(existing_sub_files.map(file => file.url)),
         paths_with_existing_files: new Set(existing_sub_files.map(file => file.path)),
-        urls_with_pending_downloads: new Set(pending_sub_downloads.map(download => download.url))
+        source_keys_with_existing_files: new Set(existing_sub_files.map(file => getSubscriptionFileArchiveKey(file, sub.type)).filter(Boolean)),
+        urls_with_pending_downloads: new Set(active_pending_sub_downloads.map(download => download.url)),
+        source_keys_with_pending_downloads: new Set(active_pending_sub_downloads.map(download => getSubscriptionDownloadArchiveKey(download, download.type || sub.type)).filter(Boolean)),
+        archived_output_keys: archived_output_keys
     };
 }
 
@@ -1342,9 +1511,12 @@ async function getFilesToDownload(sub, output_jsons, download_context = null, di
     const files_to_download = [];
     const effective_download_context = download_context || await createSubscriptionDownloadContext(sub);
     const {
-        urls_with_existing_files,
-        paths_with_existing_files,
-        urls_with_pending_downloads
+        urls_with_existing_files = new Set(),
+        paths_with_existing_files = new Set(),
+        source_keys_with_existing_files = new Set(),
+        urls_with_pending_downloads = new Set(),
+        source_keys_with_pending_downloads = new Set(),
+        archived_output_keys = new Set()
     } = effective_download_context;
 
     for (let i = 0; i < output_jsons.length; i++) {
@@ -1355,8 +1527,14 @@ async function getFilesToDownload(sub, output_jsons, download_context = null, di
 
         const output_url = output_json['webpage_url'];
         const output_path = output_json['_filename'];
+        const output_archive_key = getSubscriptionOutputArchiveKey(output_json, sub.type);
 
-        const file_missing = !urls_with_existing_files.has(output_url) && !urls_with_pending_downloads.has(output_url);
+        if (output_archive_key && archived_output_keys.has(output_archive_key)) continue;
+
+        const file_missing = !urls_with_existing_files.has(output_url)
+            && !urls_with_pending_downloads.has(output_url)
+            && (!output_archive_key || !source_keys_with_existing_files.has(output_archive_key))
+            && (!output_archive_key || !source_keys_with_pending_downloads.has(output_archive_key));
         if (!file_missing) continue;
 
         if (output_path && paths_with_existing_files.has(output_path)) {
@@ -1365,14 +1543,9 @@ async function getFilesToDownload(sub, output_jsons, download_context = null, di
             continue;
         }
 
-        const archive_extractor = getSubscriptionOutputArchiveExtractor(output_json);
-        if (archive_extractor && output_json['id']) {
-            const exists_in_archive = await archive_api.existsInArchive(archive_extractor, output_json['id'], sub.type, sub.user_uid, sub.id);
-            if (exists_in_archive) continue;
-        }
-
         files_to_download.push(output_json);
         urls_with_pending_downloads.add(output_url);
+        if (output_archive_key) source_keys_with_pending_downloads.add(output_archive_key);
     }
     return files_to_download;
 }
@@ -1448,6 +1621,7 @@ exports.getSubscription = async (subID, user_uid = null) => {
     const raw_sub = await db_api.getRecord('subscriptions', filter_obj);
     if (!raw_sub) return null;
     const sub = JSON.parse(JSON.stringify(raw_sub));
+    const removed_archived_pending_count = await removeArchivedPendingSubscriptionDownloads(sub);
     // now with the download_queue, we may need to override 'downloading'
     const [
         current_downloads,
@@ -1464,6 +1638,7 @@ exports.getSubscription = async (subID, user_uid = null) => {
     if (!sub['downloading'] && refresh_status.active) {
         refresh_status = buildInterruptedSubscriptionRefreshStatus(refresh_status);
     }
+    refresh_status = adjustRefreshStatusAfterPendingCleanup(refresh_status, removed_archived_pending_count, pending_download_count, running_download_count);
 
     if (refresh_status.phase === SUBSCRIPTION_REFRESH_PHASES.IDLE && pending_download_count > 0) {
         refresh_status = normalizeSubscriptionRefreshStatus({
@@ -1471,6 +1646,9 @@ exports.getSubscription = async (subID, user_uid = null) => {
             phase: SUBSCRIPTION_REFRESH_PHASES.QUEUED,
             queued_count: refresh_status.queued_count || pending_download_count
         });
+    }
+    if (removed_archived_pending_count > 0) {
+        await persistSubscriptionRefreshStatus(subID, refresh_status);
     }
 
     sub['refresh_status'] = {

--- a/backend/test/subscriptions.test.js
+++ b/backend/test/subscriptions.test.js
@@ -266,6 +266,50 @@ describe('Subscriptions', function() {
         assert.strictEqual(refreshed_sub['refresh_status']['pending_download_count'], 2);
         assert.strictEqual(refreshed_sub['refresh_status']['running_download_count'], 1);
     });
+    it('Removes archived pending subscription downloads before reporting refresh status', async function() {
+        const sub = Object.assign({}, new_sub, {id: uuid(), name: 'archived_pending_sub'});
+        const archived_download = {
+            uid: uuid(),
+            url: 'https://www.youtube.com/watch?v=join-only-video',
+            type: 'video',
+            title: 'Members-only video',
+            options: {},
+            sub_id: sub.id,
+            user_uid: null,
+            running: false,
+            paused: false,
+            finished_step: true,
+            finished: false,
+            error: null,
+            timestamp_start: Date.now()
+        };
+
+        await db_api.insertRecordIntoTable('subscriptions', {
+            ...sub,
+            refresh_status: {
+                active: false,
+                phase: 'queued',
+                discovered_count: 1,
+                total_count: 1,
+                new_items_count: 1,
+                queued_count: 1
+            }
+        });
+        await archive_api.addToArchive('youtube', 'join-only-video', 'video', 'Members-only video', null, sub.id);
+        await db_api.insertRecordIntoTable('download_queue', archived_download);
+
+        const refreshed_sub = await subscriptions_api.getSubscription(sub.id);
+
+        assert(refreshed_sub);
+        assert.strictEqual(refreshed_sub['refresh_status']['pending_download_count'], 0);
+        assert.strictEqual(refreshed_sub['refresh_status']['running_download_count'], 0);
+        assert.strictEqual(refreshed_sub['refresh_status']['queued_count'], 0);
+        assert.strictEqual(refreshed_sub['refresh_status']['new_items_count'], 0);
+        assert.strictEqual(refreshed_sub['refresh_status']['phase'], 'complete');
+
+        const remaining_downloads = await db_api.getRecords('download_queue', {sub_id: sub.id});
+        assert.strictEqual(remaining_downloads.length, 0);
+    });
     it('Update subscription', async function () {
         await subscriptions_api.subscribe(new_sub, null, true);
         const sub_update = Object.assign({}, new_sub, {name: 'updated_name'});
@@ -531,6 +575,68 @@ describe('Subscriptions', function() {
         assert.strictEqual(queued_downloads.length, 1);
         assert.strictEqual(queued_downloads[0].url, public_output.webpage_url);
         assert.strictEqual(await archive_api.existsInArchive('youtube', join_only_output.id, sub.type, sub.user_uid, sub.id), true);
+    });
+    it('Filters archived flat playlist entries from cached subscription archive state', async function() {
+        const original_runYoutubeDLLineStream = youtubedl_api.runYoutubeDLLineStream;
+        const original_existsInArchive = archive_api.existsInArchive;
+        const sub = Object.assign({}, new_sub, {id: uuid(), name: 'cached_archive_sub'});
+        const archived_output = {
+            _type: 'url',
+            ie_key: 'Youtube',
+            extractor: 'youtube',
+            extractor_key: 'Youtube',
+            id: 'archived-video',
+            url: 'https://www.youtube.com/watch?v=archived-video',
+            webpage_url: 'https://www.youtube.com/watch?v=archived-video',
+            title: 'Archived video',
+            availability: null
+        };
+        const public_output = {
+            _type: 'url',
+            ie_key: 'Youtube',
+            extractor: 'youtube',
+            extractor_key: 'Youtube',
+            id: 'public-video',
+            url: 'https://www.youtube.com/watch?v=public-video',
+            webpage_url: 'https://www.youtube.com/watch?v=public-video',
+            title: 'Public video',
+            availability: null
+        };
+
+        youtubedl_api.runYoutubeDLLineStream = async (requested_url, args, line_handlers = {}) => {
+            if (typeof line_handlers.onStdoutLine === 'function') {
+                line_handlers.onStdoutLine(JSON.stringify(archived_output));
+                line_handlers.onStdoutLine(JSON.stringify(public_output));
+            }
+            return {
+                child_process: {pid: 4321},
+                callback: Promise.resolve({err: null})
+            };
+        };
+
+        try {
+            await subscriptions_api.subscribe(sub, null, true);
+            await archive_api.addToArchive('youtube', archived_output.id, sub.type, archived_output.title, sub.user_uid, sub.id);
+            archive_api.existsInArchive = async () => {
+                throw new Error('archive lookups should be served from the subscription context');
+            };
+
+            const started = await subscriptions_api.getVideosForSub(sub.id);
+            assert.strictEqual(started, true);
+
+            const completed = await waitForCondition(async () => {
+                const refreshed_sub = await subscriptions_api.getSubscription(sub.id);
+                return !!(refreshed_sub && !refreshed_sub.downloading);
+            });
+            assert.strictEqual(completed, true);
+        } finally {
+            youtubedl_api.runYoutubeDLLineStream = original_runYoutubeDLLineStream;
+            archive_api.existsInArchive = original_existsInArchive;
+        }
+
+        const queued_downloads = await db_api.getRecords('download_queue', {sub_id: sub.id});
+        assert.strictEqual(queued_downloads.length, 1);
+        assert.strictEqual(queued_downloads[0].url, public_output.webpage_url);
     });
     it('Applies availability match filters while queueing flat subscription entries', async function() {
         const original_runYoutubeDLLineStream = youtubedl_api.runYoutubeDLLineStream;

--- a/src/api-types/models/GetSubscriptionRequest.ts
+++ b/src/api-types/models/GetSubscriptionRequest.ts
@@ -11,4 +11,8 @@ export type GetSubscriptionRequest = {
      * Subscription name
      */
     name?: string;
+    /**
+     * Include completed subscription files in the response
+     */
+    include_videos?: boolean;
 };

--- a/src/api-types/models/Subscription.ts
+++ b/src/api-types/models/Subscription.ts
@@ -20,5 +20,6 @@ export type Subscription = {
     downloading?: boolean;
     paused?: boolean;
     refresh_status?: SubscriptionRefreshStatus;
-    videos: Array<any>;
+    file_count?: number;
+    videos?: Array<any>;
 };

--- a/src/app/dialogs/edit-subscription-dialog/edit-subscription-dialog.component.ts
+++ b/src/app/dialogs/edit-subscription-dialog/edit-subscription-dialog.component.ts
@@ -110,7 +110,7 @@ export class EditSubscriptionDialogComponent implements OnInit {
   }
 
   getSubscription() {
-    this.postsService.getSubscription(this.sub.id).subscribe(res => {
+    this.postsService.getSubscription(this.sub.id, null, false).subscribe(res => {
       this.sub = res['subscription'];
       this.new_sub = JSON.parse(JSON.stringify(this.sub));
     });

--- a/src/app/posts.services.ts
+++ b/src/app/posts.services.ts
@@ -684,8 +684,8 @@ export class PostsService {
         return this.http.post<SuccessObject>(this.path + 'deleteSubscriptionFile', body, this.httpOptions)
     }
 
-    getSubscription(id: string, name: string = null) {
-        const body: GetSubscriptionRequest = {id: id, name: name};
+    getSubscription(id: string, name: string = null, include_videos = true) {
+        const body: GetSubscriptionRequest = {id: id, name: name, include_videos: include_videos};
         return this.http.post<GetSubscriptionResponse>(this.path + 'getSubscription', body, this.httpOptions);
     }
 

--- a/src/app/subscription/subscription/subscription.component.spec.ts
+++ b/src/app/subscription/subscription/subscription.component.spec.ts
@@ -48,6 +48,7 @@ describe('SubscriptionComponent', () => {
     component.subscription = {
       id: 'sub-1',
       name: 'Test subscription',
+      file_count: 1,
       downloading: true,
       refresh_status: {
         phase: 'collecting',
@@ -69,16 +70,40 @@ describe('SubscriptionComponent', () => {
           pending_download_count: 3,
           running_download_count: 1
         },
-        videos: [{ id: 'replacement-video' }]
+        file_count: 1
       }
     }));
 
     component.getSubscription(true);
 
+    expect(postsService.getSubscription).toHaveBeenCalledWith('sub-1', null, false);
     expect(component.subscription.videos).toBe(existing_videos);
     expect(component.subscription.downloading).toBeFalse();
     expect(component.subscription.refresh_status.phase).toBe('queued');
     expect(postsService.files_changed.next).not.toHaveBeenCalled();
+  });
+  it('should notify the media library when lightweight subscription file count increases', () => {
+    component.subscription = {
+      id: 'sub-1',
+      name: 'Test subscription',
+      file_count: 1,
+      downloading: true,
+      videos: [{ id: 'video-1' }]
+    } as any;
+    spyOn(postsService.files_changed, 'next');
+    postsService.getSubscription.and.returnValue(of({
+      subscription: {
+        id: 'sub-1',
+        name: 'Test subscription',
+        file_count: 2,
+        downloading: false
+      }
+    }));
+
+    component.getSubscription(true);
+
+    expect(component.subscription.file_count).toBe(2);
+    expect(postsService.files_changed.next).toHaveBeenCalledWith(true);
   });
 
   it('should describe collecting progress when totals are known', () => {

--- a/src/app/subscription/subscription/subscription.component.ts
+++ b/src/app/subscription/subscription/subscription.component.ts
@@ -54,10 +54,10 @@ export class SubscriptionComponent implements OnInit, OnDestroy {
   }
 
   getSubscription(low_cost = false) {
-    this.postsService.getSubscription(this.id).subscribe(res => {
+    this.postsService.getSubscription(this.id, null, false).subscribe(res => {
       const next_subscription = res['subscription'] as Subscription;
-      const current_video_count = this.subscription?.videos?.length || 0;
-      const next_video_count = next_subscription?.videos?.length || 0;
+      const current_video_count = this.getSubscriptionFileCount(this.subscription);
+      const next_video_count = this.getSubscriptionFileCount(next_subscription);
 
       if (low_cost && this.subscription && next_video_count === current_video_count) {
         this.subscription = {
@@ -72,6 +72,12 @@ export class SubscriptionComponent implements OnInit, OnDestroy {
       }
       this.subscription = next_subscription;
     });
+  }
+
+  private getSubscriptionFileCount(subscription: Subscription | null): number {
+    const file_count = Number((subscription as any)?.file_count);
+    if (Number.isFinite(file_count)) return Math.max(0, Math.floor(file_count));
+    return subscription?.videos?.length || 0;
   }
 
   getConfig(): void {


### PR DESCRIPTION
## Summary
- filter subscription discovery against cached archive/source-key state instead of doing per-entry archive DB lookups
- remove archived/skipped pending subscription downloads before reporting refresh status so dead join-only jobs no longer count as pending
- let subscription page polling request lightweight subscription metadata/counts instead of refetching every completed file for large channels

Fixes #187

## Tests
- npm run lint
- npx tsc -p src/tsconfig.app.json --noEmit
- npx tsc -p src/tsconfig.spec.json --noEmit
- CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npm run test:headless
- npx ng build --configuration production
- node --check backend/subscriptions.js && node --check backend/app.js && node --check backend/test/subscriptions.test.js
- npm test -- --grep "Subscriptions" (backend)
- npm test (backend)