### PR TITLE
feat(subscriptions): allow flat subscription downloads

### DIFF
--- a/Public API v1.yaml
+++ b/Public API v1.yaml
@@ -2043,6 +2043,8 @@ components:
           type: string
         customFileOutput:
           type: string
+        useSubfolder:
+          type: boolean
         maxQuality:
           type: string
     SubscribeResponse:
@@ -2945,6 +2947,8 @@ components:
           type: string
         custom_output:
           type: string
+        use_subfolder:
+          type: boolean
         downloading:
           type: boolean
         paused:

--- a/backend/app.js
+++ b/backend/app.js
@@ -1742,6 +1742,7 @@ app.post('/api/subscribe', optionalJwt, async (req, res) => {
     let audioOnly = req.body.audioOnly;
     let customArgs = req.body.customArgs;
     let customOutput = req.body.customFileOutput;
+    let useSubfolder = req.body.useSubfolder;
     let user_uid = req.isAuthenticated() ? req.user.uid : null;
     const new_sub = {
                         name: name,
@@ -1749,7 +1750,8 @@ app.post('/api/subscribe', optionalJwt, async (req, res) => {
                         maxQuality: maxQuality,
                         id: uuid(),
                         user_uid: user_uid,
-                        type: audioOnly ? 'audio' : 'video'
+                        type: audioOnly ? 'audio' : 'video',
+                        use_subfolder: useSubfolder !== false
                     };
 
     // adds timerange if it exists, otherwise all videos will be downloaded

--- a/backend/db.js
+++ b/backend/db.js
@@ -91,6 +91,7 @@ const tables = {
             paused: 'boolean',
             streamingOnly: 'boolean',
             isPlaylist: 'boolean',
+            use_subfolder: 'boolean',
             name: 'text',
             url: 'text'
         },
@@ -656,10 +657,10 @@ exports.getFileDirectoriesAndDBs = async () => {
             // TODO: Remove subscription as it'll never complete
             continue;
         }
-        const subscription_path_name = utils.getSubscriptionPathName(subscription_to_check);
+        const subscription_base_path = subscription_to_check.user_uid ? path.join(usersFileFolder, subscription_to_check.user_uid, 'subscriptions')
+                                                                      : subscriptions_base_path;
         dirs_to_check.push({
-            basePath: subscription_to_check.user_uid ? path.join(usersFileFolder, subscription_to_check.user_uid, 'subscriptions', subscription_to_check.isPlaylist ? 'playlists' : 'channels', subscription_path_name)
-                                      : path.join(subscriptions_base_path, subscription_to_check.isPlaylist ? 'playlists' : 'channels', subscription_path_name),
+            basePath: utils.getSubscriptionDownloadPath(subscription_to_check, subscription_base_path),
             user_uid: subscription_to_check.user_uid,
             type: subscription_to_check.type,
             sub_id: subscription_to_check['id'],

--- a/backend/subscriptions.js
+++ b/backend/subscriptions.js
@@ -35,6 +35,29 @@ function shouldRestrictToUser(user_uid) {
     return config_api.getConfigItem('ytdl_multi_user_mode') && user_uid !== null && user_uid !== undefined;
 }
 
+function getSubscriptionsBasePath(user_uid = null) {
+    if (user_uid) return path.join(config_api.getConfigItem('ytdl_users_base_path'), user_uid, 'subscriptions');
+    return config_api.getConfigItem('ytdl_subscriptions_base_path');
+}
+
+function getSubscriptionsBasePathForSub(sub = null, user_uid = null) {
+    return getSubscriptionsBasePath(user_uid || (sub && sub.user_uid));
+}
+
+function normalizeSubscriptionStorageOptions(sub = null) {
+    if (!sub || typeof sub !== 'object') return sub;
+    sub.use_subfolder = sub.use_subfolder !== false;
+    return sub;
+}
+
+function getSubscriptionMetadataBasePath(sub, base_path) {
+    return utils.getSubscriptionMetadataPath(sub, base_path);
+}
+
+function getSubscriptionTemporaryArchivePath(sub, base_path) {
+    return path.join(getSubscriptionMetadataBasePath(sub, base_path), 'archive.txt');
+}
+
 function asFiniteCount(value, default_value = 0) {
     const numeric_value = Number(value);
     if (!Number.isFinite(numeric_value)) return default_value;
@@ -924,6 +947,7 @@ exports.subscribe = async (sub, user_uid = null, skip_get_info = false) => {
         error: ''
     };
     return new Promise(async resolve => {
+        normalizeSubscriptionStorageOptions(sub);
         // sub should just have url and name. here we will get isPlaylist and path
         sub.isPlaylist = sub.isPlaylist || sub.url.includes('playlist');
         sub.videos = [];
@@ -1019,11 +1043,7 @@ exports.unsubscribe = async (sub_id, deleteMode, user_uid = null) => {
             error: 'Subscription not found or not owned by the current user.'
         };
     }
-    let basePath = null;
-    if (user_uid)
-        basePath = path.join(config_api.getConfigItem('ytdl_users_base_path'), user_uid, 'subscriptions');
-    else
-        basePath = config_api.getConfigItem('ytdl_subscriptions_base_path');
+    let basePath = getSubscriptionsBasePathForSub(sub, user_uid);
 
     let id = sub.id;
 
@@ -1042,6 +1062,13 @@ exports.unsubscribe = async (sub_id, deleteMode, user_uid = null) => {
     }
 
     await killSubDownloads(sub_id, true);
+
+    if (deleteMode && !utils.usesSubscriptionSubfolder(sub)) {
+        for (const sub_file of sub_files) {
+            await files_api.deleteFile(sub_file.uid, false, user_uid);
+        }
+    }
+
     const remove_sub_filter = {id: id};
     if (shouldRestrictToUser(user_uid)) remove_sub_filter['user_uid'] = user_uid;
     await db_api.removeRecord('subscriptions', remove_sub_filter);
@@ -1053,8 +1080,13 @@ exports.unsubscribe = async (sub_id, deleteMode, user_uid = null) => {
     }
 
     const appendedBasePath = getAppendedBasePath(sub, basePath);
-    if (deleteMode && (await fs.pathExists(appendedBasePath))) {
+    if (deleteMode && utils.usesSubscriptionSubfolder(sub) && (await fs.pathExists(appendedBasePath))) {
         await fs.remove(appendedBasePath);
+    }
+    if (deleteMode && !utils.usesSubscriptionSubfolder(sub)) {
+        const metadataBasePath = getSubscriptionMetadataBasePath(sub, basePath);
+        if (await fs.pathExists(metadataBasePath)) await fs.remove(metadataBasePath);
+        await cleanupEmptyDirectory(path.dirname(metadataBasePath), utils.getSubscriptionTypePath(sub, basePath));
     }
 
     await db_api.removeAllRecords('archives', {sub_id: sub.id, ...(shouldRestrictToUser(user_uid) ? {user_uid: user_uid} : {})});
@@ -1067,9 +1099,7 @@ exports.deleteSubscriptionFile = async (sub, file, deleteForever, file_uid = nul
         sub = await db_api.getRecord('subscriptions', {sub_id: sub});
     }
     // TODO: combine this with deletefile
-    let basePath = null;
-    basePath = user_uid ? path.join(config_api.getConfigItem('ytdl_users_base_path'), user_uid, 'subscriptions')
-                        : config_api.getConfigItem('ytdl_subscriptions_base_path');
+    let basePath = getSubscriptionsBasePathForSub(sub, user_uid);
     const appendedBasePath = getAppendedBasePath(sub, basePath);
     const name = file;
     let retrievedID = null;
@@ -1262,11 +1292,7 @@ async function _getVideosForSub(sub) {
     ]);
 
     // get basePath
-    let basePath = null;
-    if (user_uid)
-        basePath = path.join(config_api.getConfigItem('ytdl_users_base_path'), user_uid, 'subscriptions');
-    else
-        basePath = config_api.getConfigItem('ytdl_subscriptions_base_path');
+    let basePath = getSubscriptionsBasePathForSub(sub, user_uid);
 
     let appendedBasePath = getAppendedBasePath(sub, basePath);
     fs.ensureDirSync(appendedBasePath);
@@ -1300,7 +1326,7 @@ async function _getVideosForSub(sub) {
         return null;
     } finally {
         // remove temporary archive file if it exists
-        const archive_path = path.join(appendedBasePath, 'archive.txt');
+        const archive_path = getSubscriptionTemporaryArchivePath(sub, basePath);
         const archive_exists = await fs.pathExists(archive_path);
         if (archive_exists) {
             await fs.unlink(archive_path);
@@ -1340,11 +1366,7 @@ async function handleOutputJSON(output_jsons, sub, user_uid, refresh_tracker = n
 }
 
 exports.generateOptionsForSubscriptionDownload = (sub, user_uid) => {
-    let basePath = null;
-    if (user_uid)
-        basePath = path.join(config_api.getConfigItem('ytdl_users_base_path'), user_uid, 'subscriptions');
-    else
-        basePath = config_api.getConfigItem('ytdl_subscriptions_base_path');
+    let basePath = getSubscriptionsBasePathForSub(sub, user_uid);
 
     let default_output = config_api.getConfigItem('ytdl_default_file_output') ? config_api.getConfigItem('ytdl_default_file_output') : '%(title)s';
 
@@ -1361,11 +1383,7 @@ exports.generateOptionsForSubscriptionDownload = (sub, user_uid) => {
 
 async function generateArgsForSubscription(sub, user_uid, redownload = false, desired_path = null) {
     // get basePath
-    let basePath = null;
-    if (user_uid)
-        basePath = path.join(config_api.getConfigItem('ytdl_users_base_path'), user_uid, 'subscriptions');
-    else
-        basePath = config_api.getConfigItem('ytdl_subscriptions_base_path');
+    let basePath = getSubscriptionsBasePathForSub(sub, user_uid);
 
     let appendedBasePath = getAppendedBasePath(sub, basePath);
 
@@ -1397,7 +1415,8 @@ async function generateArgsForSubscription(sub, user_uid, redownload = false, de
     const archive_count = archive_text.split('\n').length - 1;
     if (archive_count > 0) {
         logger.verbose(`Generating temporary archive file for subscription ${sub.name} with ${archive_count} entries.`)
-        const archive_path = path.join(appendedBasePath, 'archive.txt');
+        const archive_path = getSubscriptionTemporaryArchivePath(sub, basePath);
+        await fs.ensureDir(path.dirname(archive_path));
         await fs.writeFile(archive_path, archive_text);
         downloadConfig.push('--download-archive', archive_path);
     }
@@ -1729,12 +1748,238 @@ exports.getSubscriptionByName = async (subName, user_uid = null) => {
     return await db_api.getRecord('subscriptions', {name: subName, user_uid: user_uid});
 }
 
+function normalizePath(file_path = '') {
+    return path.resolve(file_path);
+}
+
+function isSamePath(first_path = '', second_path = '') {
+    return normalizePath(first_path) === normalizePath(second_path);
+}
+
+function isPathInsideOrSame(candidate_path = '', parent_path = '') {
+    const normalized_candidate_path = normalizePath(candidate_path);
+    const normalized_parent_path = normalizePath(parent_path);
+    if (normalized_candidate_path === normalized_parent_path) return true;
+    const relative_path = path.relative(normalized_parent_path, normalized_candidate_path);
+    return !!relative_path && !relative_path.startsWith('..') && !path.isAbsolute(relative_path);
+}
+
+function getDestinationPathForSubscriptionMove(source_path, old_base_path, new_base_path) {
+    if (isPathInsideOrSame(new_base_path, old_base_path) && isPathInsideOrSame(source_path, new_base_path)) {
+        return source_path;
+    }
+
+    if (!isPathInsideOrSame(source_path, old_base_path)) {
+        if (isPathInsideOrSame(source_path, new_base_path)) return source_path;
+        return path.join(new_base_path, path.basename(source_path));
+    }
+
+    const relative_path = path.relative(path.resolve(old_base_path), path.resolve(source_path));
+    return path.join(new_base_path, relative_path);
+}
+
+async function getExistingSubscriptionMediaPath(file_obj = null, type = 'video') {
+    if (!file_obj || !file_obj.path) return null;
+
+    const candidate_paths = [
+        file_obj.path,
+        utils.getTrueFileName(file_obj.path, type)
+    ].filter((candidate_path, index, all_paths) => candidate_path && all_paths.indexOf(candidate_path) === index);
+
+    for (const candidate_path of candidate_paths) {
+        if (await fs.pathExists(candidate_path)) return candidate_path;
+    }
+
+    return null;
+}
+
+async function getSubscriptionSubtitleSidecarPaths(media_path) {
+    const subtitle_sidecar_paths = [];
+    const media_directory = path.dirname(media_path);
+    const media_basename = path.basename(utils.removeFileExtension(media_path)).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const subtitle_regex = new RegExp(`^${media_basename}\\.player-subtitles(?:\\.\\d+)?\\.vtt$`);
+
+    let directory_entries = [];
+    try {
+        directory_entries = await fs.readdir(media_directory);
+    } catch (e) {
+        return subtitle_sidecar_paths;
+    }
+
+    for (const directory_entry of directory_entries) {
+        if (subtitle_regex.test(directory_entry)) {
+            subtitle_sidecar_paths.push(path.join(media_directory, directory_entry));
+        }
+    }
+
+    return subtitle_sidecar_paths;
+}
+
+async function getExistingSubscriptionSidecarPaths(media_path, type = 'video') {
+    const file_path_no_extension = utils.removeFileExtension(media_path);
+    const expected_extension = type === 'audio' ? '.mp3' : '.mp4';
+    const actual_extension = path.extname(media_path);
+    const sidecar_candidates = [
+        `${media_path}.info.json`,
+        `${file_path_no_extension}.info.json`,
+        `${file_path_no_extension}${expected_extension}.info.json`,
+        `${file_path_no_extension}.webp`,
+        `${file_path_no_extension}.jpg`,
+        `${file_path_no_extension}.png`,
+        `${file_path_no_extension}.nfo`,
+        ...await getSubscriptionSubtitleSidecarPaths(media_path)
+    ];
+
+    if (actual_extension && actual_extension !== expected_extension) {
+        sidecar_candidates.push(`${file_path_no_extension}${actual_extension}.info.json`);
+    }
+
+    const existing_sidecar_paths = [];
+    for (const sidecar_candidate of [...new Set(sidecar_candidates)]) {
+        if (await fs.pathExists(sidecar_candidate)) existing_sidecar_paths.push(sidecar_candidate);
+    }
+
+    return existing_sidecar_paths;
+}
+
+function addSubscriptionMovePlanEntry(move_plan, source_path, destination_path) {
+    if (!source_path || !destination_path || isSamePath(source_path, destination_path)) return;
+    if (move_plan.some(plan_entry => isSamePath(plan_entry.source_path, source_path))) return;
+
+    move_plan.push({
+        source_path: source_path,
+        destination_path: destination_path
+    });
+}
+
+async function validateSubscriptionMovePlan(move_plan = []) {
+    const destination_paths = new Set();
+    for (const plan_entry of move_plan) {
+        const normalized_destination_path = normalizePath(plan_entry.destination_path);
+        if (destination_paths.has(normalized_destination_path)) {
+            logger.error(`Failed to move subscription files. Multiple files would move to '${plan_entry.destination_path}'.`);
+            return false;
+        }
+        destination_paths.add(normalized_destination_path);
+
+        if (await fs.pathExists(plan_entry.destination_path)) {
+            logger.error(`Failed to move subscription files. Destination already exists: '${plan_entry.destination_path}'.`);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+async function applySubscriptionMovePlan(move_plan = []) {
+    for (const plan_entry of move_plan) {
+        await fs.ensureDir(path.dirname(plan_entry.destination_path));
+        await fs.move(plan_entry.source_path, plan_entry.destination_path, {overwrite: false});
+    }
+}
+
+async function cleanupEmptyDirectory(directory_path, stop_path) {
+    let current_path = path.resolve(directory_path);
+    const resolved_stop_path = path.resolve(stop_path);
+
+    while (current_path !== resolved_stop_path && isPathInsideOrSame(current_path, resolved_stop_path)) {
+        let directory_entries = null;
+        try {
+            directory_entries = await fs.readdir(current_path);
+        } catch (e) {
+            return;
+        }
+
+        if (directory_entries.length > 0) return;
+        await fs.remove(current_path);
+        current_path = path.dirname(current_path);
+    }
+}
+
+async function moveSubscriptionFilesForUpdatedPath(current_sub, updated_sub, user_uid = null) {
+    const old_base_path = getSubscriptionsBasePathForSub(current_sub, user_uid);
+    const new_base_path = getSubscriptionsBasePathForSub(updated_sub, user_uid);
+    const old_download_path = getAppendedBasePath(current_sub, old_base_path);
+    const new_download_path = getAppendedBasePath(updated_sub, new_base_path);
+    if (isSamePath(old_download_path, new_download_path)) return true;
+
+    const sub_files_filter = {sub_id: current_sub.id};
+    if (shouldRestrictToUser(user_uid)) sub_files_filter['user_uid'] = user_uid;
+    const sub_files = await db_api.getRecords('files', sub_files_filter);
+    const move_plan = [];
+    const file_path_updates = {};
+
+    for (const sub_file of sub_files) {
+        const file_type = sub_file.isAudio || updated_sub.type === 'audio' ? 'audio' : 'video';
+        const media_source_path = await getExistingSubscriptionMediaPath(sub_file, file_type);
+        if (!media_source_path) continue;
+
+        const media_destination_path = getDestinationPathForSubscriptionMove(media_source_path, old_download_path, new_download_path);
+        addSubscriptionMovePlanEntry(move_plan, media_source_path, media_destination_path);
+
+        if (!isSamePath(media_source_path, media_destination_path)) {
+            file_path_updates[sub_file.uid] = {path: media_destination_path};
+        }
+
+        const sidecar_paths = await getExistingSubscriptionSidecarPaths(media_source_path, file_type);
+        for (const sidecar_path of sidecar_paths) {
+            addSubscriptionMovePlanEntry(
+                move_plan,
+                sidecar_path,
+                getDestinationPathForSubscriptionMove(sidecar_path, old_download_path, new_download_path)
+            );
+        }
+    }
+
+    if (!(await validateSubscriptionMovePlan(move_plan))) return false;
+
+    try {
+        await applySubscriptionMovePlan(move_plan);
+    } catch (e) {
+        logger.error(`Failed to move files for subscription '${current_sub.name}'.`);
+        logger.error(e);
+        return false;
+    }
+
+    await db_api.bulkUpdateRecordsByKey('files', 'uid', file_path_updates);
+    return true;
+}
+
+async function cleanupSubscriptionPathChange(current_sub, updated_sub, user_uid = null) {
+    const old_base_path = getSubscriptionsBasePathForSub(current_sub, user_uid);
+    const new_base_path = getSubscriptionsBasePathForSub(updated_sub, user_uid);
+    const old_download_path = getAppendedBasePath(current_sub, old_base_path);
+    const new_download_path = getAppendedBasePath(updated_sub, new_base_path);
+    const old_metadata_path = getSubscriptionMetadataBasePath(current_sub, old_base_path);
+    const new_metadata_path = getSubscriptionMetadataBasePath(updated_sub, new_base_path);
+    const old_subscription_type_path = utils.getSubscriptionTypePath(current_sub, old_base_path);
+
+    if (!isSamePath(old_metadata_path, new_metadata_path)) {
+        await fs.remove(path.join(old_metadata_path, CONSTS.SUBSCRIPTION_BACKUP_PATH));
+        await cleanupEmptyDirectory(old_metadata_path, old_subscription_type_path);
+    }
+
+    if (!isSamePath(old_download_path, new_download_path)) {
+        await cleanupEmptyDirectory(old_download_path, old_subscription_type_path);
+    }
+}
+
 exports.updateSubscription = async (sub, user_uid = null) => {
+    normalizeSubscriptionStorageOptions(sub);
     const filter_obj = {id: sub.id};
     if (shouldRestrictToUser(user_uid)) filter_obj['user_uid'] = user_uid;
+    const stored_sub = await db_api.getRecord('subscriptions', filter_obj);
+    if (!stored_sub) return false;
+    const current_sub = JSON.parse(JSON.stringify(stored_sub));
+
+    normalizeSubscriptionStorageOptions(current_sub);
+    const moved_files = await moveSubscriptionFilesForUpdatedPath(current_sub, sub, user_uid);
+    if (!moved_files) return false;
+
     const updated = await db_api.updateRecord('subscriptions', filter_obj, sub);
     if (!updated) return false;
     exports.writeSubscriptionMetadata(sub);
+    await cleanupSubscriptionPathChange(current_sub, sub, user_uid);
     return true;
 }
 
@@ -1763,8 +2008,7 @@ exports.writeSubscriptionMetadata = (sub) => {
             return false;
         }
 
-        let basePath = sub.user_uid ? path.join(config_api.getConfigItem('ytdl_users_base_path'), sub.user_uid, 'subscriptions')
-                                    : config_api.getConfigItem('ytdl_subscriptions_base_path');
+        let basePath = getSubscriptionsBasePathForSub(sub);
         if (typeof basePath !== 'string' || basePath.trim() === '') {
             logger.warn(`Skipping subscription metadata write for subscription '${subscription_name}' because the base path is missing.`);
             return false;
@@ -1772,7 +2016,7 @@ exports.writeSubscriptionMetadata = (sub) => {
 
         basePath = basePath.trim();
         const metadata_sub = Object.assign({}, sub, {name: subscription_name});
-        const appendedBasePath = getAppendedBasePath(metadata_sub, basePath);
+        const appendedBasePath = getSubscriptionMetadataBasePath(metadata_sub, basePath);
         const resolvedBasePath = path.resolve(basePath);
         const resolvedSubscriptionPath = path.resolve(appendedBasePath);
         const relativeSubscriptionPath = path.relative(resolvedBasePath, resolvedSubscriptionPath);
@@ -1842,5 +2086,5 @@ async function checkVideoIfBetterExists(file_obj, sub, user_uid) {
 // helper functions
 
 function getAppendedBasePath(sub, base_path) {
-    return path.join(base_path, sub.isPlaylist ? 'playlists' : 'channels', utils.getSubscriptionPathName(sub));
+    return utils.getSubscriptionDownloadPath(sub, base_path);
 }

--- a/backend/subscriptions.js
+++ b/backend/subscriptions.js
@@ -1769,10 +1769,7 @@ function getDestinationPathForSubscriptionMove(source_path, old_base_path, new_b
         return source_path;
     }
 
-    if (!isPathInsideOrSame(source_path, old_base_path)) {
-        if (isPathInsideOrSame(source_path, new_base_path)) return source_path;
-        return path.join(new_base_path, path.basename(source_path));
-    }
+    if (!isPathInsideOrSame(source_path, old_base_path)) return null;
 
     const relative_path = path.relative(path.resolve(old_base_path), path.resolve(source_path));
     return path.join(new_base_path, relative_path);
@@ -1852,18 +1849,45 @@ function addSubscriptionMovePlanEntry(move_plan, source_path, destination_path) 
     });
 }
 
-async function validateSubscriptionMovePlan(move_plan = []) {
+async function validateSubscriptionMovePlan(move_plan = [], source_base_path, destination_base_path) {
+    const resolved_source_base_path = path.resolve(source_base_path);
+    const resolved_destination_base_path = path.resolve(destination_base_path);
     const destination_paths = new Set();
     for (const plan_entry of move_plan) {
-        const normalized_destination_path = normalizePath(plan_entry.destination_path);
+        const source_path = path.resolve(plan_entry.source_path);
+        const destination_path = path.resolve(plan_entry.destination_path);
+        const source_relative_path = path.relative(resolved_source_base_path, source_path);
+        const destination_relative_path = path.relative(resolved_destination_base_path, destination_path);
+
+        if (source_relative_path === '..' || source_relative_path.startsWith('..' + path.sep)) {
+            logger.error(`Failed to move subscription files. Source is outside the old subscription folder: '${source_path}'.`);
+            return false;
+        }
+
+        if (path.isAbsolute(source_relative_path)) {
+            logger.error(`Failed to move subscription files. Source resolved to an absolute relative path: '${source_path}'.`);
+            return false;
+        }
+
+        if (destination_relative_path === '..' || destination_relative_path.startsWith('..' + path.sep)) {
+            logger.error(`Failed to move subscription files. Destination is outside the new subscription folder: '${destination_path}'.`);
+            return false;
+        }
+
+        if (path.isAbsolute(destination_relative_path)) {
+            logger.error(`Failed to move subscription files. Destination resolved to an absolute relative path: '${destination_path}'.`);
+            return false;
+        }
+
+        const normalized_destination_path = normalizePath(destination_path);
         if (destination_paths.has(normalized_destination_path)) {
-            logger.error(`Failed to move subscription files. Multiple files would move to '${plan_entry.destination_path}'.`);
+            logger.error(`Failed to move subscription files. Multiple files would move to '${destination_path}'.`);
             return false;
         }
         destination_paths.add(normalized_destination_path);
 
-        if (await fs.pathExists(plan_entry.destination_path)) {
-            logger.error(`Failed to move subscription files. Destination already exists: '${plan_entry.destination_path}'.`);
+        if (await fs.pathExists(destination_path)) {
+            logger.error(`Failed to move subscription files. Destination already exists: '${destination_path}'.`);
             return false;
         }
     }
@@ -1871,10 +1895,34 @@ async function validateSubscriptionMovePlan(move_plan = []) {
     return true;
 }
 
-async function applySubscriptionMovePlan(move_plan = []) {
+async function applySubscriptionMovePlan(move_plan = [], source_base_path, destination_base_path) {
+    const resolved_source_base_path = path.resolve(source_base_path);
+    const resolved_destination_base_path = path.resolve(destination_base_path);
+
     for (const plan_entry of move_plan) {
-        await fs.ensureDir(path.dirname(plan_entry.destination_path));
-        await fs.move(plan_entry.source_path, plan_entry.destination_path, {overwrite: false});
+        const source_path = path.resolve(plan_entry.source_path);
+        const destination_path = path.resolve(plan_entry.destination_path);
+        const source_relative_path = path.relative(resolved_source_base_path, source_path);
+        const destination_relative_path = path.relative(resolved_destination_base_path, destination_path);
+
+        if (source_relative_path === '..' || source_relative_path.startsWith('..' + path.sep)) {
+            throw new Error('Subscription file move source path failed validation.');
+        }
+
+        if (path.isAbsolute(source_relative_path)) {
+            throw new Error('Subscription file move source path failed validation.');
+        }
+
+        if (destination_relative_path === '..' || destination_relative_path.startsWith('..' + path.sep)) {
+            throw new Error('Subscription file move destination path failed validation.');
+        }
+
+        if (path.isAbsolute(destination_relative_path)) {
+            throw new Error('Subscription file move path failed validation.');
+        }
+
+        await fs.ensureDir(path.dirname(destination_path));
+        await fs.move(source_path, destination_path, {overwrite: false});
     }
 }
 
@@ -1899,6 +1947,8 @@ async function cleanupEmptyDirectory(directory_path, stop_path) {
 async function moveSubscriptionFilesForUpdatedPath(current_sub, updated_sub, user_uid = null) {
     const old_base_path = getSubscriptionsBasePathForSub(current_sub, user_uid);
     const new_base_path = getSubscriptionsBasePathForSub(updated_sub, user_uid);
+    const old_subscription_type_path = utils.getSubscriptionTypePath(current_sub, old_base_path);
+    const new_subscription_type_path = utils.getSubscriptionTypePath(updated_sub, new_base_path);
     const old_download_path = getAppendedBasePath(current_sub, old_base_path);
     const new_download_path = getAppendedBasePath(updated_sub, new_base_path);
     if (isSamePath(old_download_path, new_download_path)) return true;
@@ -1913,6 +1963,10 @@ async function moveSubscriptionFilesForUpdatedPath(current_sub, updated_sub, use
         const file_type = sub_file.isAudio || updated_sub.type === 'audio' ? 'audio' : 'video';
         const media_source_path = await getExistingSubscriptionMediaPath(sub_file, file_type);
         if (!media_source_path) continue;
+        if (!isPathInsideOrSame(media_source_path, old_download_path)) {
+            logger.warn(`Skipping move for subscription file '${sub_file.uid}' because its path is outside the old subscription folder.`);
+            continue;
+        }
 
         const media_destination_path = getDestinationPathForSubscriptionMove(media_source_path, old_download_path, new_download_path);
         addSubscriptionMovePlanEntry(move_plan, media_source_path, media_destination_path);
@@ -1931,10 +1985,10 @@ async function moveSubscriptionFilesForUpdatedPath(current_sub, updated_sub, use
         }
     }
 
-    if (!(await validateSubscriptionMovePlan(move_plan))) return false;
+    if (!(await validateSubscriptionMovePlan(move_plan, old_subscription_type_path, new_subscription_type_path))) return false;
 
     try {
-        await applySubscriptionMovePlan(move_plan);
+        await applySubscriptionMovePlan(move_plan, old_subscription_type_path, new_subscription_type_path);
     } catch (e) {
         logger.error(`Failed to move files for subscription '${current_sub.name}'.`);
         logger.error(e);

--- a/backend/tasks.js
+++ b/backend/tasks.js
@@ -351,7 +351,8 @@ const guessSubscriptions = async (isPlaylist, basePath = null) => {
     const subsSubPath = basePath ? path.join(basePath, 'subscriptions') : subscriptionsFileFolder;
     const subsPath = path.join(subsSubPath, isPlaylist ? 'playlists' : 'channels');
 
-    const subs = await utils.getDirectoriesInDirectory(subsPath);
+    const subs = (await utils.getDirectoriesInDirectory(subsPath))
+        .concat(await utils.getDirectoriesInDirectory(path.join(subsPath, '.metadata')));
     for (const subPath of subs) {
         const sub_backup_path = path.join(subPath, CONSTS.SUBSCRIPTION_BACKUP_PATH);
         if (!fs.existsSync(sub_backup_path)) continue;
@@ -359,7 +360,9 @@ const guessSubscriptions = async (isPlaylist, basePath = null) => {
         try {
             const sub_backup = fs.readJSONSync(sub_backup_path)
             delete sub_backup['_id'];
-            guessed_subs.push(sub_backup);
+            if (!guessed_subs.some(guessed_sub => guessed_sub.id === sub_backup.id)) {
+                guessed_subs.push(sub_backup);
+            }
         } catch(err) {
             logger.warn(`Failed to reimport subscription in path ${subPath}`)
             logger.warn(err);

--- a/backend/test/subscriptions.test.js
+++ b/backend/test/subscriptions.test.js
@@ -427,6 +427,160 @@ describe('Subscriptions', function() {
             await fs.remove(raw_subscription_path);
         }
     });
+    it('Writes flat subscription metadata outside the downloads folder', async function() {
+        const original_subscriptions_base_path = config_api.getConfigItem('ytdl_subscriptions_base_path');
+        const test_base_path = path.join('appdata', 'flat-subscription-metadata');
+        const sub = Object.assign({}, new_sub, {
+            id: uuid(),
+            name: 'flat_metadata_sub',
+            isPlaylist: false,
+            use_subfolder: false
+        });
+        const metadata_path = path.join(test_base_path, 'channels', '.metadata', 'flat_metadata_sub', 'subscription_backup.json');
+        const root_metadata_path = path.join(test_base_path, 'channels', 'subscription_backup.json');
+
+        config_api.setConfigItem('ytdl_subscriptions_base_path', test_base_path);
+
+        try {
+            await fs.remove(test_base_path);
+
+            const success = subscriptions_api.writeSubscriptionMetadata(sub);
+            const download_options = subscriptions_api.generateOptionsForSubscriptionDownload(sub, null);
+            await db_api.insertRecordIntoTable('subscriptions', sub);
+            const subscription_dir = (await db_api.getFileDirectoriesAndDBs()).find(dir => dir.sub_id === sub.id);
+
+            assert.strictEqual(success, true);
+            assert.strictEqual(fs.existsSync(metadata_path), true);
+            assert.strictEqual(fs.existsSync(root_metadata_path), false);
+            assert.strictEqual(download_options.customFileFolderPath, path.join(test_base_path, 'channels'));
+            assert(subscription_dir);
+            assert.strictEqual(subscription_dir.basePath, path.join(test_base_path, 'channels'));
+        } finally {
+            config_api.setConfigItem('ytdl_subscriptions_base_path', original_subscriptions_base_path);
+            await fs.remove(test_base_path);
+        }
+    });
+    it('Moves subscription files when toggling the subscription name folder setting', async function() {
+        const original_subscriptions_base_path = config_api.getConfigItem('ytdl_subscriptions_base_path');
+        const test_base_path = path.join('appdata', 'subscription-folder-toggle');
+        const sub = Object.assign({}, new_sub, {
+            id: uuid(),
+            name: 'move_sub',
+            isPlaylist: false,
+            use_subfolder: true
+        });
+        const nested_dir = path.join(test_base_path, 'channels', 'move_sub');
+        const flat_dir = path.join(test_base_path, 'channels');
+        const nested_media_path = path.join(nested_dir, 'Episode 1.mp4');
+        const nested_info_path = path.join(nested_dir, 'Episode 1.info.json');
+        const nested_thumbnail_path = path.join(nested_dir, 'Episode 1.jpg');
+        const flat_media_path = path.join(flat_dir, 'Episode 1.mp4');
+        const flat_info_path = path.join(flat_dir, 'Episode 1.info.json');
+        const flat_thumbnail_path = path.join(flat_dir, 'Episode 1.jpg');
+        const file_uid = uuid();
+
+        config_api.setConfigItem('ytdl_subscriptions_base_path', test_base_path);
+
+        try {
+            await fs.remove(test_base_path);
+            await fs.outputFile(nested_media_path, 'video');
+            await fs.outputJSON(nested_info_path, {id: 'episode-1', extractor: 'youtube'});
+            await fs.outputFile(nested_thumbnail_path, 'thumb');
+            await db_api.insertRecordIntoTable('subscriptions', sub);
+            await db_api.insertRecordIntoTable('files', {
+                uid: file_uid,
+                sub_id: sub.id,
+                path: nested_media_path,
+                isAudio: false,
+                url: 'https://example.com/episode-1',
+                title: 'Episode 1'
+            });
+
+            const flat_sub_update = Object.assign({}, sub, {use_subfolder: false});
+            const flattened = await subscriptions_api.updateSubscription(flat_sub_update);
+
+            assert.strictEqual(flattened, true);
+            assert.strictEqual(fs.existsSync(flat_media_path), true);
+            assert.strictEqual(fs.existsSync(flat_info_path), true);
+            assert.strictEqual(fs.existsSync(flat_thumbnail_path), true);
+            assert.strictEqual(fs.existsSync(nested_media_path), false);
+            assert.strictEqual(fs.existsSync(nested_dir), false);
+            assert.strictEqual(fs.existsSync(path.join(flat_dir, '.metadata', 'move_sub', 'subscription_backup.json')), true);
+
+            let moved_file = await db_api.getRecord('files', {uid: file_uid});
+            assert.strictEqual(moved_file.path, flat_media_path);
+
+            const nested_sub_update = Object.assign({}, flat_sub_update, {use_subfolder: true});
+            const nested = await subscriptions_api.updateSubscription(nested_sub_update);
+
+            assert.strictEqual(nested, true);
+            assert.strictEqual(fs.existsSync(nested_media_path), true);
+            assert.strictEqual(fs.existsSync(nested_info_path), true);
+            assert.strictEqual(fs.existsSync(nested_thumbnail_path), true);
+            assert.strictEqual(fs.existsSync(flat_media_path), false);
+            assert.strictEqual(fs.existsSync(path.join(nested_dir, 'subscription_backup.json')), true);
+            assert.strictEqual(fs.existsSync(path.join(flat_dir, '.metadata', 'move_sub', 'subscription_backup.json')), false);
+
+            moved_file = await db_api.getRecord('files', {uid: file_uid});
+            assert.strictEqual(moved_file.path, nested_media_path);
+        } finally {
+            config_api.setConfigItem('ytdl_subscriptions_base_path', original_subscriptions_base_path);
+            await fs.remove(test_base_path);
+        }
+    });
+    it('Does not remove other flat subscription files when unsubscribing with delete mode', async function() {
+        const original_subscriptions_base_path = config_api.getConfigItem('ytdl_subscriptions_base_path');
+        const test_base_path = path.join('appdata', 'flat-subscription-unsubscribe');
+        const sub = Object.assign({}, new_sub, {
+            id: uuid(),
+            name: 'flat_delete_sub',
+            use_subfolder: false
+        });
+        const other_sub = Object.assign({}, new_sub, {
+            id: uuid(),
+            name: 'flat_keep_sub',
+            use_subfolder: false
+        });
+        const delete_file_path = path.join(test_base_path, 'channels', 'Delete Me.mp4');
+        const keep_file_path = path.join(test_base_path, 'channels', 'Keep Me.mp4');
+
+        config_api.setConfigItem('ytdl_subscriptions_base_path', test_base_path);
+
+        try {
+            await fs.remove(test_base_path);
+            await fs.outputFile(delete_file_path, 'delete');
+            await fs.outputFile(keep_file_path, 'keep');
+            await db_api.insertRecordIntoTable('subscriptions', sub);
+            await db_api.insertRecordIntoTable('subscriptions', other_sub);
+            await db_api.insertRecordIntoTable('files', {
+                uid: 'delete-flat-file',
+                sub_id: sub.id,
+                path: delete_file_path,
+                isAudio: false,
+                url: 'https://example.com/delete',
+                title: 'Delete Me'
+            });
+            await db_api.insertRecordIntoTable('files', {
+                uid: 'keep-flat-file',
+                sub_id: other_sub.id,
+                path: keep_file_path,
+                isAudio: false,
+                url: 'https://example.com/keep',
+                title: 'Keep Me'
+            });
+
+            const result = await subscriptions_api.unsubscribe(sub.id, true);
+
+            assert.strictEqual(result.success, true);
+            assert.strictEqual(fs.existsSync(delete_file_path), false);
+            assert.strictEqual(fs.existsSync(keep_file_path), true);
+            assert.strictEqual(!!(await db_api.getRecord('subscriptions', {id: sub.id})), false);
+            assert.strictEqual(!!(await db_api.getRecord('subscriptions', {id: other_sub.id})), true);
+        } finally {
+            config_api.setConfigItem('ytdl_subscriptions_base_path', original_subscriptions_base_path);
+            await fs.remove(test_base_path);
+        }
+    });
     it('Does not let path separators split subscription metadata folders', async function() {
         const sub = Object.assign({}, new_sub, {
             id: uuid(),

--- a/backend/utils.js
+++ b/backend/utils.js
@@ -55,6 +55,31 @@ exports.getSubscriptionPathName = (sub = {}) => {
     return exports.sanitizePathSegment(sub && sub.name, fallback);
 }
 
+exports.usesSubscriptionSubfolder = (sub = {}) => {
+    return !(sub && sub.use_subfolder === false);
+}
+
+exports.getSubscriptionTypeFolder = (sub = {}) => {
+    return sub && sub.isPlaylist ? 'playlists' : 'channels';
+}
+
+exports.getSubscriptionTypePath = (sub = {}, base_path = '') => {
+    return path.join(base_path, exports.getSubscriptionTypeFolder(sub));
+}
+
+exports.getSubscriptionDownloadPath = (sub = {}, base_path = '') => {
+    const subscription_type_path = exports.getSubscriptionTypePath(sub, base_path);
+    if (!exports.usesSubscriptionSubfolder(sub)) return subscription_type_path;
+    return path.join(subscription_type_path, exports.getSubscriptionPathName(sub));
+}
+
+exports.getSubscriptionMetadataPath = (sub = {}, base_path = '') => {
+    const subscription_type_path = exports.getSubscriptionTypePath(sub, base_path);
+    const subscription_path_name = exports.getSubscriptionPathName(sub);
+    if (exports.usesSubscriptionSubfolder(sub)) return path.join(subscription_type_path, subscription_path_name);
+    return path.join(subscription_type_path, '.metadata', subscription_path_name);
+}
+
 // replaces .webm with appropriate extension
 exports.getTrueFileName = (unfixed_path, type, force_ext = null) => {
     let fixed_path = unfixed_path;

--- a/src/api-types/models/SubscribeRequest.ts
+++ b/src/api-types/models/SubscribeRequest.ts
@@ -9,5 +9,6 @@ export type SubscribeRequest = {
     audioOnly?: boolean;
     customArgs?: string;
     customFileOutput?: string;
+    useSubfolder?: boolean;
     maxQuality?: string;
 };

--- a/src/api-types/models/Subscription.ts
+++ b/src/api-types/models/Subscription.ts
@@ -17,6 +17,7 @@ export type Subscription = {
     timerange?: string;
     custom_args?: string;
     custom_output?: string;
+    use_subfolder?: boolean;
     downloading?: boolean;
     paused?: boolean;
     refresh_status?: SubscriptionRefreshStatus;

--- a/src/app/dialogs/edit-subscription-dialog/edit-subscription-dialog.component.html
+++ b/src/app/dialogs/edit-subscription-dialog/edit-subscription-dialog.component.html
@@ -11,6 +11,9 @@
       <div class="col-12 mt-3">
         <mat-checkbox (change)="downloadAllToggled()" [(ngModel)]="download_all"><ng-container i18n="Download all uploads subscription setting">Download all uploads</ng-container></mat-checkbox>
       </div>
+      <div class="col-12 mt-3">
+        <mat-checkbox [(ngModel)]="new_sub.use_subfolder"><ng-container i18n="Use subscription name folder setting">Save downloads in subscription name folder</ng-container></mat-checkbox>
+      </div>
       @if (editor_initialized) {
         <div class="col-12">
           <ng-container i18n="Download time range prefix">Download videos uploaded in the last</ng-container>

--- a/src/app/dialogs/edit-subscription-dialog/edit-subscription-dialog.component.ts
+++ b/src/app/dialogs/edit-subscription-dialog/edit-subscription-dialog.component.ts
@@ -64,6 +64,8 @@ export class EditSubscriptionDialogComponent implements OnInit {
   constructor(@Inject(MAT_DIALOG_DATA) public data: any, private dialog: MatDialog, private postsService: PostsService) {
     this.sub = JSON.parse(JSON.stringify(this.data.sub));
     this.new_sub = JSON.parse(JSON.stringify(this.sub));
+    this.sub.use_subfolder = this.sub.use_subfolder !== false;
+    this.new_sub.use_subfolder = this.new_sub.use_subfolder !== false;
 
     // ignore videos to keep requests small
     delete this.sub['videos'];

--- a/src/app/dialogs/subscribe-dialog/subscribe-dialog.component.html
+++ b/src/app/dialogs/subscribe-dialog/subscribe-dialog.component.html
@@ -25,6 +25,9 @@
         <mat-checkbox [(ngModel)]="download_all"><ng-container i18n="Download all uploads subscription setting">Download all uploads</ng-container></mat-checkbox>
       </div>
       <div class="col-12">
+        <mat-checkbox [(ngModel)]="useSubfolder"><ng-container i18n="Use subscription name folder setting">Save downloads in subscription name folder</ng-container></mat-checkbox>
+      </div>
+      <div class="col-12">
         <span i18n="Download time range prefix">Download videos uploaded in the last</span>
         <div>
           <mat-form-field color="accent" style="width: 100px; text-align: center;">

--- a/src/app/dialogs/subscribe-dialog/subscribe-dialog.component.ts
+++ b/src/app/dialogs/subscribe-dialog/subscribe-dialog.component.ts
@@ -14,6 +14,7 @@ export class SubscribeDialogComponent implements OnInit {
   timerange_amount;
   timerange_unit = 'days';
   download_all = true;
+  useSubfolder = true;
   url = null;
   name = null;
 
@@ -87,7 +88,7 @@ export class SubscribeDialogComponent implements OnInit {
         timerange = 'now-' + this.timerange_amount.toString() + this.timerange_unit;
       }
       this.postsService.createSubscription(this.url, this.name, timerange, this.maxQuality,
-                                          this.audioOnlyMode, this.customArgs, this.customFileOutput).subscribe(res => {
+                                          this.audioOnlyMode, this.customArgs, this.customFileOutput, this.useSubfolder).subscribe(res => {
         this.subscribing = false;
         if (res['new_sub']) {
           this.dialogRef.close(res['new_sub']);

--- a/src/app/posts.services.ts
+++ b/src/app/posts.services.ts
@@ -611,9 +611,9 @@ export class PostsService {
         return this.http.post<DeletePlaylistResponse>(this.path + 'deletePlaylist', body, this.httpOptions);
     }
 
-    createSubscription(url, name, timerange = null, maxQuality = 'best', audioOnly = false, customArgs: string = null, customFileOutput: string = null) {
+    createSubscription(url, name, timerange = null, maxQuality = 'best', audioOnly = false, customArgs: string = null, customFileOutput: string = null, useSubfolder = true) {
         const body: SubscribeRequest = {url: url, name: name, timerange: timerange, maxQuality: maxQuality,
-            audioOnly: audioOnly, customArgs: customArgs, customFileOutput: customFileOutput};
+            audioOnly: audioOnly, customArgs: customArgs, customFileOutput: customFileOutput, useSubfolder: useSubfolder};
         return this.http.post<SubscribeResponse>(this.path + 'subscribe', body, this.httpOptions);
     }
     


### PR DESCRIPTION
## Summary
- Adds a checked-by-default subscription dialog option to save downloads in the subscription name folder.
- Allows flat subscription downloads under `subscriptions/[channels|playlists]/...` when unchecked.
- Moves existing subscription media and sidecars when the setting changes later, and avoids deleting shared flat folders on unsubscribe.

Closes #207

## Verification
- `npm run lint`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npm run test:headless`
- `npx ng build --configuration production`
- `node --check backend/subscriptions.js && node --check backend/app.js && node --check backend/db.js && node --check backend/tasks.js && node --check backend/utils.js`
- `npm test` from `backend/`
