### PR TITLE
fix(downloads): restore history and notification deletion

### DIFF
--- a/Public API v1.yaml
+++ b/Public API v1.yaml
@@ -1810,6 +1810,9 @@ components:
             type: string
           description: Filters downloads with the array
           nullable: true
+        only_unfinished:
+          type: boolean
+          description: Filters downloads to unfinished queue items
     GetAllDownloadsResponse:
       type: object
       properties:

--- a/backend/app.js
+++ b/backend/app.js
@@ -2677,6 +2677,7 @@ app.get('/api/thumbnail/:path', optionalJwt, async (req, res) => {
 app.post('/api/downloads', optionalJwt, async (req, res) => {
     const user_uid = req.isAuthenticated() ? req.user.uid : null;
     const uids = req.body.uids;
+    const only_unfinished = req.body.only_unfinished === true;
     const filter_obj = getScopedFilterByUser(user_uid);
     if (Array.isArray(uids)) {
         if (uids.length === 0) {
@@ -2684,7 +2685,7 @@ app.post('/api/downloads', optionalJwt, async (req, res) => {
             return;
         }
         filter_obj['uid'] = {$in: uids};
-    } else {
+    } else if (only_unfinished) {
         filter_obj['finished'] = false;
     }
     const downloads = await db_api.getRecords('download_queue', filter_obj);
@@ -3183,9 +3184,14 @@ app.post('/api/setNotificationsToRead', optionalJwt, async (req, res) => {
 });
 
 app.post('/api/deleteNotification', optionalJwt, async (req, res) => {
-    const uid = req.isAuthenticated() ? req.user.uid : null;
+    const user_uid = req.isAuthenticated() ? req.user.uid : null;
+    const notification_uid = req.body.uid;
+    if (!notification_uid) {
+        res.send({success: false});
+        return;
+    }
 
-    const success = await db_api.removeRecord('notifications', {uid: uid});
+    const success = await db_api.removeRecord('notifications', {uid: notification_uid, user_uid: user_uid});
 
     res.send({success: success});
 });

--- a/src/api-types/models/GetAllDownloadsRequest.ts
+++ b/src/api-types/models/GetAllDownloadsRequest.ts
@@ -7,4 +7,8 @@ export type GetAllDownloadsRequest = {
      * Filters downloads with the array
      */
     uids?: Array<string> | null;
+    /**
+     * Filters downloads to unfinished queue items
+     */
+    only_unfinished?: boolean;
 };

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -93,6 +93,14 @@ describe('AppComponent', () => {
     expect(component.active_downloads.map(download => download.uid)).toEqual(['active-2', 'active-1']);
   });
 
+  it('requests only unfinished downloads for active download polling', () => {
+    posts_service_mock.getCurrentDownloads = jasmine.createSpy('getCurrentDownloads').and.returnValue(of({downloads: []}));
+
+    (component as any).refreshActiveDownloads();
+
+    expect(posts_service_mock.getCurrentDownloads).toHaveBeenCalledWith(null, true);
+  });
+
   it('does not auto-open on initial active download load', () => {
     const show_spy = spyOn<any>(component, 'showActiveDownloadsMenuTemporarily');
     (component as any).active_downloads_initialized = false;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -435,7 +435,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
       return;
     }
 
-    this.postsService.getCurrentDownloads().subscribe(res => {
+    this.postsService.getCurrentDownloads(null, true).subscribe(res => {
       const downloads = Array.isArray(res && res['downloads']) ? res['downloads'] : [];
       const completion_summary = this.detectSuccessfulCompletion(downloads);
       const active_downloads = downloads

--- a/src/app/posts.services.ts
+++ b/src/app/posts.services.ts
@@ -693,8 +693,8 @@ export class PostsService {
         return this.http.post<GetAllSubscriptionsResponse>(this.path + 'getSubscriptions', {}, this.httpOptions);
     }
 
-    getCurrentDownloads(uids: Array<string> = null) {
-        const body: GetAllDownloadsRequest = {uids: uids};
+    getCurrentDownloads(uids: Array<string> = null, only_unfinished = false) {
+        const body: GetAllDownloadsRequest = {uids: uids, only_unfinished: only_unfinished};
         return this.http.post<GetAllDownloadsResponse>(this.path + 'downloads', body, this.httpOptions);
     }
 


### PR DESCRIPTION
Fixes #198

## Summary
- restore the full Downloads page history by making unfinished-only queue filtering opt-in for the active-download poll
- delete notification drawer items by requested notification uid while preserving user scoping
- document and type the new downloads request flag

## Tests
- npm run lint
- npx tsc -p src/tsconfig.app.json --noEmit
- npx tsc -p src/tsconfig.spec.json --noEmit
- CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npm run test:headless
- npx ng build --configuration production
- node --check backend/app.js