### PR TITLE
fix: correct null check logic in Telegram request handler

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -3207,7 +3207,7 @@ app.post('/api/deleteAllNotifications', optionalJwt, async (req, res) => {
 });
 
 app.post('/api/telegramRequest', async (req, res) => {
-    if (!req.body.message  && !req.body.message.text) {
+    if (!req.body.message || !req.body.message.text) {
         logger.error('Invalid Telegram request received!');
         res.sendStatus(400);
         return;


### PR DESCRIPTION
The condition was using && instead of ||. With &&, if req.body.message was falsy, the second condition req.body.message.text would crash with 'Cannot read property text of undefined'.

**Before:**`if (!req.body.message && !req.body.message.text)`
**After:**`if (!req.body.message || !req.body.message.text)`

Now properly validates both message existence and message.text existence using ||.

— Sent via @AmSach bot