### PR TITLE
fix(subscription): reflect skipped refresh downloads

### DIFF
--- a/Public API v1.yaml
+++ b/Public API v1.yaml
@@ -2982,6 +2982,8 @@ components:
           nullable: true
         queued_count:
           type: number
+        skipped_count:
+          type: number
         latest_item_title:
           type: string
           nullable: true

--- a/backend/downloader.js
+++ b/backend/downloader.js
@@ -47,6 +47,8 @@ const SKIPPABLE_SUBSCRIPTION_DOWNLOAD_ERROR_TEXT = [
     'this live event will begin',
     'no output received for video download'
 ];
+const SUBSCRIPTION_REFRESH_QUEUED_PHASE = 'queued';
+const SUBSCRIPTION_REFRESH_COMPLETE_PHASE = 'complete';
 let filename_sanitization_non_ytdlp_warned = false;
 let last_download_queue_start_at = 0;
 
@@ -178,6 +180,13 @@ function isSkippableSubscriptionDownloadError(error_message = '', error_type = n
 
     const normalized_message = error_message.toLowerCase();
     return SKIPPABLE_SUBSCRIPTION_DOWNLOAD_ERROR_TEXT.some(error_text => normalized_message.includes(error_text));
+}
+exports.isSkippableSubscriptionDownloadError = isSkippableSubscriptionDownloadError;
+
+function asNonNegativeInteger(value, default_value = 0) {
+    const numeric_value = Number(value);
+    if (!Number.isFinite(numeric_value)) return default_value;
+    return Math.max(0, Math.floor(numeric_value));
 }
 
 function escapeRegexCharacterClassChar(char = '') {
@@ -1444,12 +1453,48 @@ async function handleDownloadError(download_uid, error_message, error_type = nul
     await archiveSkippedSubscriptionDownload(download, error_message, error_type);
     notifications_api.sendDownloadErrorNotification(download, download['user_uid'], error_message, error_type);
     await db_api.updateRecord('download_queue', {uid: download['uid']}, {error: error_message, finished: true, running: false, error_type: error_type});
+    await updateSubscriptionRefreshStatusForSkippedDownload(download, error_message, error_type);
 }
 
 async function archiveSkippedSubscriptionDownload(download = null, error_message = '', error_type = null) {
     if (!download || !download['sub_id']) return false;
     if (!isSkippableSubscriptionDownloadError(error_message, error_type)) return false;
     return await archiveSubscriptionDownloadBySource(download, `after ${error_type || 'download failure'}`);
+}
+
+async function updateSubscriptionRefreshStatusForSkippedDownload(download = null, error_message = '', error_type = null) {
+    if (!download || !download['sub_id']) return false;
+    if (!isSkippableSubscriptionDownloadError(error_message, error_type)) return false;
+
+    const sub = await db_api.getRecord('subscriptions', {id: download['sub_id']});
+    if (!sub) return false;
+
+    const refresh_status = sub['refresh_status'] && typeof sub['refresh_status'] === 'object'
+        ? {...sub['refresh_status']}
+        : {};
+    const skipped_count = asNonNegativeInteger(refresh_status['skipped_count']) + 1;
+    const queued_count = asNonNegativeInteger(refresh_status['queued_count']);
+    const [pending_download_count, running_download_count] = await Promise.all([
+        db_api.getRecords('download_queue', {sub_id: download['sub_id'], finished: false}, true),
+        db_api.getRecords('download_queue', {sub_id: download['sub_id'], running: true, finished: false}, true)
+    ]);
+    const should_mark_complete = refresh_status['phase'] === SUBSCRIPTION_REFRESH_QUEUED_PHASE
+        && queued_count > 0
+        && skipped_count >= queued_count
+        && pending_download_count === 0
+        && running_download_count === 0;
+
+    const updated_refresh_status = {
+        ...refresh_status,
+        skipped_count: skipped_count,
+        updated_at: Date.now()
+    };
+    if (should_mark_complete) {
+        updated_refresh_status['phase'] = SUBSCRIPTION_REFRESH_COMPLETE_PHASE;
+        updated_refresh_status['completed_at'] = updated_refresh_status['completed_at'] || Date.now();
+    }
+
+    return await db_api.updateRecord('subscriptions', {id: download['sub_id']}, {refresh_status: updated_refresh_status});
 }
 
 async function archiveSubscriptionDownloadBySource(download = null, reason = 'after being skipped') {

--- a/backend/subscriptions.js
+++ b/backend/subscriptions.js
@@ -363,11 +363,12 @@ async function archiveSkippedJoinOnlySubscriptionOutput(output_json = null, sub 
     return true;
 }
 
-async function shouldSkipSubscriptionOutput(output_json = null, sub = null, discovery_filter_context = null) {
+async function shouldSkipSubscriptionOutput(output_json = null, sub = null, discovery_filter_context = null, skip_context = null) {
     if (!output_json || typeof output_json !== 'object') return true;
 
     if (config_api.getConfigItem('ytdl_skip_join_only_videos') && isJoinOnlySubscriptionOutput(output_json)) {
         await archiveSkippedJoinOnlySubscriptionOutput(output_json, sub);
+        if (skip_context) skip_context.skipped_count = asFiniteCount(skip_context.skipped_count, 0) + 1;
         logger.info(`Skipping join-only subscription video '${output_json.webpage_url || output_json.url || output_json.id}'.`);
         return true;
     }
@@ -400,6 +401,7 @@ function normalizeSubscriptionRefreshStatus(refresh_status = null) {
         total_count: null,
         new_items_count: null,
         queued_count: 0,
+        skipped_count: 0,
         latest_item_title: null,
         started_at: null,
         updated_at: null,
@@ -419,6 +421,7 @@ function normalizeSubscriptionRefreshStatus(refresh_status = null) {
     normalized_refresh_status.total_count = normalizeNullableCount(refresh_status.total_count);
     normalized_refresh_status.new_items_count = normalizeNullableCount(refresh_status.new_items_count);
     normalized_refresh_status.queued_count = asFiniteCount(refresh_status.queued_count, 0);
+    normalized_refresh_status.skipped_count = asFiniteCount(refresh_status.skipped_count, 0);
     normalized_refresh_status.latest_item_title = normalizeNullableString(refresh_status.latest_item_title);
     normalized_refresh_status.started_at = normalizeNullableCount(refresh_status.started_at);
     normalized_refresh_status.updated_at = normalizeNullableCount(refresh_status.updated_at);
@@ -438,6 +441,7 @@ function createInitialSubscriptionRefreshStatus() {
         total_count: null,
         new_items_count: null,
         queued_count: 0,
+        skipped_count: 0,
         latest_item_title: null,
         started_at: now,
         updated_at: now,
@@ -476,6 +480,7 @@ function createSubscriptionRefreshTracker(sub) {
         last_persisted_discovered_count: 0,
         last_persisted_total_count: null,
         last_persisted_queued_count: 0,
+        last_persisted_skipped_count: 0,
         last_persisted_phase: refresh_status.phase
     };
 
@@ -536,17 +541,21 @@ async function maybePersistSubscriptionRefreshStatus(tracker, force = false) {
         || (tracker.refresh_status.discovered_count - tracker.last_persisted_discovered_count) >= SUBSCRIPTION_REFRESH_COUNT_WRITE_INTERVAL;
     const should_persist_queued_count = tracker.refresh_status.queued_count === 1
         || (tracker.refresh_status.queued_count - tracker.last_persisted_queued_count) >= SUBSCRIPTION_REFRESH_COUNT_WRITE_INTERVAL;
+    const should_persist_skipped_count = tracker.refresh_status.skipped_count === 1
+        || (tracker.refresh_status.skipped_count - tracker.last_persisted_skipped_count) >= SUBSCRIPTION_REFRESH_COUNT_WRITE_INTERVAL;
     const should_persist = force
         || tracker.refresh_status.phase !== tracker.last_persisted_phase
         || tracker.refresh_status.total_count !== tracker.last_persisted_total_count
         || should_persist_discovered_count
-        || should_persist_queued_count;
+        || should_persist_queued_count
+        || should_persist_skipped_count;
     if (!should_persist) return false;
 
     await persistSubscriptionRefreshStatus(tracker.sub_id, tracker.refresh_status);
     tracker.last_persisted_discovered_count = tracker.refresh_status.discovered_count;
     tracker.last_persisted_total_count = tracker.refresh_status.total_count;
     tracker.last_persisted_queued_count = tracker.refresh_status.queued_count;
+    tracker.last_persisted_skipped_count = tracker.refresh_status.skipped_count;
     tracker.last_persisted_phase = tracker.refresh_status.phase;
     return true;
 }
@@ -657,7 +666,8 @@ async function ensureSubscriptionRefreshQueueContext(sub, user_uid, refresh_trac
             concurrentQueueGroupKey: 'subscription-downloads',
             concurrentQueueGroupLimit: downloader_api.getExclusivePlaylistConcurrencyLimit()
         },
-        queued_count: 0
+        queued_count: 0,
+        skipped_count: 0
     };
 
     if (refresh_tracker) {
@@ -668,14 +678,34 @@ async function ensureSubscriptionRefreshQueueContext(sub, user_uid, refresh_trac
             total_count: refresh_tracker.refresh_status.total_count === null
                 ? refresh_tracker.refresh_status.discovered_count
                 : Math.max(refresh_tracker.refresh_status.total_count, refresh_tracker.refresh_status.discovered_count),
-            new_items_count: created_queue_context.queued_count,
+            new_items_count: created_queue_context.queued_count + created_queue_context.skipped_count,
             queued_count: created_queue_context.queued_count,
+            skipped_count: created_queue_context.skipped_count,
             error: null
         });
         await maybePersistSubscriptionRefreshStatus(refresh_tracker, true);
     }
 
     return created_queue_context;
+}
+
+async function updateSubscriptionRefreshTrackerQueueCounts(refresh_tracker, queue_context = null, force = false) {
+    if (!refresh_tracker || !refresh_tracker.refresh_status || !queue_context) return false;
+
+    const queued_count = asFiniteCount(queue_context.queued_count, 0);
+    const skipped_count = asFiniteCount(queue_context.skipped_count, 0);
+    const new_items_count = queued_count + skipped_count;
+    const should_update = force
+        || refresh_tracker.refresh_status.queued_count !== queued_count
+        || refresh_tracker.refresh_status.skipped_count !== skipped_count
+        || refresh_tracker.refresh_status.new_items_count !== new_items_count;
+
+    if (!should_update) return false;
+
+    refresh_tracker.refresh_status.queued_count = queued_count;
+    refresh_tracker.refresh_status.skipped_count = skipped_count;
+    refresh_tracker.refresh_status.new_items_count = new_items_count;
+    return await maybePersistSubscriptionRefreshStatus(refresh_tracker, force);
 }
 
 async function removeArchivedPendingSubscriptionDownloads(sub, pending_downloads = null) {
@@ -717,31 +747,64 @@ async function removeArchivedPendingSubscriptionDownloads(sub, pending_downloads
     return removed_count;
 }
 
-function adjustRefreshStatusAfterPendingCleanup(refresh_status, removed_pending_count = 0, pending_download_count = 0, running_download_count = 0) {
+function adjustRefreshStatusAfterPendingCleanup(refresh_status, removed_pending_count = 0, pending_download_count = 0, running_download_count = 0, skipped_download_count = 0) {
     const normalized_refresh_status = normalizeSubscriptionRefreshStatus(refresh_status);
-    if (removed_pending_count <= 0) return normalized_refresh_status;
+    const normalized_removed_pending_count = asFiniteCount(removed_pending_count, 0);
+    const adjusted_skipped_count = Math.max(
+        normalized_refresh_status.skipped_count,
+        asFiniteCount(skipped_download_count, 0)
+    ) + normalized_removed_pending_count;
 
-    const adjusted_queued_count = Math.max(0, normalized_refresh_status.queued_count - removed_pending_count);
-    const adjusted_new_items_count = normalized_refresh_status.new_items_count === null
-        ? null
-        : Math.max(0, normalized_refresh_status.new_items_count - removed_pending_count);
+    if (normalized_removed_pending_count <= 0 && adjusted_skipped_count === normalized_refresh_status.skipped_count) {
+        return normalized_refresh_status;
+    }
+
+    const adjusted_queued_count = normalized_removed_pending_count > 0
+        ? Math.max(0, normalized_refresh_status.queued_count - normalized_removed_pending_count)
+        : normalized_refresh_status.queued_count;
+    const adjusted_new_items_count = normalized_removed_pending_count > 0 && normalized_refresh_status.new_items_count !== null
+        ? Math.max(0, normalized_refresh_status.new_items_count - normalized_removed_pending_count)
+        : normalized_refresh_status.new_items_count;
     const should_mark_complete = normalized_refresh_status.phase === SUBSCRIPTION_REFRESH_PHASES.QUEUED
-        && adjusted_queued_count === 0
         && pending_download_count === 0
-        && running_download_count === 0;
+        && running_download_count === 0
+        && (adjusted_queued_count === 0 || adjusted_skipped_count >= adjusted_queued_count);
 
     return normalizeSubscriptionRefreshStatus({
         ...normalized_refresh_status,
         phase: should_mark_complete ? SUBSCRIPTION_REFRESH_PHASES.COMPLETE : normalized_refresh_status.phase,
         new_items_count: adjusted_new_items_count,
-        queued_count: adjusted_queued_count
+        queued_count: adjusted_queued_count,
+        skipped_count: adjusted_skipped_count
     });
+}
+
+function countSkippedSubscriptionDownloads(downloads = [], refresh_started_at = null) {
+    if (!Array.isArray(downloads)) return 0;
+    const normalized_refresh_started_at = normalizeNullableCount(refresh_started_at);
+    return downloads.filter(download => {
+        if (!downloader_api.isSkippableSubscriptionDownloadError(download && download.error, download && download.error_type)) return false;
+        const download_started_at = normalizeNullableCount(download && download.timestamp_start);
+        return normalized_refresh_started_at === null || download_started_at === null || download_started_at >= normalized_refresh_started_at;
+    }).length;
+}
+
+async function persistSubscriptionRefreshStatusIfChanged(sub_id, original_refresh_status, refresh_status) {
+    const original_normalized_refresh_status = normalizeSubscriptionRefreshStatus(original_refresh_status);
+    const next_refresh_status = normalizeSubscriptionRefreshStatus(refresh_status);
+    const changed = original_normalized_refresh_status.phase !== next_refresh_status.phase
+        || original_normalized_refresh_status.new_items_count !== next_refresh_status.new_items_count
+        || original_normalized_refresh_status.queued_count !== next_refresh_status.queued_count
+        || original_normalized_refresh_status.skipped_count !== next_refresh_status.skipped_count;
+    if (!changed) return false;
+    return await persistSubscriptionRefreshStatus(sub_id, next_refresh_status);
 }
 
 async function finalizeSubscriptionRefreshSuccess(sub, tracker, queue_context = null) {
     if (!tracker) return 0;
 
     const queued_count = queue_context ? queue_context.queued_count : 0;
+    const skipped_count = queue_context ? asFiniteCount(queue_context.skipped_count, 0) : tracker.refresh_status.skipped_count;
     const discovered_count = tracker.refresh_status.discovered_count;
     tracker.refresh_status = normalizeSubscriptionRefreshStatus({
         ...tracker.refresh_status,
@@ -750,8 +813,9 @@ async function finalizeSubscriptionRefreshSuccess(sub, tracker, queue_context = 
         total_count: tracker.refresh_status.total_count === null
             ? discovered_count
             : Math.max(tracker.refresh_status.total_count, discovered_count),
-        new_items_count: queued_count,
+        new_items_count: queued_count + skipped_count,
         queued_count: queued_count,
+        skipped_count: skipped_count,
         latest_item_title: null,
         completed_at: Date.now(),
         error: null
@@ -1258,7 +1322,8 @@ async function handleOutputJSON(output_jsons, sub, user_uid, refresh_tracker = n
     }
 
     const effective_queue_context = await ensureSubscriptionRefreshQueueContext(sub, user_uid, refresh_tracker, queue_context);
-    const files_to_download = await getFilesToDownload(sub, filtered_output_jsons, effective_queue_context.download_context, discovery_filter_context);
+    const files_to_download = await getFilesToDownload(sub, filtered_output_jsons, effective_queue_context.download_context, discovery_filter_context, effective_queue_context);
+    await updateSubscriptionRefreshTrackerQueueCounts(refresh_tracker, effective_queue_context);
 
     for (const file_to_download of files_to_download) {
         const prefetched_info = getSubscriptionPrefetchedInfoForDownload(file_to_download);
@@ -1268,11 +1333,7 @@ async function handleOutputJSON(output_jsons, sub, user_uid, refresh_tracker = n
         }
         await downloader_api.createDownload(file_to_download['webpage_url'], sub.type || 'video', effective_queue_context.base_download_options, user_uid, sub.id, sub.name, prefetched_info);
         effective_queue_context.queued_count += 1;
-        if (refresh_tracker) {
-            refresh_tracker.refresh_status.queued_count = effective_queue_context.queued_count;
-            refresh_tracker.refresh_status.new_items_count = effective_queue_context.queued_count;
-            await maybePersistSubscriptionRefreshStatus(refresh_tracker);
-        }
+        await updateSubscriptionRefreshTrackerQueueCounts(refresh_tracker, effective_queue_context);
     }
 
     return effective_queue_context;
@@ -1507,7 +1568,7 @@ async function createSubscriptionDownloadContext(sub) {
     };
 }
 
-async function getFilesToDownload(sub, output_jsons, download_context = null, discovery_filter_context = null) {
+async function getFilesToDownload(sub, output_jsons, download_context = null, discovery_filter_context = null, skip_context = null) {
     const files_to_download = [];
     const effective_download_context = download_context || await createSubscriptionDownloadContext(sub);
     const {
@@ -1523,7 +1584,7 @@ async function getFilesToDownload(sub, output_jsons, download_context = null, di
         const output_json = output_jsons[i];
         if (!output_json || !output_json['webpage_url']) continue;
 
-        if (await shouldSkipSubscriptionOutput(output_json, sub, discovery_filter_context)) continue;
+        if (await shouldSkipSubscriptionOutput(output_json, sub, discovery_filter_context, skip_context)) continue;
 
         const output_url = output_json['webpage_url'];
         const output_path = output_json['_filename'];
@@ -1626,19 +1687,23 @@ exports.getSubscription = async (subID, user_uid = null) => {
     const [
         current_downloads,
         pending_download_count,
-        running_download_count
+        running_download_count,
+        skipped_downloads
     ] = await Promise.all([
         db_api.getRecords('download_queue', {running: true, sub_id: subID}, true),
         db_api.getRecords('download_queue', {sub_id: subID, finished: false}, true),
-        db_api.getRecords('download_queue', {sub_id: subID, running: true, finished: false}, true)
+        db_api.getRecords('download_queue', {sub_id: subID, running: true, finished: false}, true),
+        db_api.getRecords('download_queue', {sub_id: subID, finished: true, error: {$ne: null}})
     ]);
     if (!sub['downloading']) sub['downloading'] = current_downloads > 0;
 
-    let refresh_status = normalizeSubscriptionRefreshStatus(sub['refresh_status']);
+    const original_refresh_status = normalizeSubscriptionRefreshStatus(sub['refresh_status']);
+    const skipped_download_count = countSkippedSubscriptionDownloads(skipped_downloads, original_refresh_status.started_at);
+    let refresh_status = normalizeSubscriptionRefreshStatus(original_refresh_status);
     if (!sub['downloading'] && refresh_status.active) {
         refresh_status = buildInterruptedSubscriptionRefreshStatus(refresh_status);
     }
-    refresh_status = adjustRefreshStatusAfterPendingCleanup(refresh_status, removed_archived_pending_count, pending_download_count, running_download_count);
+    refresh_status = adjustRefreshStatusAfterPendingCleanup(refresh_status, removed_archived_pending_count, pending_download_count, running_download_count, skipped_download_count);
 
     if (refresh_status.phase === SUBSCRIPTION_REFRESH_PHASES.IDLE && pending_download_count > 0) {
         refresh_status = normalizeSubscriptionRefreshStatus({
@@ -1647,9 +1712,7 @@ exports.getSubscription = async (subID, user_uid = null) => {
             queued_count: refresh_status.queued_count || pending_download_count
         });
     }
-    if (removed_archived_pending_count > 0) {
-        await persistSubscriptionRefreshStatus(subID, refresh_status);
-    }
+    await persistSubscriptionRefreshStatusIfChanged(subID, original_refresh_status, refresh_status);
 
     sub['refresh_status'] = {
         ...refresh_status,

--- a/backend/test/subscriptions.test.js
+++ b/backend/test/subscriptions.test.js
@@ -305,10 +305,72 @@ describe('Subscriptions', function() {
         assert.strictEqual(refreshed_sub['refresh_status']['running_download_count'], 0);
         assert.strictEqual(refreshed_sub['refresh_status']['queued_count'], 0);
         assert.strictEqual(refreshed_sub['refresh_status']['new_items_count'], 0);
+        assert.strictEqual(refreshed_sub['refresh_status']['skipped_count'], 1);
         assert.strictEqual(refreshed_sub['refresh_status']['phase'], 'complete');
 
         const remaining_downloads = await db_api.getRecords('download_queue', {sub_id: sub.id});
         assert.strictEqual(remaining_downloads.length, 0);
+    });
+    it('Reports skipped finished subscription downloads in refresh status', async function() {
+        const sub = Object.assign({}, new_sub, {id: uuid(), name: 'skipped_finished_sub'});
+
+        await db_api.insertRecordIntoTable('subscriptions', {
+            ...sub,
+            refresh_status: {
+                active: false,
+                phase: 'queued',
+                discovered_count: 2,
+                total_count: 2,
+                new_items_count: 2,
+                queued_count: 2
+            }
+        });
+        await db_api.insertRecordIntoTable('download_queue', {
+            uid: uuid(),
+            url: 'https://www.youtube.com/watch?v=join-only-video-1',
+            type: 'video',
+            title: 'Members-only video 1',
+            options: {},
+            sub_id: sub.id,
+            user_uid: null,
+            running: false,
+            paused: false,
+            finished_step: true,
+            finished: true,
+            error: 'Error while retrieving info on video: Join this channel to get access to members-only content',
+            error_type: 'join_only',
+            timestamp_start: Date.now()
+        });
+        await db_api.insertRecordIntoTable('download_queue', {
+            uid: uuid(),
+            url: 'https://www.youtube.com/watch?v=join-only-video-2',
+            type: 'video',
+            title: 'Members-only video 2',
+            options: {},
+            sub_id: sub.id,
+            user_uid: null,
+            running: false,
+            paused: false,
+            finished_step: true,
+            finished: true,
+            error: 'Error while retrieving info on video: Join this channel to get access to members-only content',
+            error_type: 'join_only',
+            timestamp_start: Date.now()
+        });
+
+        const refreshed_sub = await subscriptions_api.getSubscription(sub.id);
+
+        assert(refreshed_sub);
+        assert.strictEqual(refreshed_sub['refresh_status']['pending_download_count'], 0);
+        assert.strictEqual(refreshed_sub['refresh_status']['running_download_count'], 0);
+        assert.strictEqual(refreshed_sub['refresh_status']['queued_count'], 2);
+        assert.strictEqual(refreshed_sub['refresh_status']['new_items_count'], 2);
+        assert.strictEqual(refreshed_sub['refresh_status']['skipped_count'], 2);
+        assert.strictEqual(refreshed_sub['refresh_status']['phase'], 'complete');
+
+        const stored_sub = await db_api.getRecord('subscriptions', {id: sub.id});
+        assert.strictEqual(stored_sub['refresh_status']['skipped_count'], 2);
+        assert.strictEqual(stored_sub['refresh_status']['phase'], 'complete');
     });
     it('Update subscription', async function () {
         await subscriptions_api.subscribe(new_sub, null, true);
@@ -575,6 +637,11 @@ describe('Subscriptions', function() {
         assert.strictEqual(queued_downloads.length, 1);
         assert.strictEqual(queued_downloads[0].url, public_output.webpage_url);
         assert.strictEqual(await archive_api.existsInArchive('youtube', join_only_output.id, sub.type, sub.user_uid, sub.id), true);
+
+        const refreshed_sub = await subscriptions_api.getSubscription(sub.id);
+        assert.strictEqual(refreshed_sub.refresh_status.queued_count, 1);
+        assert.strictEqual(refreshed_sub.refresh_status.skipped_count, 1);
+        assert.strictEqual(refreshed_sub.refresh_status.new_items_count, 2);
     });
     it('Filters archived flat playlist entries from cached subscription archive state', async function() {
         const original_runYoutubeDLLineStream = youtubedl_api.runYoutubeDLLineStream;

--- a/src/api-types/models/SubscriptionRefreshStatus.ts
+++ b/src/api-types/models/SubscriptionRefreshStatus.ts
@@ -9,6 +9,7 @@ export type SubscriptionRefreshStatus = {
     total_count?: number | null;
     new_items_count?: number | null;
     queued_count?: number;
+    skipped_count?: number;
     latest_item_title?: string | null;
     started_at?: number | null;
     updated_at?: number | null;

--- a/src/app/subscription/subscription/subscription.component.spec.ts
+++ b/src/app/subscription/subscription/subscription.component.spec.ts
@@ -152,4 +152,29 @@ describe('SubscriptionComponent', () => {
 
     expect(router.navigate).toHaveBeenCalledWith(['/downloads']);
   });
+
+  it('should describe skipped downloads instead of leaving queued wording behind', () => {
+    component.subscription = {
+      id: 'sub-1',
+      name: 'Test subscription',
+      downloading: false,
+      refresh_status: {
+        phase: 'complete',
+        active: false,
+        new_items_count: 2,
+        queued_count: 2,
+        skipped_count: 2,
+        pending_download_count: 0,
+        running_download_count: 0
+      },
+      videos: []
+    } as any;
+
+    expect(component.shouldShowRefreshStatus()).toBeTrue();
+    expect(component.getRefreshHeadline()).toBe('Downloads skipped');
+    expect(component.getRefreshDescription()).toContain('were skipped');
+    expect(component.getRefreshMetrics()).toContain('2 skipped');
+    expect(component.getRefreshMetrics()).not.toContain('2 queued');
+    expect(component.canOpenDownloads()).toBeFalse();
+  });
 });

--- a/src/app/subscription/subscription/subscription.component.ts
+++ b/src/app/subscription/subscription/subscription.component.ts
@@ -149,6 +149,7 @@ export class SubscriptionComponent implements OnInit, OnDestroy {
       || refresh_status.active
       || refresh_status.pending_download_count > 0
       || refresh_status.running_download_count > 0
+      || refresh_status.skipped_count > 0
       || refresh_status.started_at
       || refresh_status.completed_at
     ));
@@ -161,6 +162,12 @@ export class SubscriptionComponent implements OnInit, OnDestroy {
 
   getRefreshHeadline(): string {
     const refresh_status = this.getRefreshStatus();
+    if (this.hasSkippedDownloads(refresh_status) && !this.hasUnfinishedDownloads(refresh_status)) {
+      return this.getQueuedAfterSkippedCount(refresh_status) > 0
+        ? $localize`Refresh completed with skips`
+        : $localize`Downloads skipped`;
+    }
+
     switch (refresh_status?.phase) {
     case 'collecting':
       return $localize`Checking channel metadata`;
@@ -186,6 +193,10 @@ export class SubscriptionComponent implements OnInit, OnDestroy {
   getRefreshDescription(): string {
     const refresh_status = this.getRefreshStatus();
     const latest_item_title = refresh_status?.latest_item_title ? ` "${refresh_status.latest_item_title}"` : '';
+    if (this.hasSkippedDownloads(refresh_status) && !this.hasUnfinishedDownloads(refresh_status) && !refresh_status?.active) {
+      return this.getSkippedRefreshDescription(refresh_status);
+    }
+
     switch (refresh_status?.phase) {
     case 'collecting':
       return $localize`The app is scanning this channel before it creates download jobs. Files will appear here after queued downloads finish.` + latest_item_title;
@@ -195,10 +206,19 @@ export class SubscriptionComponent implements OnInit, OnDestroy {
         : $localize`The metadata scan finished. The app is preparing download jobs now.`;
     case 'queued':
       if (refresh_status?.pending_download_count > 0) {
+        if (this.hasSkippedDownloads(refresh_status)) {
+          return $localize`Download jobs are queued, and ${this.getSkippedCount(refresh_status)}:skipped count: were skipped because they are unavailable or members-only. New files will appear here as each download completes.`;
+        }
         return $localize`Download jobs are queued. New files will appear here as each download completes.`;
+      }
+      if (this.hasSkippedDownloads(refresh_status)) {
+        return this.getSkippedRefreshDescription(refresh_status);
       }
       return $localize`The refresh queued download jobs successfully.`;
     case 'complete':
+      if (this.hasSkippedDownloads(refresh_status)) {
+        return this.getSkippedRefreshDescription(refresh_status);
+      }
       return refresh_status?.new_items_count > 0
         ? $localize`The refresh finished successfully.`
         : $localize`The last refresh did not find any new videos to download.`;
@@ -253,6 +273,8 @@ export class SubscriptionComponent implements OnInit, OnDestroy {
     if (!refresh_status) return [];
 
     const metrics: string[] = [];
+    const skipped_count = this.getSkippedCount(refresh_status);
+    const queued_count = this.getQueuedAfterSkippedCount(refresh_status);
     if (refresh_status.phase === 'collecting') {
       if (refresh_status.total_count > 0) {
         metrics.push($localize`${refresh_status.discovered_count}:discovered count: / ${refresh_status.total_count}:total count: items scanned`);
@@ -265,8 +287,12 @@ export class SubscriptionComponent implements OnInit, OnDestroy {
       metrics.push($localize`${refresh_status.new_items_count}:new items count: new downloads found`);
     }
 
-    if (refresh_status.queued_count > 0) {
-      metrics.push($localize`${refresh_status.queued_count}:queued count: queued`);
+    if (queued_count > 0) {
+      metrics.push($localize`${queued_count}:queued count: queued`);
+    }
+
+    if (skipped_count > 0) {
+      metrics.push($localize`${skipped_count}:skipped count: skipped`);
     }
 
     if (refresh_status.running_download_count > 0) {
@@ -278,6 +304,39 @@ export class SubscriptionComponent implements OnInit, OnDestroy {
     }
 
     return metrics;
+  }
+
+  private getSkippedCount(refresh_status: SubscriptionRefreshStatus | null = this.getRefreshStatus()): number {
+    return Math.max(0, Math.floor(Number(refresh_status?.skipped_count) || 0));
+  }
+
+  private hasSkippedDownloads(refresh_status: SubscriptionRefreshStatus | null = this.getRefreshStatus()): boolean {
+    return this.getSkippedCount(refresh_status) > 0;
+  }
+
+  private hasUnfinishedDownloads(refresh_status: SubscriptionRefreshStatus | null = this.getRefreshStatus()): boolean {
+    return !!(refresh_status && (refresh_status.pending_download_count > 0 || refresh_status.running_download_count > 0));
+  }
+
+  private getQueuedAfterSkippedCount(refresh_status: SubscriptionRefreshStatus | null = this.getRefreshStatus()): number {
+    const queued_count = Math.max(0, Math.floor(Number(refresh_status?.queued_count) || 0));
+    if (this.hasUnfinishedDownloads(refresh_status)) {
+      const unfinished_count = Math.max(
+        Number(refresh_status?.pending_download_count) || 0,
+        Number(refresh_status?.running_download_count) || 0
+      );
+      return Math.max(unfinished_count, queued_count - this.getSkippedCount(refresh_status));
+    }
+    return Math.max(0, queued_count - this.getSkippedCount(refresh_status));
+  }
+
+  private getSkippedRefreshDescription(refresh_status: SubscriptionRefreshStatus | null): string {
+    const skipped_count = this.getSkippedCount(refresh_status);
+    const found_count = Math.max(0, Math.floor(Number(refresh_status?.new_items_count) || 0));
+    if (found_count > skipped_count) {
+      return $localize`The refresh found ${found_count}:new item count: new item(s), but ${skipped_count}:skipped count: were skipped because they are unavailable or members-only.`;
+    }
+    return $localize`The refresh found ${skipped_count}:skipped count: new item(s), but they were skipped because they are unavailable or members-only.`;
   }
 
   canOpenDownloads(): boolean {


### PR DESCRIPTION
Summary:
- Add skipped_count to subscription refresh status for discovery-time and downloader-time bypasses.
- Update the subscription refresh card to show skipped downloads instead of stale queued wording.
- Cover skipped refresh status with backend and Angular component tests.

Verification:
- npm run lint
- npx tsc -p src/tsconfig.app.json --noEmit
- npx tsc -p src/tsconfig.spec.json --noEmit
- CHROMIUM_BIN="/usr/bin/chromium" npm run test:headless -- --include=src/app/subscription/subscription/subscription.component.spec.ts
- ./node_modules/.bin/mocha test/subscriptions.test.js --exit -s 1000
- ./node_modules/.bin/mocha test/downloader.test.js --exit -s 1000 --grep "Archives no-output subscription downloads|Archives skippable errored subscription downloads"
- node --check backend/subscriptions.js && node --check backend/downloader.js
- npx ng build --configuration production