### PR TITLE
fix(backend): update rate-limit-redis

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -49,7 +49,7 @@
         "pg": "^8.20.0",
         "progress": "^2.0.3",
         "ps-node": "^0.1.6",
-        "rate-limit-redis": "^4.3.1",
+        "rate-limit-redis": "^5.0.0",
         "read-last-lines": "^1.8.0",
         "redis": "^5.12.1",
         "rxjs": "^7.8.2",
@@ -4312,15 +4312,15 @@
       }
     },
     "node_modules/rate-limit-redis": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/rate-limit-redis/-/rate-limit-redis-4.3.1.tgz",
-      "integrity": "sha512-+a1zU8+D7L8siDK9jb14refQXz60vq427VuiplgnaLk9B2LnvGe/APLTfhwb4uNIL7eWVknh8GnRp/unCj+lMA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rate-limit-redis/-/rate-limit-redis-5.0.0.tgz",
+      "integrity": "sha512-+M9el8KZjZ2HXM6/E38jFGmozBbN4C200iLE8+80TgS+8PzSfAAvD1zkx2oWu6YEgSrdiJJNrd4LCFm5vjVJkg==",
       "license": "MIT",
       "engines": {
         "node": ">= 16"
       },
       "peerDependencies": {
-        "express-rate-limit": ">= 6"
+        "express-rate-limit": ">= 8.5.0"
       }
     },
     "node_modules/raw-body": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -63,7 +63,7 @@
     "pg": "^8.20.0",
     "progress": "^2.0.3",
     "ps-node": "^0.1.6",
-    "rate-limit-redis": "^4.3.1",
+    "rate-limit-redis": "^5.0.0",
     "read-last-lines": "^1.8.0",
     "redis": "^5.12.1",
     "rxjs": "^7.8.2",


### PR DESCRIPTION
## Summary
- Update backend `rate-limit-redis` from `^4.3.1` to `^5.0.0`
- Refresh backend lockfile so the scheduled outdated check no longer reports the package

## Verification
- `npm ci --ignore-scripts` (root)
- `npm ci --ignore-scripts` (backend)
- `npm outdated` (root)
- `npm outdated` (backend)
- `npm test` (backend)
- `npm run lint`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npm run test:headless`
- `npx ng build --configuration production`

Related failing job: https://github.com/voc0der/ytdl-material/actions/runs/25631118630/job/75234874586