### PR TITLE
fix(files): clean stale orphan artifacts

### DIFF
--- a/backend/downloader.js
+++ b/backend/downloader.js
@@ -1724,7 +1724,6 @@ exports.collectInfo = async (download_uid) => {
     // set custom output if the category has one and re-retrieve info so the download manager has the right file name
     if (category && category['custom_output']) {
         options.customOutput = category['custom_output'];
-        options.noRelativePath = true;
         args = await exports.generateArgs(url, type, options, download['user_uid']);
         info = await exports.getVideoInfoByURL(url, args, download_uid, options);
     }

--- a/backend/files.js
+++ b/backend/files.js
@@ -14,6 +14,8 @@ const MEDIA_EXTENSIONS_BY_TYPE = {
     audio: ['mp3'],
     video: ['mp4']
 };
+const SIDECAR_SCAN_EXTENSIONS = ['json', 'webp', 'jpg', 'png', 'nfo', 'vtt'];
+const MANAGED_SIDECAR_EXTENSIONS = ['.webp', '.jpg', '.png', '.nfo'];
 
 function shouldRestrictToUser(user_uid) {
     return config_api.getConfigItem('ytdl_multi_user_mode') && user_uid !== null && user_uid !== undefined;
@@ -35,6 +37,22 @@ function normalizePathForComparison(file_path = '') {
     return path.resolve(file_path);
 }
 
+function normalizeMediaBasePath(file_path = '') {
+    if (typeof file_path !== 'string' || file_path.trim() === '') return null;
+    return normalizePathForComparison(utils.removeFileExtension(file_path));
+}
+
+function uniqueNormalizedPaths(paths = []) {
+    const seen_paths = new Set();
+    return paths.filter(candidate_path => {
+        if (!candidate_path) return false;
+        const normalized_path = normalizePathForComparison(candidate_path);
+        if (seen_paths.has(normalized_path)) return false;
+        seen_paths.add(normalized_path);
+        return true;
+    });
+}
+
 function getExistingMediaPath(file_path, type) {
     const candidate_paths = [file_path, utils.getTrueFileName(file_path, type)]
         .filter((candidate_path, index, all_paths) => candidate_path && all_paths.indexOf(candidate_path) === index);
@@ -52,13 +70,7 @@ async function getDownloadedMediaPathsByType(basePath, type) {
         media_paths.push(...await utils.recFindByExt(basePath, extension));
     }
 
-    const seen_paths = new Set();
-    return media_paths.filter(media_path => {
-        const normalized_path = normalizePathForComparison(media_path);
-        if (seen_paths.has(normalized_path)) return false;
-        seen_paths.add(normalized_path);
-        return true;
-    });
+    return uniqueNormalizedPaths(media_paths);
 }
 
 async function getFileDirectoriesToCheck(user_uid = null) {
@@ -67,16 +79,67 @@ async function getFileDirectoriesToCheck(user_uid = null) {
     return dirs_to_check.filter(dir_to_check => dir_to_check.user_uid === user_uid);
 }
 
-async function getRegisteredFilePathSet(user_uid = null) {
+async function getRegisteredFilePathSummary(user_uid = null) {
     const filter_obj = {};
     if (shouldRestrictToUser(user_uid)) filter_obj['user_uid'] = user_uid;
 
     const all_files = await db_api.getRecords('files', filter_obj);
-    return new Set(
-        all_files
-            .filter(file_obj => file_obj && file_obj.path)
-            .map(file_obj => normalizePathForComparison(file_obj.path))
-    );
+    const registered_paths = new Set();
+    const registered_base_paths = new Set();
+
+    all_files
+        .filter(file_obj => file_obj && file_obj.path)
+        .forEach(file_obj => {
+            registered_paths.add(normalizePathForComparison(file_obj.path));
+            const normalized_base_path = normalizeMediaBasePath(file_obj.path);
+            if (normalized_base_path) registered_base_paths.add(normalized_base_path);
+        });
+
+    return {
+        paths: registered_paths,
+        base_paths: registered_base_paths
+    };
+}
+
+async function getRegisteredFilePathSet(user_uid = null) {
+    return (await getRegisteredFilePathSummary(user_uid)).paths;
+}
+
+function getSidecarMediaBasePath(sidecar_path, type) {
+    if (typeof sidecar_path !== 'string' || sidecar_path.trim() === '') return null;
+
+    const normalized_sidecar_path = normalizePathForComparison(sidecar_path);
+    const lower_sidecar_path = normalized_sidecar_path.toLowerCase();
+    const managed_media_extensions = getMediaExtensions(type).map(extension => `.${extension}`);
+
+    if (lower_sidecar_path.endsWith('.info.json')) {
+        const path_before_info_suffix = normalized_sidecar_path.substring(0, normalized_sidecar_path.length - '.info.json'.length);
+        const path_before_info_extension = path.extname(path_before_info_suffix).toLowerCase();
+        return managed_media_extensions.includes(path_before_info_extension)
+            ? normalizeMediaBasePath(path_before_info_suffix)
+            : normalizePathForComparison(path_before_info_suffix);
+    }
+
+    const subtitle_sidecar_match = normalized_sidecar_path.match(/\.player-subtitles(?:\.\d+)?\.vtt$/i);
+    if (subtitle_sidecar_match) {
+        return normalizePathForComparison(normalized_sidecar_path.substring(0, normalized_sidecar_path.length - subtitle_sidecar_match[0].length));
+    }
+
+    if (MANAGED_SIDECAR_EXTENSIONS.includes(path.extname(normalized_sidecar_path).toLowerCase())) {
+        return normalizeMediaBasePath(normalized_sidecar_path);
+    }
+
+    return null;
+}
+
+async function getDownloadedSidecarPathsByType(basePath, type) {
+    const sidecar_paths = [];
+    for (const extension of SIDECAR_SCAN_EXTENSIONS) {
+        sidecar_paths.push(...await utils.recFindByExt(basePath, extension));
+    }
+
+    return uniqueNormalizedPaths(sidecar_paths)
+        .filter(sidecar_path => getSidecarMediaBasePath(sidecar_path, type));
 }
 
 function getSidecarCandidatePaths(file_path, type) {
@@ -135,23 +198,103 @@ async function getExistingSidecarPaths(file_path, type) {
     return existing_paths;
 }
 
-async function deleteMediaAndSidecars(file_path, type) {
-    const sidecar_paths = await getExistingSidecarPaths(file_path, type);
+async function deleteSidecarPaths(sidecar_paths = []) {
+    const unique_sidecar_paths = uniqueNormalizedPaths(sidecar_paths);
 
-    for (const sidecar_path of sidecar_paths) {
-        await fs.unlink(sidecar_path);
+    for (const sidecar_path of unique_sidecar_paths) {
+        await fs.remove(sidecar_path);
     }
 
-    if (await fs.pathExists(file_path)) {
-        await fs.unlink(file_path);
-    }
-
-    if (await fs.pathExists(file_path)) return false;
-    for (const sidecar_path of sidecar_paths) {
+    for (const sidecar_path of unique_sidecar_paths) {
         if (await fs.pathExists(sidecar_path)) return false;
     }
 
     return true;
+}
+
+async function deleteMediaAndSidecars(file_path, type, additional_sidecar_paths = []) {
+    const sidecar_paths = uniqueNormalizedPaths([
+        ...await getExistingSidecarPaths(file_path, type),
+        ...additional_sidecar_paths
+    ]);
+
+    const sidecars_deleted = await deleteSidecarPaths(sidecar_paths);
+
+    if (await fs.pathExists(file_path)) {
+        await fs.remove(file_path);
+    }
+
+    if (await fs.pathExists(file_path)) return false;
+    return sidecars_deleted;
+}
+
+async function getCandidateMediaPathsForFileObject(file_obj = null, type = 'video') {
+    if (!file_obj || !file_obj.path) return [];
+
+    const expected_extension = getExpectedMediaExtension(type);
+    const basename_candidates = new Set();
+    const relative_path_candidates = new Set();
+    const direct_candidates = uniqueNormalizedPaths([
+        file_obj.path,
+        utils.getTrueFileName(file_obj.path, type)
+    ]);
+
+    for (const direct_candidate of direct_candidates) {
+        basename_candidates.add(path.basename(direct_candidate));
+    }
+
+    if (file_obj.id) {
+        basename_candidates.add(`${path.basename(file_obj.id)}${expected_extension}`);
+        const id_relative_path = path.normalize(`${file_obj.id}${expected_extension}`);
+        if (!path.isAbsolute(id_relative_path) && !id_relative_path.startsWith('..')) {
+            relative_path_candidates.add(id_relative_path);
+        }
+    }
+
+    const directory_candidates = [];
+    const dirs_to_check = await getFileDirectoriesToCheck(file_obj.user_uid);
+    for (const dir_to_check of dirs_to_check) {
+        if (dir_to_check.type !== type) continue;
+        if (file_obj.sub_id && dir_to_check.sub_id !== file_obj.sub_id) continue;
+        if (!file_obj.sub_id && dir_to_check.sub_id) continue;
+
+        for (const basename_candidate of basename_candidates) {
+            directory_candidates.push(path.join(dir_to_check.basePath, basename_candidate));
+        }
+        for (const relative_path_candidate of relative_path_candidates) {
+            directory_candidates.push(path.join(dir_to_check.basePath, relative_path_candidate));
+        }
+    }
+
+    return uniqueNormalizedPaths([
+        ...direct_candidates,
+        ...directory_candidates
+    ]);
+}
+
+async function resolveExistingMediaPathForFileObject(file_obj = null, type = 'video') {
+    const candidate_paths = await getCandidateMediaPathsForFileObject(file_obj, type);
+    const existing_paths = [];
+
+    for (const candidate_path of candidate_paths) {
+        if (await fs.pathExists(candidate_path)) {
+            existing_paths.push(normalizePathForComparison(candidate_path));
+        }
+    }
+
+    if (existing_paths.length === 0) return file_obj && file_obj.path ? file_obj.path : null;
+
+    const normalized_original_path = normalizePathForComparison(file_obj.path);
+    if (existing_paths.includes(normalized_original_path)) return file_obj.path;
+
+    const unique_existing_paths = [...new Set(existing_paths)];
+    if (unique_existing_paths.length === 1) {
+        logger.warn(`Resolved stale DB path '${file_obj.path}' to existing media file '${unique_existing_paths[0]}' before deletion.`);
+        return unique_existing_paths[0];
+    }
+
+    logger.warn(`Could not safely resolve stale DB path '${file_obj.path}' because multiple matching files exist.`);
+    return file_obj.path;
 }
 
 function normalizeChapter(raw_chapter) {
@@ -1010,8 +1153,12 @@ exports.calculatePlaylistDuration = async (playlist, playlist_file_objs = null) 
 exports.deleteFileObject = async (file_obj, blacklistMode = false) => {
     if (!file_obj) return false;
     const type = file_obj.isAudio ? 'audio' : 'video';
-    const sidecarPaths = await getExistingSidecarPaths(file_obj.path, type);
-    let fileExists = await fs.pathExists(file_obj.path);
+    const media_path_to_delete = await resolveExistingMediaPathForFileObject(file_obj, type);
+    if (!media_path_to_delete) return false;
+    const sidecarPaths = uniqueNormalizedPaths([
+        ...await getExistingSidecarPaths(media_path_to_delete, type),
+        ...(media_path_to_delete !== file_obj.path ? await getExistingSidecarPaths(file_obj.path, type) : [])
+    ]);
 
     if (config_api.descriptors[file_obj.uid]) {
         try {
@@ -1027,7 +1174,7 @@ exports.deleteFileObject = async (file_obj, blacklistMode = false) => {
     if (useYoutubeDLArchive || file_obj.sub_id) {
         // get id/extractor from JSON
 
-        const info_json = utils.getJSON(file_obj.path, type);
+        const info_json = utils.getJSON(media_path_to_delete, type) || utils.getJSON(file_obj.path, type);
         let retrievedID = null;
         let retrievedExtractor = null;
         if (info_json) {
@@ -1048,26 +1195,14 @@ exports.deleteFileObject = async (file_obj, blacklistMode = false) => {
         }
     }
 
-    for (const sidecarPath of sidecarPaths) {
-        await fs.unlink(sidecarPath);
-    }
+    const deleted = await deleteMediaAndSidecars(media_path_to_delete, type, sidecarPaths);
+    if (!deleted) return false;
 
     if (file_obj.uid) {
         await db_api.removeRecord('files', {uid: file_obj.uid});
     }
 
-    if (fileExists) {
-        await fs.unlink(file_obj.path);
-        const sidecarsStillExist = (await Promise.all(sidecarPaths.map(sidecarPath => fs.pathExists(sidecarPath)))).some(Boolean);
-        if (sidecarsStillExist || await fs.pathExists(file_obj.path)) {
-            return false;
-        } else {
-            return true;
-        }
-    } else {
-        // TODO: tell user that the file didn't exist
-        return true;
-    }
+    return true;
 }
 
 exports.deleteFile = async (uid, blacklistMode = false, user_uid = null) => {
@@ -1116,22 +1251,42 @@ exports.deleteFilesInBatches = async (uids = [], blacklistMode = false, user_uid
 
 exports.deleteOrphanFiles = async (user_uid = null) => {
     const dirs_to_check = await getFileDirectoriesToCheck(user_uid);
-    const registered_file_paths = await getRegisteredFilePathSet(user_uid);
+    const registered_file_path_summary = await getRegisteredFilePathSummary(user_uid);
+    const registered_file_paths = registered_file_path_summary.paths;
+    const registered_file_base_paths = registered_file_path_summary.base_paths;
     const orphan_files = [];
+    const orphan_media_base_paths = new Set();
+    const orphan_sidecar_groups = new Map();
 
     for (const dir_to_check of dirs_to_check) {
         const files = await getDownloadedMediaPathsByType(dir_to_check.basePath, dir_to_check.type);
         for (const file_path of files) {
             if (!registered_file_paths.has(normalizePathForComparison(file_path))) {
+                const media_base_path = normalizeMediaBasePath(file_path);
+                if (media_base_path) orphan_media_base_paths.add(media_base_path);
                 orphan_files.push({
                     path: file_path,
                     type: dir_to_check.type
                 });
             }
         }
+
+        const sidecar_paths = await getDownloadedSidecarPathsByType(dir_to_check.basePath, dir_to_check.type);
+        for (const sidecar_path of sidecar_paths) {
+            const media_base_path = getSidecarMediaBasePath(sidecar_path, dir_to_check.type);
+            if (!media_base_path) continue;
+            if (orphan_media_base_paths.has(media_base_path)) continue;
+            if (registered_file_base_paths.has(media_base_path)) continue;
+
+            if (!orphan_sidecar_groups.has(media_base_path)) {
+                orphan_sidecar_groups.set(media_base_path, []);
+            }
+            orphan_sidecar_groups.get(media_base_path).push(sidecar_path);
+        }
     }
 
-    if (orphan_files.length === 0) return {deleted_count: 0, failed_count: 0};
+    const orphan_sidecar_group_paths = [...orphan_sidecar_groups.values()];
+    if (orphan_files.length === 0 && orphan_sidecar_group_paths.length === 0) return {deleted_count: 0, failed_count: 0};
 
     let deleted_count = 0;
     let failed_count = 0;
@@ -1139,6 +1294,21 @@ exports.deleteOrphanFiles = async (user_uid = null) => {
         const batch_orphan_files = orphan_files.slice(i, i + PLAYLIST_FILE_DELETE_BATCH_SIZE);
         const batch_results = await Promise.allSettled(
             batch_orphan_files.map(orphan_file => deleteMediaAndSidecars(orphan_file.path, orphan_file.type))
+        );
+
+        for (const result of batch_results) {
+            if (result.status === 'fulfilled' && result.value) {
+                deleted_count += 1;
+            } else {
+                failed_count += 1;
+            }
+        }
+    }
+
+    for (let i = 0; i < orphan_sidecar_group_paths.length; i += PLAYLIST_FILE_DELETE_BATCH_SIZE) {
+        const batch_orphan_sidecar_groups = orphan_sidecar_group_paths.slice(i, i + PLAYLIST_FILE_DELETE_BATCH_SIZE);
+        const batch_results = await Promise.allSettled(
+            batch_orphan_sidecar_groups.map(sidecar_paths => deleteSidecarPaths(sidecar_paths))
         );
 
         for (const result of batch_results) {

--- a/backend/test/downloader.test.js
+++ b/backend/test/downloader.test.js
@@ -703,6 +703,49 @@ describe('Downloader', function() {
         }
     });
 
+    it('Collect info keeps category custom output relative to the download folder', async function() {
+        const original_get_video_info = downloader_api.getVideoInfoByURL;
+        const custom_output = path.join('categorized', '%(title)s');
+        const expected_output_template = `${path.join(config_api.getConfigItem('ytdl_video_folder_path'), custom_output)}.%(ext)s`;
+
+        try {
+            await db_api.removeAllRecords('categories');
+            await db_api.insertRecordIntoTable('categories', {
+                name: 'categorized',
+                uid: uuid(),
+                rules: [{
+                    preceding_operator: null,
+                    comparator: 'includes',
+                    property: 'title',
+                    value: fixture_single[0].title
+                }],
+                custom_output: custom_output
+            });
+
+            downloader_api.getVideoInfoByURL = async (requestedUrl, requested_args = []) => {
+                const output_arg_index = requested_args.indexOf('-o');
+                const output_template = output_arg_index >= 0 ? requested_args[output_arg_index + 1] : fixture_single[0]._filename;
+                return [{
+                    ...fixture_single[0],
+                    _filename: output_template
+                        .replace('%(title)s', fixture_single[0].title)
+                        .replace('%(ext)s', 'mp4')
+                }];
+            };
+
+            const returned_download = await downloader_api.createDownload(url, 'video', {ui_uid: uuid()});
+            await downloader_api.collectInfo(returned_download['uid']);
+            const updated_download = await db_api.getRecord('download_queue', {uid: returned_download['uid']});
+            const output_arg_index = updated_download.args.indexOf('-o');
+
+            assert(output_arg_index >= 0);
+            assert.strictEqual(updated_download.args[output_arg_index + 1], expected_output_template);
+        } finally {
+            downloader_api.getVideoInfoByURL = original_get_video_info;
+            await db_api.removeAllRecords('categories');
+        }
+    });
+
     it('Collect info filters duplicate playlist items down to remaining playlist indices', async function() {
         const original_get_video_info = downloader_api.getVideoInfoByURL;
         const original_find_existing_duplicate = files_api.findExistingDuplicateByInfo;

--- a/backend/test/files.test.js
+++ b/backend/test/files.test.js
@@ -125,6 +125,48 @@ describe('Files', function() {
         }
     });
 
+    it('deleteFileObject removes media from disk when the DB path is stale', async function() {
+        const original_get_file_directories = db_api.getFileDirectoriesAndDBs;
+        const original_remove_record = db_api.removeRecord;
+        const actual_file_path = path.join(fixture_dir, 'stale-video.mp4');
+        const stale_file_path = path.join(fixture_dir, 'old-location', 'stale-video.mp4');
+        const actual_info_path = path.join(fixture_dir, 'stale-video.info.json');
+        const actual_thumbnail_path = path.join(fixture_dir, 'stale-video.webp');
+        let removed_filter = null;
+
+        try {
+            await fs.writeFile(actual_file_path, 'fixture');
+            await fs.writeFile(actual_info_path, '{}');
+            await fs.writeFile(actual_thumbnail_path, 'thumbnail');
+            db_api.getFileDirectoriesAndDBs = async () => [{
+                basePath: fixture_dir,
+                type: 'video'
+            }];
+            db_api.removeRecord = async (table, filter_obj) => {
+                assert.strictEqual(table, 'files');
+                removed_filter = filter_obj;
+                return true;
+            };
+
+            const output = await files_api.deleteFileObject({
+                uid: 'stale-file',
+                id: 'stale-video',
+                path: stale_file_path,
+                isAudio: false,
+                title: 'Stale video'
+            });
+
+            assert.strictEqual(output, true);
+            assert.deepStrictEqual(removed_filter, {uid: 'stale-file'});
+            assert.strictEqual(await fs.pathExists(actual_file_path), false);
+            assert.strictEqual(await fs.pathExists(actual_info_path), false);
+            assert.strictEqual(await fs.pathExists(actual_thumbnail_path), false);
+        } finally {
+            db_api.getFileDirectoriesAndDBs = original_get_file_directories;
+            db_api.removeRecord = original_remove_record;
+        }
+    });
+
     it('deleteFilesInBatches deduplicates playlist files and caps batch concurrency', async function() {
         const original_get_videos_by_uids = files_api.getVideosByUIDs;
         const original_delete_file_object = files_api.deleteFileObject;
@@ -224,6 +266,39 @@ describe('Files', function() {
             assert.strictEqual(await fs.pathExists(orphan_thumbnail_path), false);
             assert.strictEqual(await fs.pathExists(orphan_subtitle_path), false);
             assert.strictEqual(await fs.pathExists(registered_file_path), true);
+        } finally {
+            db_api.getFileDirectoriesAndDBs = original_get_file_directories;
+            db_api.getRecords = original_get_records;
+        }
+    });
+
+    it('deleteOrphanFiles removes sidecar-only orphan groups from disk', async function() {
+        const original_get_file_directories = db_api.getFileDirectoriesAndDBs;
+        const original_get_records = db_api.getRecords;
+        const sidecar_info_path = path.join(fixture_dir, 'sidecar-only.info.json');
+        const sidecar_thumbnail_path = path.join(fixture_dir, 'sidecar-only.webp');
+        const sidecar_subtitle_path = files_api.getSubtitleSidecarPath(path.join(fixture_dir, 'sidecar-only.mp4'));
+
+        try {
+            await fs.writeFile(sidecar_info_path, '{}');
+            await fs.writeFile(sidecar_thumbnail_path, 'thumbnail');
+            await fs.writeFile(sidecar_subtitle_path, 'WEBVTT');
+
+            db_api.getFileDirectoriesAndDBs = async () => [{
+                basePath: fixture_dir,
+                type: 'video'
+            }];
+            db_api.getRecords = async (table) => {
+                assert.strictEqual(table, 'files');
+                return [];
+            };
+
+            const output = await files_api.deleteOrphanFiles();
+
+            assert.deepStrictEqual(output, {deleted_count: 1, failed_count: 0});
+            assert.strictEqual(await fs.pathExists(sidecar_info_path), false);
+            assert.strictEqual(await fs.pathExists(sidecar_thumbnail_path), false);
+            assert.strictEqual(await fs.pathExists(sidecar_subtitle_path), false);
         } finally {
             db_api.getFileDirectoriesAndDBs = original_get_file_directories;
             db_api.getRecords = original_get_records;


### PR DESCRIPTION
## Summary
- resolve stale DB paths before deleting media so disk files from moved/deleted playlist entries are actually removed
- sweep orphan sidecar groups, including info JSON, thumbnails, NFO, and player subtitle files
- keep category custom outputs relative to configured download folders so files stay inside managed scan paths

## Tests
- npm test --prefix backend
- node --check backend/downloader.js backend/files.js backend/test/downloader.test.js backend/test/files.test.js
- npm run lint
- npx tsc -p src/tsconfig.app.json --noEmit
- npx tsc -p src/tsconfig.spec.json --noEmit
- CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npm run test:headless
- npx ng build --configuration production

Note: production build still emits the existing CommonJS warning for file-saver.