### PR TITLE
fix(files): scan legacy orphan paths

### DIFF
--- a/backend/files.js
+++ b/backend/files.js
@@ -74,9 +74,59 @@ async function getDownloadedMediaPathsByType(basePath, type) {
 }
 
 async function getFileDirectoriesToCheck(user_uid = null) {
-    const dirs_to_check = await db_api.getFileDirectoriesAndDBs();
+    return await getFileDirectoriesToCheckWithOptions(user_uid);
+}
+
+function getLegacySingleUserDirectories() {
+    return [
+        {
+            basePath: config_api.getConfigItem('ytdl_audio_folder_path'),
+            type: 'audio',
+            legacy_single_user: true
+        },
+        {
+            basePath: config_api.getConfigItem('ytdl_video_folder_path'),
+            type: 'video',
+            legacy_single_user: true
+        }
+    ];
+}
+
+function isUnassignedDirectory(dir_to_check = null) {
+    return !!dir_to_check && (dir_to_check.user_uid === null || dir_to_check.user_uid === undefined);
+}
+
+function getDirectoryDeduplicationKey(dir_to_check = {}) {
+    return [
+        normalizePathForComparison(dir_to_check.basePath || ''),
+        dir_to_check.type || ''
+    ].join('\u0000');
+}
+
+function deduplicateDirectories(dirs_to_check = []) {
+    const seen_directories = new Set();
+    return dirs_to_check.filter(dir_to_check => {
+        if (!dir_to_check || !dir_to_check.basePath || !dir_to_check.type) return false;
+        const directory_key = getDirectoryDeduplicationKey(dir_to_check);
+        if (seen_directories.has(directory_key)) return false;
+        seen_directories.add(directory_key);
+        return true;
+    });
+}
+
+async function getFileDirectoriesToCheckWithOptions(user_uid = null, options = {}) {
+    let dirs_to_check = await db_api.getFileDirectoriesAndDBs();
+    if (options.include_legacy_single_user_dirs && config_api.getConfigItem('ytdl_multi_user_mode')) {
+        dirs_to_check = dirs_to_check.concat(getLegacySingleUserDirectories());
+    }
+
+    dirs_to_check = deduplicateDirectories(dirs_to_check);
     if (!shouldRestrictToUser(user_uid)) return dirs_to_check;
-    return dirs_to_check.filter(dir_to_check => dir_to_check.user_uid === user_uid);
+
+    return dirs_to_check.filter(dir_to_check => {
+        if (dir_to_check.user_uid === user_uid) return true;
+        return options.include_unassigned_dirs && isUnassignedDirectory(dir_to_check);
+    });
 }
 
 async function getRegisteredFilePathSummary(user_uid = null) {
@@ -1250,7 +1300,10 @@ exports.deleteFilesInBatches = async (uids = [], blacklistMode = false, user_uid
 }
 
 exports.deleteOrphanFiles = async (user_uid = null) => {
-    const dirs_to_check = await getFileDirectoriesToCheck(user_uid);
+    const dirs_to_check = await getFileDirectoriesToCheckWithOptions(user_uid, {
+        include_legacy_single_user_dirs: true,
+        include_unassigned_dirs: true
+    });
     const registered_file_path_summary = await getRegisteredFilePathSummary(user_uid);
     const registered_file_paths = registered_file_path_summary.paths;
     const registered_file_base_paths = registered_file_path_summary.base_paths;

--- a/backend/test/files.test.js
+++ b/backend/test/files.test.js
@@ -305,6 +305,74 @@ describe('Files', function() {
         }
     });
 
+    it('deleteOrphanFiles scans legacy single-user and unassigned subscription dirs in multi-user mode', async function() {
+        const original_get_file_directories = db_api.getFileDirectoriesAndDBs;
+        const original_get_records = db_api.getRecords;
+        const original_multi_user_mode = config_api.getConfigItem('ytdl_multi_user_mode');
+        const original_audio_folder_path = config_api.getConfigItem('ytdl_audio_folder_path');
+        const original_video_folder_path = config_api.getConfigItem('ytdl_video_folder_path');
+        const legacy_audio_dir = path.join(fixture_dir, 'legacy-audio');
+        const legacy_video_dir = path.join(fixture_dir, 'legacy-video');
+        const user_video_dir = path.join(fixture_dir, 'users', 'user-1', 'video');
+        const other_user_video_dir = path.join(fixture_dir, 'users', 'user-2', 'video');
+        const unassigned_subscription_dir = path.join(fixture_dir, 'subscriptions', 'playlists', 'deleted-playlist');
+        const legacy_orphan_path = path.join(legacy_video_dir, 'legacy-orphan.mp4');
+        const legacy_info_path = path.join(legacy_video_dir, 'legacy-orphan.info.json');
+        const subscription_orphan_path = path.join(unassigned_subscription_dir, 'subscription-orphan.mp4');
+        const registered_user_path = path.join(user_video_dir, 'registered-user-video.mp4');
+        const other_user_path = path.join(other_user_video_dir, 'other-user-video.mp4');
+
+        try {
+            config_api.setConfigItem('ytdl_multi_user_mode', true);
+            config_api.setConfigItem('ytdl_audio_folder_path', legacy_audio_dir);
+            config_api.setConfigItem('ytdl_video_folder_path', legacy_video_dir);
+            await fs.outputFile(legacy_orphan_path, 'legacy orphan media');
+            await fs.outputFile(legacy_info_path, '{}');
+            await fs.outputFile(subscription_orphan_path, 'subscription orphan media');
+            await fs.outputFile(registered_user_path, 'registered user media');
+            await fs.outputFile(other_user_path, 'other user media');
+
+            db_api.getFileDirectoriesAndDBs = async () => [
+                {
+                    basePath: user_video_dir,
+                    user_uid: 'user-1',
+                    type: 'video'
+                },
+                {
+                    basePath: other_user_video_dir,
+                    user_uid: 'user-2',
+                    type: 'video'
+                },
+                {
+                    basePath: unassigned_subscription_dir,
+                    user_uid: undefined,
+                    type: 'video',
+                    sub_id: 'deleted-playlist'
+                }
+            ];
+            db_api.getRecords = async (table, filter_obj) => {
+                assert.strictEqual(table, 'files');
+                assert.deepStrictEqual(filter_obj, {user_uid: 'user-1'});
+                return [{uid: 'registered-user-video', path: registered_user_path, user_uid: 'user-1'}];
+            };
+
+            const output = await files_api.deleteOrphanFiles('user-1');
+
+            assert.deepStrictEqual(output, {deleted_count: 2, failed_count: 0});
+            assert.strictEqual(await fs.pathExists(legacy_orphan_path), false);
+            assert.strictEqual(await fs.pathExists(legacy_info_path), false);
+            assert.strictEqual(await fs.pathExists(subscription_orphan_path), false);
+            assert.strictEqual(await fs.pathExists(registered_user_path), true);
+            assert.strictEqual(await fs.pathExists(other_user_path), true);
+        } finally {
+            config_api.setConfigItem('ytdl_multi_user_mode', original_multi_user_mode);
+            config_api.setConfigItem('ytdl_audio_folder_path', original_audio_folder_path);
+            config_api.setConfigItem('ytdl_video_folder_path', original_video_folder_path);
+            db_api.getFileDirectoriesAndDBs = original_get_file_directories;
+            db_api.getRecords = original_get_records;
+        }
+    });
+
     it('importUnregisteredFiles imports loose media files without info JSON', async function() {
         const original_get_file_directories = db_api.getFileDirectoriesAndDBs;
         const loose_file_path = path.join(fixture_dir, 'loose-import.mp4');


### PR DESCRIPTION
## Summary
- include legacy single-user audio/video directories when deleting orphan files in multi-user mode
- include unassigned legacy directories during orphan cleanup so old migrated/playlist remnants can be removed
- add a regression covering legacy root media, unassigned subscription media, current user media, and another user's media

## Tests
- npm test --prefix backend -- --grep "deleteOrphanFiles"
- npm test --prefix backend
- node --check backend/files.js && node --check backend/test/files.test.js
- npm run lint
- npx tsc -p src/tsconfig.app.json --noEmit
- npx tsc -p src/tsconfig.spec.json --noEmit
- CHROMIUM_BIN="/usr/bin/chromium" npm run test:headless
- npx ng build --configuration production