### PR TITLE
fix(downloads): resume paused mid-step downloads

### DIFF
--- a/backend/downloader.js
+++ b/backend/downloader.js
@@ -1373,7 +1373,7 @@ exports.pauseDownload = async (download_uid) => {
     }
 
     killActiveDownload(download);
-    return await db_api.updateRecord('download_queue', {uid: download_uid}, {paused: true, running: false});
+    return await db_api.updateRecord('download_queue', {uid: download_uid}, getPausedDownloadUpdate(download));
 }
 
 exports.resumeDownload = async (download_uid) => {
@@ -1384,7 +1384,7 @@ exports.resumeDownload = async (download_uid) => {
             return false;
         }
 
-        const success = db_api.updateRecord('download_queue', {uid: download_uid}, {paused: false});
+        const success = await db_api.updateRecord('download_queue', {uid: download_uid}, getResumedDownloadUpdate(download));
         should_check_downloads = true;
         return success;
     })
@@ -1504,15 +1504,34 @@ async function fixDownloadState() {
     downloads.sort((download1, download2) => download1.timestamp_start - download2.timestamp_start);
     const running_downloads = downloads.filter(download => download['running'] && !download['finished'] && !download['error']);
     for (let i = 0; i < running_downloads.length; i++) {
-        const running_download = running_downloads[i];
-        const update_obj = {finished_step: true, paused: true, running: false};
-        if (running_download['step_index'] > 0) {
-            update_obj['step_index'] = running_download['step_index'] - 1;
-        }
-        await db_api.updateRecord('download_queue', {uid: running_download['uid']}, update_obj);
+        await db_api.updateRecord('download_queue', {uid: running_downloads[i]['uid']}, getPausedDownloadUpdate(running_downloads[i]));
     }
 }
 exports.fixDownloadState = fixDownloadState;
+
+function getRetryableDownloadStepUpdate(download) {
+    const update_obj = {finished_step: true, running: false};
+    if (download['step_index'] > 0) {
+        update_obj['step_index'] = download['step_index'] - 1;
+    }
+    return update_obj;
+}
+
+function getPausedDownloadUpdate(download) {
+    const update_obj = {paused: true, running: false};
+    if (download['running'] || !download['finished_step']) {
+        Object.assign(update_obj, getRetryableDownloadStepUpdate(download));
+    }
+    return update_obj;
+}
+
+function getResumedDownloadUpdate(download) {
+    const update_obj = {paused: false};
+    if (download['running'] || !download['finished_step']) {
+        Object.assign(update_obj, getRetryableDownloadStepUpdate(download));
+    }
+    return update_obj;
+}
 
 async function checkDownloads() {
     if (!should_check_downloads) return;

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@discordjs/builders": "^1.14.1",
         "@discordjs/core": "^2.4.0",
-        "@scalar/express-api-reference": "^0.9.12",
+        "@scalar/express-api-reference": "^0.9.13",
         "archiver": "^7.0.1",
         "async": "^3.2.3",
         "async-mutex": "^0.5.0",
@@ -407,45 +407,45 @@
       }
     },
     "node_modules/@scalar/client-side-rendering": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@scalar/client-side-rendering/-/client-side-rendering-0.1.5.tgz",
-      "integrity": "sha512-XZ+lZbVli1rAX8Y13sQqisvbjVhkbePVeo0izJZ4cNzpzSh7fDpigEqpV67u4ljpTpLO0B12JDXR5xnmSy+YwQ==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@scalar/client-side-rendering/-/client-side-rendering-0.1.6.tgz",
+      "integrity": "sha512-ooc5RKyi83EvBuxB2N8H00ZE2CF4oKynuUToSCaoqxkjv+oJ6B3+OYsb0HVixznsyWhUDdtQZm4/xOb0kxBaaA==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/types": "0.9.4"
+        "@scalar/types": "0.9.5"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/express-api-reference": {
-      "version": "0.9.12",
-      "resolved": "https://registry.npmjs.org/@scalar/express-api-reference/-/express-api-reference-0.9.12.tgz",
-      "integrity": "sha512-4YdtRoHUIeFj82hqfhx6s1Mx2L/7j5ibU3VuPn3tGneHxxyGPl9c+bZrmRniyH27PqUihYiE0fwe3sBuNG26Aw==",
+      "version": "0.9.13",
+      "resolved": "https://registry.npmjs.org/@scalar/express-api-reference/-/express-api-reference-0.9.13.tgz",
+      "integrity": "sha512-QjmHpqKxsVxYqtlS1FkSHrK1AtLzsQRvAwwxTan+hH2c/xJ00hSjXCeDEyUnmy6UF5J+B2GuuyKEOWsFv0ApzA==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/client-side-rendering": "0.1.5"
+        "@scalar/client-side-rendering": "0.1.6"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/helpers": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.5.4.tgz",
-      "integrity": "sha512-AJFJNoSVcCHXDPH1Mosie+5+AOpNC4zrtwWywvQEhcaqHfiH4LSq8Og8Bay82M/jhCwNRNjWfGOGcaCE4XbCDw==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.5.5.tgz",
+      "integrity": "sha512-TqbErkqGijJJW6Ad8lpswHFTmlJaYFt9oolaWF1/Nn9171xdkK9ZDAk3pCaOCWs8WpwvcbUSxIVD8JxdBg0MFg==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/types": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.9.4.tgz",
-      "integrity": "sha512-nspIWRUVPv2uf9d0bBxn2uqKcEVbLqoUqKvNAuBgKMinZ95XSMcGjQjsgqDiRBPsn1luTtjC9xupUFfer7kLtg==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.9.5.tgz",
+      "integrity": "sha512-joen5nuqgmGzgXK5XIqkGs0JmCZ16djaw+pgC24sfb+p3sSPVfKQTNTil/RuvHMNsmA/dFcQ6GI0Y3HhTlUQrg==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.5.4",
+        "@scalar/helpers": "0.5.5",
         "nanoid": "^5.1.6",
         "type-fest": "^5.3.1",
         "zod": "^4.3.5"
@@ -3490,9 +3490,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
-      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
+      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
       "funding": [
         {
           "type": "github",

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@discordjs/builders": "^1.14.1",
     "@discordjs/core": "^2.4.0",
-    "@scalar/express-api-reference": "^0.9.12",
+    "@scalar/express-api-reference": "^0.9.13",
     "archiver": "^7.0.1",
     "async": "^3.2.3",
     "async-mutex": "^0.5.0",

--- a/backend/test/downloader.test.js
+++ b/backend/test/downloader.test.js
@@ -1695,6 +1695,41 @@ describe('Downloader', function() {
         assert(updated_download['paused'] && !updated_download['running']);
     });
 
+    it('Pausing an active queue step makes it resumable from the previous step', async function() {
+        const returned_download = await downloader_api.createDownload(`${url}&pause_mid_step=1`, 'video', options);
+        await db_api.updateRecord('download_queue', {uid: returned_download['uid']}, {
+            step_index: 2,
+            finished_step: false,
+            running: true
+        });
+
+        await downloader_api.pauseDownload(returned_download['uid']);
+
+        const updated_download = await db_api.getRecord('download_queue', {uid: returned_download['uid']});
+        assert.strictEqual(updated_download['paused'], true);
+        assert.strictEqual(updated_download['running'], false);
+        assert.strictEqual(updated_download['finished_step'], true);
+        assert.strictEqual(updated_download['step_index'], 1);
+    });
+
+    it('Resume repairs legacy paused downloads interrupted mid-step', async function() {
+        const returned_download = await downloader_api.createDownload(`${url}&legacy_paused_mid_step=1`, 'video', options);
+        await db_api.updateRecord('download_queue', {uid: returned_download['uid']}, {
+            paused: true,
+            step_index: 2,
+            finished_step: false,
+            running: false
+        });
+
+        await downloader_api.resumeDownload(returned_download['uid']);
+
+        const updated_download = await db_api.getRecord('download_queue', {uid: returned_download['uid']});
+        assert.strictEqual(updated_download['paused'], false);
+        assert.strictEqual(updated_download['running'], false);
+        assert.strictEqual(updated_download['finished_step'], true);
+        assert.strictEqual(updated_download['step_index'], 1);
+    });
+
     it('Generate args', async function() {
         const args = await downloader_api.generateArgs(url, 'video', options);
         assert(args.length > 0);

--- a/src/app/components/downloads/downloads.component.spec.ts
+++ b/src/app/components/downloads/downloads.component.spec.ts
@@ -17,6 +17,8 @@ describe('DownloadsComponent', () => {
       initialized: true,
       service_initialized: of(true),
       getCurrentDownloads: jasmine.createSpy('getCurrentDownloads').and.returnValue(of({downloads: []})),
+      pauseDownload: jasmine.createSpy('pauseDownload').and.returnValue(of({success: true})),
+      resumeDownload: jasmine.createSpy('resumeDownload').and.returnValue(of({success: true})),
       restartDownload: jasmine.createSpy('restartDownload').and.returnValue(of({success: true})),
       openSnackBar: jasmine.createSpy('openSnackBar')
     };
@@ -116,6 +118,34 @@ describe('DownloadsComponent', () => {
     component.retryFailedDownloads();
 
     expect(posts_service_mock.openSnackBar).toHaveBeenCalled();
+  });
+
+  it('shows resume instead of pause for paused downloads interrupted mid-step', () => {
+    const pause_action = component.downloadActions.find(action => action.icon === 'pause')!;
+    const resume_action = component.downloadActions.find(action => action.icon === 'play_arrow')!;
+    const interrupted_download = {
+      uid: 'paused-mid-step',
+      finished: false,
+      paused: true,
+      finished_step: false
+    } as unknown as Download;
+
+    expect(pause_action.show(interrupted_download)).toBeFalse();
+    expect(resume_action.show(interrupted_download)).toBeTrue();
+  });
+
+  it('resumes paused downloads even when their queue step needs retrying', () => {
+    const interrupted_download = {
+      uid: 'paused-mid-step',
+      finished: false,
+      paused: true,
+      finished_step: false
+    } as unknown as Download;
+
+    component.resumeDownload(interrupted_download);
+
+    expect(posts_service_mock.resumeDownload).toHaveBeenCalledOnceWith('paused-mid-step');
+    expect(posts_service_mock.pauseDownload).not.toHaveBeenCalled();
   });
 
   it('persists the downloads page size', () => {

--- a/src/app/components/downloads/downloads.component.ts
+++ b/src/app/components/downloads/downloads.component.ts
@@ -81,13 +81,13 @@ export class DownloadsComponent implements OnInit, OnDestroy {
     {
       tooltip: $localize`Pause`,
       action: (download: Download) => this.pauseDownload(download),
-      show: (download: Download) => !download.finished && (!download.paused || !download.finished_step),
+      show: (download: Download) => !download.finished && !download.paused,
       icon: 'pause'
     },
     {
       tooltip: $localize`Resume`,
       action: (download: Download) => this.resumeDownload(download),
-      show: (download: Download) => !download.finished && download.paused && download.finished_step,
+      show: (download: Download) => !download.finished && download.paused,
       icon: 'play_arrow'
     },
     {
@@ -223,7 +223,7 @@ export class DownloadsComponent implements OnInit, OnDestroy {
 
   pauseDownload(download: Download): void {
     const target_downloads = this.getActionTargetDownloads(download)
-      .filter(target_download => !target_download.finished && (!target_download.paused || !target_download.finished_step));
+      .filter(target_download => !target_download.finished && !target_download.paused);
     this.runSuccessActionForDownloads(
       target_downloads,
       (download_uid: string) => this.postsService.pauseDownload(download_uid),
@@ -241,7 +241,7 @@ export class DownloadsComponent implements OnInit, OnDestroy {
 
   resumeDownload(download: Download): void {
     const target_downloads = this.getActionTargetDownloads(download)
-      .filter(target_download => !target_download.finished && target_download.paused && target_download.finished_step);
+      .filter(target_download => !target_download.finished && target_download.paused);
     this.runSuccessActionForDownloads(
       target_downloads,
       (download_uid: string) => this.postsService.resumeDownload(download_uid),


### PR DESCRIPTION
## Summary
- Rewind interrupted queue steps when pausing so mid-step downloads become resumable waiting items.
- Repair legacy paused rows with `finished_step: false` when they are resumed, so Resume All can pick them back up.
- Show Resume for any paused unfinished download in the downloads manager and add frontend/backend regressions.

Closes #195

## Tests
- `npm run lint`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npm run test:headless`
- `npx ng build --configuration production`
- `node --check backend/downloader.js`
- `npx mocha test/downloader.test.js --exit -s 1000 --grep "Pausing an active queue step|Resume repairs legacy paused downloads"`