### PR TITLE
chore(deps): bump @scalar/express-api-reference from 0.9.14 to 0.9.16 in /backend

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@discordjs/builders": "^1.14.1",
         "@discordjs/core": "^2.4.0",
-        "@scalar/express-api-reference": "^0.9.14",
+        "@scalar/express-api-reference": "^0.9.16",
         "archiver": "^8.0.0",
         "async": "^3.2.3",
         "async-mutex": "^0.5.0",
@@ -407,51 +407,74 @@
       }
     },
     "node_modules/@scalar/client-side-rendering": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@scalar/client-side-rendering/-/client-side-rendering-0.1.7.tgz",
-      "integrity": "sha512-IDzjKF93jrOljlvKBsLHXT1FPWgz56jFrMPC+iLihREp1qH8wF92mG8Zpakw8cURkEuw5WijRk0xNBP2moGyuw==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@scalar/client-side-rendering/-/client-side-rendering-0.1.9.tgz",
+      "integrity": "sha512-Gv3CK0X+BqXYkVJLTQXNM8YgdquhuGV4hKlsM8S9k5GGonj8LBDSAiuU3W48JGX1pY7hRotBGcIIU+1a1X1mcw==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/types": "0.9.6"
+        "@scalar/schemas": "0.2.0",
+        "@scalar/types": "0.11.0",
+        "@scalar/validation": "0.5.0"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/express-api-reference": {
-      "version": "0.9.14",
-      "resolved": "https://registry.npmjs.org/@scalar/express-api-reference/-/express-api-reference-0.9.14.tgz",
-      "integrity": "sha512-OPhqH+OOPHjuka/4v6x+/sYU1aPB5xfAMeb1lNMallWZBok7ZmVicDVSfRC/9NQCHzOgpMzdRdo847qJJ6TTXw==",
+      "version": "0.9.16",
+      "resolved": "https://registry.npmjs.org/@scalar/express-api-reference/-/express-api-reference-0.9.16.tgz",
+      "integrity": "sha512-P1zT6f5inPQqnqgkmIjaAW1CEmsNOptW4AYOSeSwkAwK9auknUf2337FTaqY/P8irvoI2fzqcBeUCVv17NgY3Q==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/client-side-rendering": "0.1.7"
+        "@scalar/client-side-rendering": "0.1.9"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.6.0.tgz",
-      "integrity": "sha512-pfSamAgBxqFeE8IpEG6uGkHlnPhY1CLeOTttV9+vKQbrBk5b7vvyTsUXv0Hz4kNU1TFrxcTTPE+Akn5S+jlTtQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.8.0.tgz",
+      "integrity": "sha512-gmOC6VravNB9VDl6wnt/GOj4K/hn48tj5bpW4AM4MhH8Ubil6uu7g1DSoKHwltu8Ks79KEtR6JmOrROi9R7jaQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
-    "node_modules/@scalar/types": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.9.6.tgz",
-      "integrity": "sha512-UaCQQcscFTJdxZREE8KhUdSJgaDlc44TZbmWcZffs4m1hzqOvEI7lEBS13iBpLq7/cxUXFgyJdecywvNqJ0PkA==",
+    "node_modules/@scalar/schemas": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@scalar/schemas/-/schemas-0.2.0.tgz",
+      "integrity": "sha512-FOpNecNoEKo8SogHEsdWlVRN4Q4PH3dzuOBWMA5tGt1xLZu5iFnPG2X/h6+Z/mOR34c7iW+hiKTqdUZoDgT9CA==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.6.0",
+        "@scalar/validation": "0.5.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/types": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.11.0.tgz",
+      "integrity": "sha512-TGZR8sys1jRlaWxLYfBo8y6D1W4UClYuDmkJ6Hmsb7oNuqokEAAK+AVYIzascVdBmaly0D1fqoqK7CzuGYHgyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/helpers": "0.8.0",
         "nanoid": "^5.1.6",
         "type-fest": "^5.3.1",
         "zod": "^4.3.5"
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/validation": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@scalar/validation/-/validation-0.5.0.tgz",
+      "integrity": "sha512-48CS1B0C7im57RQCHhS0GKt+qDLxB34IX8rO91jZj9D+Y/OosQZG3Gy57gJdHqZoD7l0sPUZtF8tVYry3BxRtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@sec-ant/readable-stream": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@discordjs/builders": "^1.14.1",
     "@discordjs/core": "^2.4.0",
-    "@scalar/express-api-reference": "^0.9.14",
+    "@scalar/express-api-reference": "^0.9.16",
     "archiver": "^8.0.0",
     "async": "^3.2.3",
     "async-mutex": "^0.5.0",


### PR DESCRIPTION
Closes #228

## Summary
- Bumps `@scalar/express-api-reference` from 0.9.14 to 0.9.16 in `/backend`
- Pulls in updated `@scalar/client-side-rendering`, `@scalar/types`, `@scalar/helpers`, and new `@scalar/schemas`/`@scalar/validation` packages

## Test plan
- [x] `npm run lint` — clean
- [x] `npx tsc -p src/tsconfig.app.json --noEmit` — clean
- [x] `npx tsc -p src/tsconfig.spec.json --noEmit` — clean
- [x] `npm run test:headless` — 196/196 passed
- [x] `npx ng build --configuration production` — successful