### PR TITLE
fix(tasks): run subscription refresh on startup

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -858,6 +858,7 @@ async function loadConfig() {
                 refresh_status: subscriptions_api.buildInterruptedSubscriptionRefreshStatus(sub.refresh_status)
             });
         }));
+        await tasks_api.executeRunOnStartup('subscriptions_check');
     }
 
     // start the server here

--- a/backend/tasks.js
+++ b/backend/tasks.js
@@ -66,6 +66,7 @@ const TASKS = {
     }
 }
 const TASK_JOBS = new Map();
+let setup_tasks_promise = null;
 
 // Backwards-compatible job access for tests/callers while storing jobs in a Map.
 function ensureTaskJobAccessor(taskKey) {
@@ -157,15 +158,17 @@ function scheduleJob(task_key, schedule) {
     });
 }
 
-if (db_api.database_initialized) {
-    exports.setupTasks();
-} else {
-    db_api.database_initialized_bs.subscribe(init => {
-        if (init) exports.setupTasks();
-    });
+exports.setupTasks = async () => {
+    if (setup_tasks_promise) return await setup_tasks_promise;
+    setup_tasks_promise = setupTasks();
+    try {
+        return await setup_tasks_promise;
+    } finally {
+        setup_tasks_promise = null;
+    }
 }
 
-exports.setupTasks = async () => {
+async function setupTasks() {
     const tasks_keys = Object.keys(TASKS);
     for (let i = 0; i < tasks_keys.length; i++) {
         const task_key = tasks_keys[i];
@@ -218,6 +221,14 @@ exports.setupTasks = async () => {
     }
 }
 
+if (db_api.database_initialized) {
+    exports.setupTasks();
+} else {
+    db_api.database_initialized_bs.subscribe(init => {
+        if (init) exports.setupTasks();
+    });
+}
+
 exports.executeTask = async (task_key) => {
     if (!TASKS[task_key]) {
         logger.error(`Task ${task_key} does not exist!`);
@@ -228,6 +239,28 @@ exports.executeTask = async (task_key) => {
     if (!TASKS[task_key]['confirm']) return;
     await exports.executeConfirm(task_key);
     logger.verbose(`Finished executing ${task_key}`);
+}
+
+exports.executeRunOnStartup = async (task_key) => {
+    if (!TASKS[task_key]) {
+        logger.error(`Task ${task_key} does not exist!`);
+        return false;
+    }
+
+    await exports.setupTasks();
+    const task_state = await db_api.getRecord('tasks', {key: task_key});
+    if (!task_state || !task_state['schedule']) {
+        logger.verbose(`Skipping startup run for task ${task_key} as it is not scheduled.`);
+        return false;
+    }
+
+    if (task_state['running'] || task_state['confirming']) {
+        logger.verbose(`Skipping startup run for task ${task_key} as it is already in progress.`);
+        return false;
+    }
+
+    await exports.executeRun(task_key);
+    return true;
 }
 
 exports.executeRun = async (task_key) => {

--- a/backend/test/tasks.test.js
+++ b/backend/test/tasks.test.js
@@ -58,6 +58,47 @@ describe('Tasks', function() {
         }
     });
 
+    it('Runs the scheduled subscription check task on startup', async function() {
+        const original_check_next_subscription = subscriptions_api.checkNextSubscription;
+        let check_next_subscription_called = false;
+
+        subscriptions_api.checkNextSubscription = async () => {
+            check_next_subscription_called = true;
+            return {success: true, checked: true, sub_id: 'startup-subscription'};
+        };
+
+        try {
+            const success = await tasks_api.executeRunOnStartup('subscriptions_check');
+            const task = await db_api.getRecord('tasks', {key: 'subscriptions_check'});
+
+            assert.strictEqual(success, true);
+            assert(check_next_subscription_called);
+            assert(task['last_ran']);
+        } finally {
+            subscriptions_api.checkNextSubscription = original_check_next_subscription;
+        }
+    });
+
+    it('Skips the startup subscription check when the task is not scheduled', async function() {
+        const original_check_next_subscription = subscriptions_api.checkNextSubscription;
+        let check_next_subscription_called = false;
+
+        subscriptions_api.checkNextSubscription = async () => {
+            check_next_subscription_called = true;
+            return {success: true};
+        };
+
+        try {
+            await tasks_api.updateTaskSchedule('subscriptions_check', null);
+            const success = await tasks_api.executeRunOnStartup('subscriptions_check');
+
+            assert.strictEqual(success, false);
+            assert.strictEqual(check_next_subscription_called, false);
+        } finally {
+            subscriptions_api.checkNextSubscription = original_check_next_subscription;
+        }
+    });
+
     it('Check for missing files', async function() {
         this.timeout(300000);
         await db_api.removeAllRecords('files', {uid: 'test'});


### PR DESCRIPTION
## Summary
- run the `subscriptions_check` task once during backend startup after interrupted subscription state is cleaned up
- keep startup execution tied to the task being scheduled, so disabling the task in Tasks disables automatic startup checks
- serialize task setup so startup execution waits for task metadata/jobs to exist

## Verification
- `node --check backend/app.js`
- `node --check backend/tasks.js`
- `node --check backend/test/tasks.test.js`
- `npx mocha test/tasks.test.js test/subscriptions.test.js --exit -s 1000`
- `npm run lint`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx ng build --configuration production`
- `CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npm run test:headless`
- `git diff --check`