### PR TITLE
fix(deps): bump express-rate-limit from 8.4.1 to 8.5.0 in /backend

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -23,7 +23,7 @@
         "config": "^4.4.1",
         "execa": "^9.6.1",
         "express": "^5.2.1",
-        "express-rate-limit": "^8.4.1",
+        "express-rate-limit": "^8.5.0",
         "express-session": "^1.19.0",
         "feed": "^5.2.1",
         "fluent-ffmpeg": "^2.1.3",
@@ -2046,9 +2046,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
-      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.0.tgz",
+      "integrity": "sha512-XKhFohWaSBdVJNTi5TaHziqnPkv04I9UQV6q1Wy7Ui6GGQZVW12ojDFwqer14EvCXxjvPG0CyWXx7cAXpALB4Q==",
       "license": "MIT",
       "dependencies": {
         "ip-address": "10.1.0"

--- a/backend/package.json
+++ b/backend/package.json
@@ -37,7 +37,7 @@
     "config": "^4.4.1",
     "execa": "^9.6.1",
     "express": "^5.2.1",
-    "express-rate-limit": "^8.4.1",
+    "express-rate-limit": "^8.5.0",
     "express-session": "^1.19.0",
     "feed": "^5.2.1",
     "fluent-ffmpeg": "^2.1.3",


### PR DESCRIPTION
Bumps `express-rate-limit` from 8.4.1 to 8.5.0 in the backend to fix the failing [Dependencies CI check](https://github.com/voc0der/ytdl-material/actions/runs/25347364593/job/74319226574).

`npm outdated` was reporting `express-rate-limit` as outdated, causing the workflow to exit with code 1.