### PR TITLE
feat(downloader): add yt-dlp impersonation support

### DIFF
--- a/backend/appdata/default.json
+++ b/backend/appdata/default.json
@@ -20,7 +20,8 @@
       "min_sleep_between_downloads": 0,
       "download_rate_limit": "",
       "playlist_chunk_size": 100,
-      "skip_join_only_videos": false
+      "skip_join_only_videos": false,
+      "use_ytdlp_impersonation": false
     },
     "Extra": {
       "title_top": "ytdl-material",

--- a/backend/config.js
+++ b/backend/config.js
@@ -12,6 +12,33 @@ let configPath = debugMode ? '../src/assets/default.json' : 'appdata/default.jso
 exports.config_updated = new BehaviorSubject();
 const CONFIG_ROOT_KEY = 'YtdlMaterial';
 const LEGACY_CONFIG_ROOT_KEY = ['Youtube', 'DLMaterial'].join('');
+const YTDLP_IMPERSONATION_DEPENDENCY_ENV_KEYS = [
+    'ytdl_enable_ytdlp_impersonation_dependencies',
+    'YTDL_ENABLE_YTDLP_IMPERSONATION_DEPENDENCIES',
+    'ytdl_enable_curl_cffi',
+    'YTDL_ENABLE_CURL_CFFI'
+];
+
+function isTruthyEnvValue(value) {
+    return typeof value === 'string' && ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase());
+}
+
+function isYtDlpImpersonationDependencyEnvEnabled() {
+    return YTDLP_IMPERSONATION_DEPENDENCY_ENV_KEYS.some(env_key => isTruthyEnvValue(process.env[env_key]));
+}
+
+function getDefaultConfig() {
+    const default_config = JSON.parse(JSON.stringify(DEFAULT_CONFIG));
+    if (isYtDlpImpersonationDependencyEnvEnabled()) {
+        default_config.YtdlMaterial.Downloader.use_ytdlp_impersonation = true;
+    }
+    return default_config;
+}
+
+function getDefaultConfigItemValue(key) {
+    const default_config = getDefaultConfig();
+    return Object.byString(default_config, exports.CONFIG_ITEMS[key]['path']);
+}
 
 function normalizeConfigRoot(config_json) {
     if (!config_json || typeof config_json !== 'object') return {normalized_config: config_json, migrated: false};
@@ -39,7 +66,7 @@ function ensureConfigItemsExist() {
 function ensureConfigFileExists() {
     if (!fs.existsSync(configPath)) {
         logger.info('Cannot find config file. Creating one with default values...');
-        fs.writeFileSync(configPath, JSON.stringify(DEFAULT_CONFIG, null, 2));
+        fs.writeFileSync(configPath, JSON.stringify(getDefaultConfig(), null, 2));
     }
 }
 
@@ -76,7 +103,7 @@ function getElementNameInConfig(path) {
 exports.configExistsCheck = () => {
     let exists = fs.existsSync(configPath);
     if (!exists) {
-        exports.setConfigFile(DEFAULT_CONFIG);
+        exports.setConfigFile(getDefaultConfig());
     }
 }
 
@@ -124,8 +151,9 @@ exports.getConfigItem = (key) => {
     const val = Object.byString(config_json, path);
     if (val === undefined && Object.byString(DEFAULT_CONFIG, path) !== undefined) {
         logger.warn(`Cannot find config with key '${key}'. Creating one with the default value...`);
-        exports.setConfigItem(key, Object.byString(DEFAULT_CONFIG, path));
-        return Object.byString(DEFAULT_CONFIG, path);
+        const default_value = getDefaultConfigItemValue(key);
+        exports.setConfigItem(key, default_value);
+        return default_value;
     }
     return Object.byString(config_json, path);
 }
@@ -232,7 +260,8 @@ const DEFAULT_CONFIG = {
         "min_sleep_between_downloads": 0,
         "playlist_chunk_size": 20,
         "download_rate_limit": "",
-        "skip_join_only_videos": false
+        "skip_join_only_videos": false,
+        "use_ytdlp_impersonation": false
       },
       "Extra": {
         "title_top": "ytdl-material",

--- a/backend/consts.js
+++ b/backend/consts.js
@@ -82,6 +82,10 @@ exports.CONFIG_ITEMS = {
         'key': 'ytdl_skip_join_only_videos',
         'path': 'YtdlMaterial.Downloader.skip_join_only_videos'
     },
+    'ytdl_use_ytdlp_impersonation': {
+        'key': 'ytdl_use_ytdlp_impersonation',
+        'path': 'YtdlMaterial.Downloader.use_ytdlp_impersonation'
+    },
 
     // Extra
     'ytdl_title_top': {
@@ -445,6 +449,7 @@ const YTDL_ARGS_WITH_VALUES = [
     '--cache-dir',
     '--encoding',
     '--user-agent',
+    '--impersonate',
     '--referer',
     '--add-header',
     '--sleep-interval',

--- a/backend/downloader.js
+++ b/backend/downloader.js
@@ -34,6 +34,7 @@ const FAST_PROGRESS_SIZE_THRESHOLD_BYTES = 100 * 1024 * 1024;
 const ANSI_ESCAPE_SEQUENCE_REGEX = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
 const DEFAULT_INVALID_FILENAME_CHARS = '\\/:*?"<>|';
 const METADATA_FIELDS_FOR_FILENAME_SANITIZATION = 'title,fulltitle,playlist_title,uploader,channel,series,chapter,album,artist';
+const DEFAULT_YTDLP_IMPERSONATION_ARG = '--impersonate=';
 const SKIPPABLE_SUBSCRIPTION_DOWNLOAD_ERROR_TYPES = new Set(['join_only', 'no_output', 'no_downloadable_items']);
 const SKIPPABLE_SUBSCRIPTION_DOWNLOAD_ERROR_TEXT = [
     'join this channel',
@@ -76,6 +77,21 @@ function hasArg(args = [], target_arg = '') {
     }
     return false;
 }
+
+function isYtDlpImpersonationEnabled() {
+    return !!config_api.getConfigItem('ytdl_use_ytdlp_impersonation');
+}
+exports.isYtDlpImpersonationEnabled = isYtDlpImpersonationEnabled;
+
+function appendYtDlpImpersonationArgs(download_args = [], downloader_fork = config_api.getConfigItem('ytdl_default_downloader')) {
+    if (!Array.isArray(download_args)) return [];
+    if (downloader_fork !== 'yt-dlp') return download_args;
+    if (!isYtDlpImpersonationEnabled()) return download_args;
+    if (hasArg(download_args, '--impersonate')) return download_args;
+
+    return download_args.concat([DEFAULT_YTDLP_IMPERSONATION_ARG]);
+}
+exports.appendYtDlpImpersonationArgs = appendYtDlpImpersonationArgs;
 
 function normalizeArchiveExtractor(value = null) {
     if (typeof value !== 'string') return null;
@@ -1141,7 +1157,8 @@ async function finalizePlaylistBatchContainer(download_uid = null) {
 exports.finalizePlaylistBatchContainer = finalizePlaylistBatchContainer;
 
 async function getPlaylistChunkingMetadata(url, options = {}) {
-    const probe_args = ['--flat-playlist', '--dump-single-json', '--ignore-errors'];
+    const downloader_fork = getPreferredDownloaderFork(options);
+    let probe_args = ['--flat-playlist', '--dump-single-json', '--ignore-errors'];
     if (url.includes('list=') && !probe_args.includes('--yes-playlist')) {
         probe_args.push('--yes-playlist');
     }
@@ -1155,9 +1172,11 @@ async function getPlaylistChunkingMetadata(url, options = {}) {
         probe_args.push('--cookies', path.join('appdata', 'cookies.txt'));
     }
 
+    probe_args = appendYtDlpImpersonationArgs(probe_args, downloader_fork);
+
     logger.debug(`Probing playlist metadata for automatic chunking: ${url}`);
     try {
-        const run_result = await youtubedl_api.runYoutubeDL(url, probe_args);
+        const run_result = await youtubedl_api.runYoutubeDL(url, probe_args, null, downloader_fork);
         if (!run_result || !run_result.callback) return null;
         const {parsed_output} = await run_result.callback;
         if (!Array.isArray(parsed_output) || parsed_output.length === 0) return null;
@@ -2046,6 +2065,7 @@ function shouldForceYtDlpForCustomQualityConfiguration(custom_quality_configurat
 
 function getPreferredDownloaderFork(options = {}) {
     if (options.forceYtDlp) return 'yt-dlp';
+    if (isYtDlpImpersonationEnabled()) return 'yt-dlp';
     const selected_audio_language = normalizeSelectedAudioLanguage(options.selectedAudioLanguage);
     const selected_subtitle_language = normalizeSelectedSubtitleLanguage(options.selectedSubtitleLanguage);
     const custom_quality_configuration = typeof options.customQualityConfiguration === 'string'
@@ -2270,6 +2290,8 @@ exports.generateArgs = async (url, type, options, user_uid = null, simulated = f
         }
 
     }
+
+    downloadConfig = appendYtDlpImpersonationArgs(downloadConfig, default_downloader);
 
     // filter out incompatible args
     downloadConfig = filterArgs(downloadConfig, is_audio);

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -2,35 +2,80 @@
 set -eu
 
 resolve_runtime_env() {
-    local preferred_name="$1"
-    local lowercase_legacy_name="$2"
-    local uppercase_legacy_name="$3"
-    local default_value="$4"
+    local default_value="$1"
+    shift
     local resolved_value=""
+    local env_name
 
-    resolved_value="$(printenv "$preferred_name" 2>/dev/null || true)"
-    if [ -n "$resolved_value" ]; then
-        printf '%s' "$resolved_value"
-        return
-    fi
-
-    resolved_value="$(printenv "$lowercase_legacy_name" 2>/dev/null || true)"
-    if [ -n "$resolved_value" ]; then
-        printf '%s' "$resolved_value"
-        return
-    fi
-
-    resolved_value="$(printenv "$uppercase_legacy_name" 2>/dev/null || true)"
-    if [ -n "$resolved_value" ]; then
-        printf '%s' "$resolved_value"
-        return
-    fi
+    for env_name in "$@"; do
+        resolved_value="$(printenv "$env_name" 2>/dev/null || true)"
+        if [ -n "$resolved_value" ]; then
+            printf '%s' "$resolved_value"
+            return
+        fi
+    done
 
     printf '%s' "$default_value"
 }
 
-runtime_uid="$(resolve_runtime_env ytdl_uid uid UID 1000)"
-runtime_gid="$(resolve_runtime_env ytdl_gid gid GID 1000)"
+is_truthy() {
+    case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+        1|true|yes|on)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+python_module_available() {
+    python3 - "$1" <<'PY'
+import importlib.util
+import sys
+
+sys.exit(0 if importlib.util.find_spec(sys.argv[1]) else 1)
+PY
+}
+
+install_ytdlp_impersonation_dependencies() {
+    local enabled
+    enabled="$(resolve_runtime_env false \
+        ytdl_enable_ytdlp_impersonation_dependencies \
+        YTDL_ENABLE_YTDLP_IMPERSONATION_DEPENDENCIES \
+        ytdl_enable_curl_cffi \
+        YTDL_ENABLE_CURL_CFFI)"
+
+    if ! is_truthy "$enabled"; then
+        return
+    fi
+
+    if python_module_available curl_cffi; then
+        echo "[entrypoint] yt-dlp impersonation dependency curl_cffi is already installed"
+        return
+    fi
+
+    if [ "$(id -u)" != "0" ]; then
+        echo "[entrypoint] ERROR: ytdl_enable_ytdlp_impersonation_dependencies is enabled,"
+        echo "[entrypoint] but curl_cffi is missing and the container is not running as root."
+        echo "[entrypoint] Start as root for the entrypoint install step, or bake curl_cffi into a custom image."
+        exit 1
+    fi
+
+    echo "[entrypoint] Installing optional yt-dlp impersonation dependencies"
+    python3 -m pip install --upgrade --break-system-packages "yt-dlp[default,curl-cffi]" yt-dlp-ejs || \
+        python3 -m pip install --upgrade "yt-dlp[default,curl-cffi]" yt-dlp-ejs
+
+    if ! python_module_available curl_cffi; then
+        echo "[entrypoint] ERROR: curl_cffi was not available after installation."
+        exit 1
+    fi
+}
+
+runtime_uid="$(resolve_runtime_env 1000 ytdl_uid uid UID)"
+runtime_gid="$(resolve_runtime_env 1000 ytdl_gid gid GID)"
+
+install_ytdlp_impersonation_dependencies
 
 # Check if we're running as root
 if [ "$(id -u)" = "0" ]; then

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@discordjs/builders": "^1.14.1",
-        "@discordjs/core": "^2.4.0",
+        "@discordjs/core": "^2.5.0",
         "@scalar/express-api-reference": "^0.10.3",
         "archiver": "^8.0.0",
         "async": "^3.2.3",
@@ -122,17 +122,17 @@
       }
     },
     "node_modules/@discordjs/core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/core/-/core-2.4.0.tgz",
-      "integrity": "sha512-+y9kvW94Zc/3IVZVBktSnC2tK45LTonfmhZh+ExUUsBlfgorMY/A+11jAcCbtzz15NtNrtUOJiMA1MGGJkv0/A==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-7wRdqrfT/cBOwDCj1wu8KrvolUad9fIdYTBk8EOzaz8+9Yqu38R2ZxEQEDxKU4kIi8p4UK8SGOjd6gV3hZZBjw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@discordjs/rest": "^2.6.0",
+        "@discordjs/rest": "^2.6.1",
         "@discordjs/util": "^1.2.0",
         "@discordjs/ws": "^2.0.4",
-        "@sapphire/snowflake": "^3.5.3",
+        "@sapphire/snowflake": "^3.5.5",
         "@vladfrangu/async_event_emitter": "^2.4.6",
-        "discord-api-types": "^0.38.33"
+        "discord-api-types": "^0.38.48"
       },
       "engines": {
         "node": ">=20"
@@ -1770,9 +1770,9 @@
       "license": "MIT"
     },
     "node_modules/discord-api-types": {
-      "version": "0.38.47",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.47.tgz",
-      "integrity": "sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA==",
+      "version": "0.38.48",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.48.tgz",
+      "integrity": "sha512-WFUE/2o0lBlLeCQonQ+Pu2RqHAqbytBJ2RlXR91gzk05InSS6k9ShzzLYoymrA4c2oRgRKGE7/VqQJNNdGWSxQ==",
       "license": "MIT",
       "workspaces": [
         "scripts/actions/documentation"

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,7 +24,7 @@
   "homepage": "",
   "dependencies": {
     "@discordjs/builders": "^1.14.1",
-    "@discordjs/core": "^2.4.0",
+    "@discordjs/core": "^2.5.0",
     "@scalar/express-api-reference": "^0.10.3",
     "archiver": "^8.0.0",
     "async": "^3.2.3",

--- a/backend/subscriptions.js
+++ b/backend/subscriptions.js
@@ -982,10 +982,12 @@ exports.subscribe = async (sub, user_uid = null, skip_get_info = false) => {
 
 async function getSubscriptionInfo(sub) {
     // get videos
+    const downloader_fork = downloader_api.getPreferredDownloaderFork({});
     let downloadConfig = ['--dump-json'];
     downloadConfig = applyCustomArgs(downloadConfig, config_api.getConfigItem('ytdl_custom_args'));
     downloadConfig = applyCustomArgs(downloadConfig, sub.custom_args);
     downloadConfig = utils.injectArgs(downloadConfig, ['--playlist-end', '1']);
+    downloadConfig = downloader_api.appendYtDlpImpersonationArgs(downloadConfig, downloader_fork);
     let useCookies = config_api.getConfigItem('ytdl_use_cookies');
     if (useCookies) {
         if (await fs.pathExists(path.join(__dirname, 'appdata', 'cookies.txt'))) {
@@ -998,7 +1000,7 @@ async function getSubscriptionInfo(sub) {
     // Note: yt-dlp-ejs is installed via pip and will be automatically detected
     // No --remote-components flag needed (would conflict with Deno's --no-remote flag)
 
-    let {callback} = await youtubedl_api.runYoutubeDL(sub.url, downloadConfig);
+    let {callback} = await youtubedl_api.runYoutubeDL(sub.url, downloadConfig, null, downloader_fork);
     const {parsed_output, err} = await callback;
     if (err) {
         logger.error(`Subscribe: failed to retrieve info for subscription ${sub.id}: ${describeSubscriptionInfoError(err)}`);
@@ -1329,10 +1331,11 @@ async function _getVideosForSub(sub) {
     logger.verbose(`Subscription: getting list of videos to download for ${sub.name} with args: ${utils.redactCommandArgsForLogging(discoveryDownloadConfig).join(',')}`);
 
     const refresh_stream_processor = createSubscriptionRefreshStreamProcessor(sub, user_uid, refresh_tracker, discovery_filter_context);
+    const downloader_fork = downloader_api.getPreferredDownloaderFork({});
     let {child_process, callback} = await youtubedl_api.runYoutubeDLLineStream(sub.url, discoveryDownloadConfig, {
         onStdoutLine: (line) => refresh_stream_processor.ingestLine(line),
         onStderrLine: (line) => refresh_stream_processor.ingestLine(line)
-    });
+    }, downloader_fork);
     await updateSubscriptionProperty(sub, {child_process: child_process}, user_uid);
     try {
         const {err} = await callback;
@@ -1446,7 +1449,7 @@ async function generateArgsForSubscription(sub, user_uid, redownload = false, de
     downloadConfig = applyCustomArgs(downloadConfig, config_api.getConfigItem('ytdl_custom_args'));
     downloadConfig = applyCustomArgs(downloadConfig, sub.custom_args);
 
-    const default_downloader = config_api.getConfigItem('ytdl_default_downloader');
+    const default_downloader = downloader_api.getPreferredDownloaderFork({});
     downloadConfig = downloader_api.appendFilenameSanitizationArgs(downloadConfig, default_downloader);
 
     if (sub.timerange && !redownload) {
@@ -1476,6 +1479,8 @@ async function generateArgsForSubscription(sub, user_uid, redownload = false, de
         // Note: yt-dlp-ejs is installed via pip and will be automatically detected
         // No --remote-components flag needed (would conflict with Deno's --no-remote flag)
     }
+
+    downloadConfig = downloader_api.appendYtDlpImpersonationArgs(downloadConfig, default_downloader);
 
     downloadConfig = utils.filterArgs(downloadConfig, ['--write-comments']);
 
@@ -2146,7 +2151,8 @@ async function checkVideoIfBetterExists(file_obj, sub, user_uid) {
         const metric_to_compare = sub.type === 'audio' ? 'abr' : 'height';
         if (info[metric_to_compare] > file_obj[metric_to_compare]) {
             // download new video as the simulated one is better
-            let {callback} = await youtubedl_api.runYoutubeDL(sub.url, downloadConfig);
+            const downloader_fork = downloader_api.getPreferredDownloaderFork({});
+            let {callback} = await youtubedl_api.runYoutubeDL(sub.url, downloadConfig, null, downloader_fork);
             const {parsed_output, err} = await callback;
             if (err) {
                 logger.verbose(`Failed to download better version of video ${file_obj['id']}`);

--- a/backend/test/downloader.test.js
+++ b/backend/test/downloader.test.js
@@ -245,6 +245,41 @@ describe('Downloader', function() {
         }
     });
 
+    it('Generate args appends yt-dlp browser impersonation when enabled', async function() {
+        const original_default_downloader = config_api.getConfigItem('ytdl_default_downloader');
+        const original_impersonation = config_api.getConfigItem('ytdl_use_ytdlp_impersonation');
+
+        try {
+            config_api.setConfigItem('ytdl_default_downloader', 'youtube-dl');
+            config_api.setConfigItem('ytdl_use_ytdlp_impersonation', true);
+
+            const args = await downloader_api.generateArgs(url, 'video', {ui_uid: uuid()}, null, true);
+            assert(args.includes('--impersonate='));
+            assert.strictEqual(downloader_api.getPreferredDownloaderFork({}), 'yt-dlp');
+        } finally {
+            config_api.setConfigItem('ytdl_default_downloader', original_default_downloader);
+            config_api.setConfigItem('ytdl_use_ytdlp_impersonation', original_impersonation);
+        }
+    });
+
+    it('Generate args does not duplicate manually configured impersonation args', async function() {
+        const original_impersonation = config_api.getConfigItem('ytdl_use_ytdlp_impersonation');
+
+        try {
+            config_api.setConfigItem('ytdl_use_ytdlp_impersonation', true);
+
+            const args = await downloader_api.generateArgs(url, 'video', {
+                customArgs: '--impersonate,,chrome',
+                ui_uid: uuid()
+            }, null, true);
+            const impersonate_args = args.filter(arg => arg === '--impersonate');
+            assert.strictEqual(impersonate_args.length, 1);
+            assert.strictEqual(args[args.indexOf('--impersonate') + 1], 'chrome');
+        } finally {
+            config_api.setConfigItem('ytdl_use_ytdlp_impersonation', original_impersonation);
+        }
+    });
+
     it('Download file', async function() {
         this.timeout(300000);
         await downloader_api.setupDownloads();

--- a/docker-compose-extended.yml
+++ b/docker-compose-extended.yml
@@ -15,6 +15,11 @@ services:
       # ytdl_db_migrate: 'postgres'
       write_ytdl_config: 'true'
 
+      # Optional yt-dlp browser impersonation support.
+      # When true, the entrypoint installs yt-dlp's curl_cffi extra before app startup.
+      # It also enables Settings > Downloader > Use yt-dlp browser impersonation on first startup.
+      # ytdl_enable_ytdlp_impersonation_dependencies: 'true'
+
       # Option 1: Let the container start as root, fix permissions, then drop privileges.
       # Default user/group IDs are 1000:1000.
       # ytdl_uid: 1000

--- a/docker-environment.md
+++ b/docker-environment.md
@@ -14,8 +14,14 @@ These apply to many Docker setups regardless of which database or login method y
 * `ytdl_uid` / `ytdl_gid`: app user/group IDs used inside the container
 * `ytdl_log_level`: backend log level (`error`, `warn`, `info`, `verbose`, `debug`), default `info`
 * `ytdl_umask`: set the process umask before startup (for example `'022'`)
+* `ytdl_enable_ytdlp_impersonation_dependencies`: set to `'true'` to install yt-dlp's optional `curl_cffi` browser impersonation dependency during container startup
 
 For most setups, prefer Docker's `user: "<uid>:<gid>"` directly in your compose file together with `ytdl_uid` and `ytdl_gid` for clearer container isolation and ownership behavior.
+
+If `ytdl_enable_ytdlp_impersonation_dependencies` is enabled, let the container start as root so the entrypoint can install the Python dependency before it drops privileges.
+Custom images that already include `curl_cffi` can still run directly as a non-root user.
+The first startup with this env flag also enables the Settings > Downloader > Use yt-dlp browser impersonation option when that setting does not exist yet.
+That setting adds yt-dlp's `--impersonate=""` option; installing `curl_cffi` alone only makes impersonation targets available.
 
 Subscription refresh scheduling is managed from the in-app Tasks page. It is not configured with a Docker environment variable.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "@typescript-eslint/eslint-plugin": "^8.61.0",
         "@typescript-eslint/parser": "^8.61.0",
         "ajv": "^8.20.0",
-        "eslint": "^10.4.1",
+        "eslint": "^10.5.0",
         "globals": "^17.6.0",
         "istanbul-lib-instrument": "^6.0.3",
         "jasmine-core": "~6.3.0",
@@ -5612,11 +5612,14 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.1.tgz",
-      "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
+      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@typescript-eslint/eslint-plugin": "^8.61.0",
     "@typescript-eslint/parser": "^8.61.0",
     "ajv": "^8.20.0",
-    "eslint": "^10.4.1",
+    "eslint": "^10.5.0",
     "globals": "^17.6.0",
     "istanbul-lib-instrument": "^6.0.3",
     "jasmine-core": "~6.3.0",

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -186,6 +186,9 @@
             <div class="col-12 mt-2 mb-2">
               <mat-checkbox color="accent" [(ngModel)]="new_config['Downloader']['skip_join_only_videos']"><ng-container i18n="Skip join-only videos setting">Skip join-only videos</ng-container></mat-checkbox>
             </div>
+            <div class="col-12 mt-2 mb-2">
+              <mat-checkbox color="accent" [(ngModel)]="new_config['Downloader']['use_ytdlp_impersonation']"><ng-container i18n="Use yt-dlp browser impersonation setting">Use yt-dlp browser impersonation</ng-container></mat-checkbox>
+            </div>
           </div>
         </div>
       }

--- a/src/assets/default.json
+++ b/src/assets/default.json
@@ -19,7 +19,9 @@
       "max_concurrent_downloads": 5,
       "min_sleep_between_downloads": 0,
       "playlist_chunk_size": 20,
-      "download_rate_limit": ""
+      "download_rate_limit": "",
+      "skip_join_only_videos": false,
+      "use_ytdlp_impersonation": false
     },
     "Extra": {
       "title_top": "ytdl-material",
@@ -31,7 +33,12 @@
       "settings_pin_required": false,
       "enable_downloads_manager": true,
       "allow_playlist_categorization": true,
-      "allow_autoplay": true
+      "allow_autoplay": true,
+      "force_autoplay": false,
+      "enable_notifications": true,
+      "enable_all_notifications": true,
+      "allowed_notification_types": [],
+      "enable_rss_feed": false
     },
     "API": {
       "use_API_key": false,
@@ -43,7 +50,22 @@
       "twitch_API_key": "",
       "twitch_auto_download_chat": true,
       "use_sponsorblock_API": false,
-      "generate_NFO_files": false
+      "generate_NFO_files": false,
+      "use_telegram_API": false,
+      "telegram_bot_token": "",
+      "use_ntfy_API": false,
+      "ntfy_topic_URL": "",
+      "use_gotify_API": false,
+      "gotify_server_URL": "",
+      "gotify_app_token": "",
+      "telegram_chat_id": "",
+      "telegram_webhook_proxy": "",
+      "webhook_URL": "",
+      "use_custom_webhook_template": false,
+      "custom_webhook_title_template": "{{event_name}}",
+      "custom_webhook_body_template": "{{event_body}}",
+      "discord_webhook_URL": "",
+      "slack_webhook_URL": ""
     },
     "Themes": {
       "default_theme": "default",
@@ -87,7 +109,8 @@
       "mongodb_connection_string": "mongodb://127.0.0.1:27017/?compressors=zlib",
       "postgresdb_connection_string": "postgresql://ytdl-material:ytdl-material@127.0.0.1:5432/ytdl-material",
       "db_migrate": "",
-      "use_local_db": false
+      "use_local_db": true,
+      "redis_connection_string": ""
     },
     "Advanced": {
       "use_default_downloading_agent": true,


### PR DESCRIPTION
## Summary
- add an opt-in Docker startup path to install yt-dlp curl_cffi impersonation dependencies
- add a Downloader setting that applies yt-dlp `--impersonate=` across downloads, probes, and subscriptions
- document the env flag only in the extended compose/docs and add backend coverage for generated args

Closes #264

## Verification
- npm test -- --grep "Generate args appends yt-dlp browser impersonation|Generate args does not duplicate manually configured impersonation args"
- npm run build
- docker compose -f docker-compose.yml config
- docker compose -f docker-compose-youtubedl-material.yml config
- docker compose -f docker-compose-extended.yml config
- bash -n backend/entrypoint.sh
- git diff --check