### PR TITLE
feat(tasks): schedule subscription refreshes

### DIFF
--- a/Public API v1.yaml
+++ b/Public API v1.yaml
@@ -2853,6 +2853,7 @@ components:
       - delete_old_files
       - import_legacy_archives
       - rebuild_database
+      - subscriptions_check
     Schedule:
       required:
         - type

--- a/backend/app.js
+++ b/backend/app.js
@@ -858,8 +858,6 @@ async function loadConfig() {
                 refresh_status: subscriptions_api.buildInterruptedSubscriptionRefreshStatus(sub.refresh_status)
             });
         }));
-        // runs initially, then runs every ${subscriptionCheckInterval} seconds
-        subscriptions_api.watchSubscriptionsInterval();
     }
 
     // start the server here
@@ -2821,7 +2819,9 @@ app.post('/api/getTasks', optionalJwt, async (req, res) => {
             logger.verbose(`Task ${task['key']} does not exist!`);
             continue;
         }
-        if (task['schedule']) task['next_invocation'] = tasks_api.TASKS[task['key']]['job'].nextInvocation().getTime();
+        const job = tasks_api.TASKS[task['key']]['job'];
+        const next_invocation = job && job.nextInvocation ? job.nextInvocation() : null;
+        if (task['schedule'] && next_invocation) task['next_invocation'] = next_invocation.getTime();
     }
     res.send({tasks: tasks});
 });
@@ -2840,7 +2840,9 @@ app.post('/api/resetTasks', optionalJwt, async (req, res) => {
 app.post('/api/getTask', optionalJwt, async (req, res) => {
     const task_key = req.body.task_key;
     const task = await db_api.getRecord('tasks', {key: task_key});
-    if (task['schedule']) task['next_invocation'] = tasks_api.TASKS[task_key]['job'].nextInvocation().getTime();
+    const job = tasks_api.TASKS[task_key] && tasks_api.TASKS[task_key]['job'];
+    const next_invocation = job && job.nextInvocation ? job.nextInvocation() : null;
+    if (task['schedule'] && next_invocation) task['next_invocation'] = next_invocation.getTime();
     res.send({task: task});
 });
 

--- a/backend/config.js
+++ b/backend/config.js
@@ -280,7 +280,6 @@ const DEFAULT_CONFIG = {
       "Subscriptions": {
         "allow_subscriptions": true,
         "subscriptions_base_path": "subscriptions/",
-        "subscriptions_check_interval": "86400",
         "redownload_fresh_uploads": false
       },
       "Users": {

--- a/backend/consts.js
+++ b/backend/consts.js
@@ -247,10 +247,6 @@ exports.CONFIG_ITEMS = {
         'key': 'ytdl_subscriptions_base_path',
         'path': 'YtdlMaterial.Subscriptions.subscriptions_base_path'
     },
-    'ytdl_subscriptions_check_interval': {
-        'key': 'ytdl_subscriptions_check_interval',
-        'path': 'YtdlMaterial.Subscriptions.subscriptions_check_interval'
-    },
     'ytdl_subscriptions_redownload_fresh_uploads': {
         'key': 'ytdl_subscriptions_redownload_fresh_uploads',
         'path': 'YtdlMaterial.Subscriptions.redownload_fresh_uploads'

--- a/backend/subscriptions.js
+++ b/backend/subscriptions.js
@@ -1216,48 +1216,62 @@ exports.redownloadSubscription = async (sub_id, user_uid = null) => {
 }
 
 let current_sub_index = 0; // To keep track of the current subscription
-exports.watchSubscriptionsInterval = async () => {
-    const subscriptions_check_interval = config_api.getConfigItem('ytdl_subscriptions_check_interval');
-    let parent_interval = setInterval(() => watchSubscriptions(), subscriptions_check_interval*1000);
-    watchSubscriptions();
-    config_api.config_updated.subscribe(change => {
-        if (!change) return;
-        if (change['key'] === 'ytdl_subscriptions_check_interval' || change['key'] === 'ytdl_multi_user_mode') {
-            current_sub_index = 0; // TODO: start after the last sub check
-            logger.verbose('Resetting sub check schedule due to config change');
-            clearInterval(parent_interval);
-            const new_interval = config_api.getConfigItem('ytdl_subscriptions_check_interval');
-            parent_interval = setInterval(() => watchSubscriptions(), new_interval*1000);
-            watchSubscriptions();
-        }
-    });
+exports.resetSubscriptionCheckCursor = () => {
+    current_sub_index = 0;
 }
 
-async function watchSubscriptions() {
-    const subscription_ids = await getValidSubscriptionsToCheck();
-    if (subscription_ids.length === 0) {
-        logger.info('Skipping subscription check as no valid subscriptions exist.');
-        return;
+exports.checkNextSubscription = async () => {
+    if (!config_api.getConfigItem('ytdl_allow_subscriptions')) {
+        logger.info('Skipping subscription check as subscriptions are disabled.');
+        return {
+            success: true,
+            checked: false,
+            reason: 'subscriptions_disabled'
+        };
     }
-    checkSubscription(subscription_ids[current_sub_index]);
+
+    const subscription_ids = await getValidSubscriptionsToCheck();
+    if (!subscription_ids || subscription_ids.length === 0) {
+        logger.info('Skipping subscription check as no valid subscriptions exist.');
+        return {
+            success: true,
+            checked: false,
+            reason: 'no_valid_subscriptions'
+        };
+    }
+
+    current_sub_index = current_sub_index % subscription_ids.length;
+    const sub_id = subscription_ids[current_sub_index];
     current_sub_index = (current_sub_index + 1) % subscription_ids.length;
+    const started = await checkSubscription(sub_id);
+
+    return {
+        success: started !== false,
+        checked: started !== false,
+        sub_id: sub_id
+    };
 }
 
 async function checkSubscription(sub_id) {
     let sub = await exports.getSubscription(sub_id);
 
+    if (!sub) {
+        logger.verbose(`Subscription: skipped check for missing subscription with uid ${sub_id}.`);
+        return false;
+    }
+
     // don't check the sub if the last check for the same subscription has not completed
     if (sub.downloading) {
         logger.verbose(`Subscription: skipped checking ${sub.name} as it's downloading videos.`);
-        return;
+        return false;
     }
 
     if (!sub.name) {
         logger.verbose(`Subscription: skipped check for subscription with uid ${sub.id} as name has not been retrieved yet.`);
-        return;
+        return false;
     }
 
-    await exports.getVideosForSub(sub.id);
+    return await exports.getVideosForSub(sub.id);
 }
 
 async function getValidSubscriptionsToCheck() {

--- a/backend/tasks.js
+++ b/backend/tasks.js
@@ -14,6 +14,14 @@ const fs = require('fs-extra');
 const path = require('path');
 const scheduler = require('node-schedule');
 
+const DEFAULT_SUBSCRIPTIONS_CHECK_SCHEDULE = {
+    type: 'recurring',
+    data: {
+        hour: 0,
+        minute: 0
+    }
+};
+
 const TASKS = {
     backup_local_db: {
         run: db_api.backupDB,
@@ -50,6 +58,11 @@ const TASKS = {
     rebuild_database: {
         run: rebuildDB,
         title: 'Rebuild database'
+    },
+    subscriptions_check: {
+        run: checkSubscriptions,
+        title: 'Check subscriptions',
+        defaultSchedule: () => JSON.parse(JSON.stringify(DEFAULT_SUBSCRIPTIONS_CHECK_SCHEDULE))
     }
 }
 const TASK_JOBS = new Map();
@@ -81,6 +94,27 @@ function ensureTaskJobAccessor(taskKey) {
 }
 for (const taskKey of Object.keys(TASKS)) {
     ensureTaskJobAccessor(taskKey);
+}
+
+function getDefaultTaskSchedule(task_key) {
+    const default_schedule = TASKS[task_key] && TASKS[task_key]['defaultSchedule'];
+    if (!default_schedule) return null;
+    const schedule = typeof default_schedule === 'function' ? default_schedule() : default_schedule;
+    return schedule ? JSON.parse(JSON.stringify(schedule)) : null;
+}
+
+function cancelTaskJob(task_key) {
+    const existing_job = TASK_JOBS.get(task_key);
+    if (existing_job) existing_job.cancel();
+    TASK_JOBS.delete(task_key);
+}
+
+function scheduleTaskJob(task_key, schedule) {
+    cancelTaskJob(task_key);
+    if (!schedule) return null;
+    const job = scheduleJob(task_key, schedule);
+    if (job) TASK_JOBS.set(task_key, job);
+    return job;
 }
 
 const defaultOptions = {
@@ -139,6 +173,7 @@ exports.setupTasks = async () => {
         const mergedDefaultOptions = Object.assign({}, defaultOptions['all'], defaultOptions[task_key] || {});
         const task_in_db = await db_api.getRecord('tasks', {key: task_key});
         if (!task_in_db) {
+            const default_schedule = getDefaultTaskSchedule(task_key);
             // insert task metadata into table if missing, eventually move title to UI
             await db_api.insertRecordIntoTable('tasks', {
                 key: task_key,
@@ -149,9 +184,10 @@ exports.setupTasks = async () => {
                 confirming: false,
                 data: null,
                 error: null,
-                schedule: null,
-                options: Object.assign({}, defaultOptions['all'], defaultOptions[task_key] || {})
+                schedule: default_schedule,
+                options: mergedDefaultOptions
             });
+            if (default_schedule) scheduleTaskJob(task_key, default_schedule);
         } else {
             // verify all options exist in task
             for (const key of Object.keys(mergedDefaultOptions)) {
@@ -170,10 +206,13 @@ exports.setupTasks = async () => {
             if (task_in_db['schedule']) {
                 // prevent timestamp schedules from being set to the past
                 if (task_in_db['schedule']['type'] === 'timestamp' && task_in_db['schedule']['data']['timestamp'] < Date.now()) {
+                    cancelTaskJob(task_key);
                     await db_api.updateRecord('tasks', {key: task_key}, {schedule: null});
                     continue;
                 }
-                TASK_JOBS.set(task_key, scheduleJob(task_key, task_in_db['schedule']));
+                scheduleTaskJob(task_key, task_in_db['schedule']);
+            } else {
+                cancelTaskJob(task_key);
             }
         }
     }
@@ -230,14 +269,12 @@ exports.updateTaskSchedule = async (task_key, schedule) => {
     }
     ensureTaskJobAccessor(task_key);
     await db_api.updateRecord('tasks', {key: task_key}, {schedule: schedule});
-    const existingJob = TASK_JOBS.get(task_key);
-    if (existingJob) {
-        existingJob.cancel();
-        TASK_JOBS.delete(task_key);
-    }
-    if (schedule) {
-        TASK_JOBS.set(task_key, scheduleJob(task_key, schedule));
-    }
+    scheduleTaskJob(task_key, schedule);
+    return true;
+}
+
+async function checkSubscriptions() {
+    return await subscriptions_api.checkNextSubscription();
 }
 
 // missing files check

--- a/backend/test/subscriptions.test.js
+++ b/backend/test/subscriptions.test.js
@@ -18,6 +18,7 @@ describe('Subscriptions', function() {
         await db_api.removeAllRecords('download_queue');
         await db_api.removeAllRecords('files');
         await db_api.removeAllRecords('archives');
+        config_api.setConfigItem('ytdl_allow_subscriptions', true);
         config_api.setConfigItem('ytdl_subscriptions_redownload_fresh_uploads', false);
         config_api.setConfigItem('ytdl_custom_args', '');
         config_api.setConfigItem('ytdl_skip_join_only_videos', false);
@@ -218,6 +219,48 @@ describe('Subscriptions', function() {
         await subscriptions_api.subscribe(new_sub, null, true);
         const subs = await subscriptions_api.getSubscriptions(null);
         assert(subs && subs.length === 1);
+    });
+    it('Checks valid subscriptions in round-robin order', async function() {
+        const original_get_videos_for_sub = subscriptions_api.getVideosForSub;
+        const checked_sub_ids = [];
+        const sub_one = Object.assign({}, new_sub, {
+            id: uuid(),
+            name: 'round_robin_sub_one',
+            paused: false
+        });
+        const sub_two = Object.assign({}, new_sub, {
+            id: uuid(),
+            name: 'round_robin_sub_two',
+            url: 'https://www.youtube.com/channel/round-robin-two',
+            paused: false
+        });
+        const paused_sub = Object.assign({}, new_sub, {
+            id: uuid(),
+            name: 'round_robin_paused_sub',
+            url: 'https://www.youtube.com/channel/round-robin-paused',
+            paused: true
+        });
+
+        subscriptions_api.getVideosForSub = async (sub_id) => {
+            checked_sub_ids.push(sub_id);
+            return true;
+        };
+
+        try {
+            subscriptions_api.resetSubscriptionCheckCursor();
+            await db_api.insertRecordIntoTable('subscriptions', sub_one);
+            await db_api.insertRecordIntoTable('subscriptions', sub_two);
+            await db_api.insertRecordIntoTable('subscriptions', paused_sub);
+
+            const first_result = await subscriptions_api.checkNextSubscription();
+            const second_result = await subscriptions_api.checkNextSubscription();
+
+            assert.strictEqual(first_result.checked, true);
+            assert.strictEqual(second_result.checked, true);
+            assert.deepStrictEqual(checked_sub_ids, [sub_one.id, sub_two.id]);
+        } finally {
+            subscriptions_api.getVideosForSub = original_get_videos_for_sub;
+        }
     });
     it('Get subscription refresh status with pending queue counts', async function() {
         await subscriptions_api.subscribe(new_sub, null, true);

--- a/backend/test/tasks.test.js
+++ b/backend/test/tasks.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-const { assert, fs, db_api, utils, generateEmptyVideoFile } = require('./test-shared');
+const { assert, fs, db_api, utils, subscriptions_api, generateEmptyVideoFile } = require('./test-shared');
 
 describe('Tasks', function() {
     const tasks_api = require('../tasks');
@@ -24,6 +24,38 @@ describe('Tasks', function() {
         const backups_new = await utils.recFindByExt('appdata', 'bak');
         const new_length = backups_new.length;
         assert(original_length === new_length-1);
+    });
+
+    it('Creates the subscription check task with a daily default schedule', async function() {
+        const task = await db_api.getRecord('tasks', {key: 'subscriptions_check'});
+
+        assert(task);
+        assert.strictEqual(task['title'], 'Check subscriptions');
+        assert.strictEqual(task['schedule']['type'], 'recurring');
+        assert.strictEqual(task['schedule']['data']['hour'], 0);
+        assert.strictEqual(task['schedule']['data']['minute'], 0);
+        assert(!!tasks_api.TASKS['subscriptions_check']['job']);
+    });
+
+    it('Runs subscription checks from the task manager', async function() {
+        const original_check_next_subscription = subscriptions_api.checkNextSubscription;
+        let check_next_subscription_called = false;
+
+        subscriptions_api.checkNextSubscription = async () => {
+            check_next_subscription_called = true;
+            return {success: true, checked: true, sub_id: 'test-subscription'};
+        };
+
+        try {
+            await tasks_api.executeRun('subscriptions_check');
+            const task = await db_api.getRecord('tasks', {key: 'subscriptions_check'});
+
+            assert(check_next_subscription_called);
+            assert(task['last_ran']);
+            assert.strictEqual(task['running'], false);
+        } finally {
+            subscriptions_api.checkNextSubscription = original_check_next_subscription;
+        }
     });
 
     it('Check for missing files', async function() {
@@ -112,4 +144,3 @@ describe('Tasks', function() {
         assert(dummy_task_obj['data']);
     });
 });
-

--- a/docker-environment.md
+++ b/docker-environment.md
@@ -17,6 +17,8 @@ These apply to many Docker setups regardless of which database or login method y
 
 For most setups, prefer Docker's `user: "<uid>:<gid>"` directly in your compose file together with `ytdl_uid` and `ytdl_gid` for clearer container isolation and ownership behavior.
 
+Subscription refresh scheduling is managed from the in-app Tasks page. It is not configured with a Docker environment variable.
+
 ## Database Variables
 
 If you use the provided default compose files, PostgreSQL is already wired up for you. If you want to stay on the local JSON database, you can skip most of this section.

--- a/src/api-types/models/TaskType.ts
+++ b/src/api-types/models/TaskType.ts
@@ -11,4 +11,5 @@ export enum TaskType {
     DELETE_OLD_FILES = 'delete_old_files',
     IMPORT_LEGACY_ARCHIVES = 'import_legacy_archives',
     REBUILD_DATABASE = 'rebuild_database',
+    SUBSCRIPTIONS_CHECK = 'subscriptions_check',
 }

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -54,13 +54,6 @@
                 <mat-hint><ng-container i18n="Subscriptions base path setting input hint">Base path for videos from your subscribed channels and playlists. It is relative to YTDL-Material's root folder.</ng-container></mat-hint>
               </mat-form-field>
             </div>
-            <div class="col-12 mt-4">
-              <mat-form-field class="text-field" color="accent">
-                <mat-label i18n="Check interval">Check interval</mat-label>
-                <input [disabled]="!new_config['Subscriptions']['allow_subscriptions']" [(ngModel)]="new_config['Subscriptions']['subscriptions_check_interval']" matInput>
-                <mat-hint><ng-container i18n="Check interval setting input hint">Unit is seconds, only include numbers.</ng-container></mat-hint>
-              </mat-form-field>
-            </div>
             <div class="col-12 mt-3 mb-3">
               <mat-checkbox color="accent" [(ngModel)]="new_config['Subscriptions']['redownload_fresh_uploads']" matTooltip="Sometimes new videos are downloaded before being fully processed. This setting will mean new videos will be checked for a higher quality version the following day." i18n-matTooltip="Redownload fresh uploads tooltip"><ng-container i18n="Redownload fresh uploads">Redownload fresh uploads</ng-container></mat-checkbox>
             </div>

--- a/src/assets/default.json
+++ b/src/assets/default.json
@@ -52,7 +52,6 @@
     "Subscriptions": {
       "allow_subscriptions": true,
       "subscriptions_base_path": "subscriptions/",
-      "subscriptions_check_interval": "86400",
       "subscriptions_use_youtubedl_archive": true,
       "redownload_fresh_uploads": false
     },


### PR DESCRIPTION
## Summary
- move automatic subscription refresh scheduling into the Tasks manager
- add a default daily `subscriptions_check` task that checks the next eligible subscription round-robin
- remove the old subscription interval config/env setting from defaults and Settings UI
- document that subscription refresh scheduling is managed in-app from Tasks

## Verification
- `node --check backend/app.js backend/config.js backend/consts.js backend/subscriptions.js backend/tasks.js backend/test/tasks.test.js backend/test/subscriptions.test.js`
- `npx mocha test/tasks.test.js test/subscriptions.test.js --exit -s 1000`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npm run lint`
- `npx ng build --configuration production`
- `git diff --check`