### PR TITLE
fix(root): update express-rate-limit override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9301,13 +9301,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -10264,9 +10264,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
       "ajv": "8.18.0",
       "picomatch": "4.0.4"
     },
-    "express-rate-limit": "8.3.1",
+    "express-rate-limit": "8.5.1",
     "ngx-avatars": {
       "@angular/common": "21.2.0",
       "@angular/core": "21.2.0"


### PR DESCRIPTION
## Summary
- Update the root `express-rate-limit` override from `8.3.1` to `8.5.1`
- Refresh `package-lock.json` so transitive `ip-address` resolves to `10.2.0`
- Clear Dependabot advisory 51 / GHSA-v2v4-37r5-5v8g without using `npm audit fix --force`

## Verification
- `npm ci --ignore-scripts`
- `npm ls ip-address express-rate-limit`
- `npm audit --audit-level=moderate`
- `npm outdated`
- `npm run lint`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npm run test:headless`
- `npx ng build --configuration production`

Related advisory: https://github.com/voc0der/ytdl-material/security/dependabot/51