### PR TITLE
fix(docker): avoid runtime impersonation install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,9 +92,9 @@ RUN npm install -g pm2 && \
 # Install Deno system-wide for yt-dlp YouTube support
 RUN curl -fsSL https://deno.land/install.sh | DENO_INSTALL=/usr/local sh
 
-# Ensure yt-dlp and yt-dlp-ejs are up to date
-RUN pip install --upgrade yt-dlp yt-dlp-ejs --break-system-packages || \
-    pip install --upgrade yt-dlp yt-dlp-ejs
+# Ensure yt-dlp, yt-dlp-ejs, and optional browser impersonation support are available.
+RUN pip install --upgrade "yt-dlp[default,curl-cffi]" yt-dlp-ejs --break-system-packages || \
+    pip install --upgrade "yt-dlp[default,curl-cffi]" yt-dlp-ejs
 WORKDIR /app
 # User 1000 already exist from base image
 COPY --chown=$UID:$GID --from=utils [ "/usr/local/bin/ffmpeg", "/usr/local/bin/ffmpeg" ]

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -18,64 +18,8 @@ resolve_runtime_env() {
     printf '%s' "$default_value"
 }
 
-is_truthy() {
-    case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
-        1|true|yes|on)
-            return 0
-            ;;
-        *)
-            return 1
-            ;;
-    esac
-}
-
-python_module_available() {
-    python3 - "$1" <<'PY'
-import importlib.util
-import sys
-
-sys.exit(0 if importlib.util.find_spec(sys.argv[1]) else 1)
-PY
-}
-
-install_ytdlp_impersonation_dependencies() {
-    local enabled
-    enabled="$(resolve_runtime_env false \
-        ytdl_enable_ytdlp_impersonation_dependencies \
-        YTDL_ENABLE_YTDLP_IMPERSONATION_DEPENDENCIES \
-        ytdl_enable_curl_cffi \
-        YTDL_ENABLE_CURL_CFFI)"
-
-    if ! is_truthy "$enabled"; then
-        return
-    fi
-
-    if python_module_available curl_cffi; then
-        echo "[entrypoint] yt-dlp impersonation dependency curl_cffi is already installed"
-        return
-    fi
-
-    if [ "$(id -u)" != "0" ]; then
-        echo "[entrypoint] ERROR: ytdl_enable_ytdlp_impersonation_dependencies is enabled,"
-        echo "[entrypoint] but curl_cffi is missing and the container is not running as root."
-        echo "[entrypoint] Start as root for the entrypoint install step, or bake curl_cffi into a custom image."
-        exit 1
-    fi
-
-    echo "[entrypoint] Installing optional yt-dlp impersonation dependencies"
-    python3 -m pip install --upgrade --break-system-packages "yt-dlp[default,curl-cffi]" yt-dlp-ejs || \
-        python3 -m pip install --upgrade "yt-dlp[default,curl-cffi]" yt-dlp-ejs
-
-    if ! python_module_available curl_cffi; then
-        echo "[entrypoint] ERROR: curl_cffi was not available after installation."
-        exit 1
-    fi
-}
-
 runtime_uid="$(resolve_runtime_env 1000 ytdl_uid uid UID)"
 runtime_gid="$(resolve_runtime_env 1000 ytdl_gid gid GID)"
-
-install_ytdlp_impersonation_dependencies
 
 # Check if we're running as root
 if [ "$(id -u)" = "0" ]; then

--- a/backend/test/downloader-info.test.js
+++ b/backend/test/downloader-info.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-const { assert, path, fs, youtubedl_api, CONSTS } = require('./test-shared');
+const { assert, path, fs, youtubedl_api, config_api, CONSTS } = require('./test-shared');
 
 describe('downloader info', function() {
     const fork = 'yt-dlp';
@@ -82,5 +82,42 @@ describe('downloader info', function() {
         assert.strictEqual(details.version, null);
         assert.strictEqual(details.binary_exists, false);
         assert.strictEqual(details.loaded, false);
+    });
+
+    it('uses the system yt-dlp binary only when impersonation is enabled', function() {
+        const system_binary_path = path.join('test', 'tmp-system-yt-dlp');
+        const original_impersonation = config_api.getConfigItem('ytdl_use_ytdlp_impersonation');
+        const original_lower_env = process.env.ytdl_ytdlp_impersonation_binary;
+        const original_upper_env = process.env.YTDL_YTDLP_IMPERSONATION_BINARY;
+
+        try {
+            fs.ensureDirSync(path.dirname(system_binary_path));
+            fs.writeFileSync(system_binary_path, '');
+            process.env.ytdl_ytdlp_impersonation_binary = system_binary_path;
+            delete process.env.YTDL_YTDLP_IMPERSONATION_BINARY;
+
+            config_api.setConfigItem('ytdl_use_ytdlp_impersonation', false);
+            assert.strictEqual(youtubedl_api.getYoutubeDLRuntimePath(fork), binary_path);
+
+            config_api.setConfigItem('ytdl_use_ytdlp_impersonation', true);
+            assert.strictEqual(youtubedl_api.getYoutubeDLRuntimePath(fork), system_binary_path);
+            assert.strictEqual(
+                youtubedl_api.getYoutubeDLRuntimePath('youtube-dl'),
+                path.join('appdata', 'bin', 'youtube-dl' + (process.platform === 'win32' ? '.exe' : ''))
+            );
+        } finally {
+            config_api.setConfigItem('ytdl_use_ytdlp_impersonation', original_impersonation);
+            if (original_lower_env === undefined) {
+                delete process.env.ytdl_ytdlp_impersonation_binary;
+            } else {
+                process.env.ytdl_ytdlp_impersonation_binary = original_lower_env;
+            }
+            if (original_upper_env === undefined) {
+                delete process.env.YTDL_YTDLP_IMPERSONATION_BINARY;
+            } else {
+                process.env.YTDL_YTDLP_IMPERSONATION_BINARY = original_upper_env;
+            }
+            fs.removeSync(system_binary_path);
+        }
     });
 });

--- a/backend/youtube-dl.js
+++ b/backend/youtube-dl.js
@@ -13,6 +13,7 @@ const config_api = require('./config.js');
 
 const is_windows = process.platform === 'win32';
 const STREAMING_ERROR_BUFFER_LIMIT = 20000;
+const DEFAULT_SYSTEM_YTDLP_PATH = is_windows ? 'yt-dlp.exe' : '/usr/local/bin/yt-dlp';
 
 exports.youtubedl_forks = {
     'youtube-dl': {
@@ -50,6 +51,26 @@ function getYoutubeDLEnv() {
         HOME: '/tmp'
     };
 }
+
+function getConfiguredSystemYtDlpPath() {
+    return process.env.ytdl_ytdlp_impersonation_binary
+        || process.env.YTDL_YTDLP_IMPERSONATION_BINARY
+        || DEFAULT_SYSTEM_YTDLP_PATH;
+}
+
+function isYtDlpImpersonationEnabled() {
+    return !!config_api.getConfigItem('ytdl_use_ytdlp_impersonation');
+}
+
+function getYoutubeDLRuntimePath(youtubedl_fork = config_api.getConfigItem('ytdl_default_downloader')) {
+    if (youtubedl_fork === 'yt-dlp' && isYtDlpImpersonationEnabled()) {
+        const system_ytdlp_path = getConfiguredSystemYtDlpPath();
+        if (fs.existsSync(system_ytdlp_path)) return system_ytdlp_path;
+    }
+
+    return getYoutubeDLPath(youtubedl_fork);
+}
+exports.getYoutubeDLRuntimePath = getYoutubeDLRuntimePath;
 
 function appendStreamChunk(existing_output = '', chunk = null, limit = STREAMING_ERROR_BUFFER_LIMIT) {
     const chunk_text = chunk === null || chunk === undefined ? '' : chunk.toString();
@@ -104,7 +125,7 @@ function createLineStreamHandler(stream = null, line_handler = null) {
 
 exports.runYoutubeDL = async (url, args, customDownloadHandler = null, youtubedl_fork = null) => {
     const selected_fork = youtubedl_fork || config_api.getConfigItem('ytdl_default_downloader');
-    const output_file_path = getYoutubeDLPath(selected_fork);
+    const output_file_path = getYoutubeDLRuntimePath(selected_fork);
     if (!fs.existsSync(output_file_path)) await exports.checkForYoutubeDLUpdate(selected_fork);
     let callback = null;
     let child_process = null;
@@ -119,12 +140,12 @@ exports.runYoutubeDL = async (url, args, customDownloadHandler = null, youtubedl
 
 exports.runYoutubeDLLineStream = async (url, args, line_handlers = {}, youtubedl_fork = null) => {
     const selected_fork = youtubedl_fork || config_api.getConfigItem('ytdl_default_downloader');
-    const output_file_path = getYoutubeDLPath(selected_fork);
+    const output_file_path = getYoutubeDLRuntimePath(selected_fork);
     if (!fs.existsSync(output_file_path)) await exports.checkForYoutubeDLUpdate(selected_fork);
 
     const runtime_args = ensureJavascriptRuntimeArgs(args, selected_fork);
     logger.debug(`Spawning ${selected_fork} process in streaming mode with ${runtime_args.length + 1} arguments`);
-    const child_process = spawn(output_file_path, [url, ...runtime_args], {
+    const child_process = spawn(getYoutubeDLRuntimePath(selected_fork), [url, ...runtime_args], {
         stdio: ['ignore', 'pipe', 'pipe'],
         env: getYoutubeDLEnv()
     });
@@ -195,7 +216,7 @@ const runYoutubeDLCustom = async (url, args, customDownloadHandler) => {
 
 // Run youtube-dl in a subprocess (cancellable)
 const runYoutubeDLProcess = async (url, args, youtubedl_fork = config_api.getConfigItem('ytdl_default_downloader')) => {
-    const youtubedl_path = getYoutubeDLPath(youtubedl_fork);
+    const youtubedl_path = getYoutubeDLRuntimePath(youtubedl_fork);
     const binary_exists = fs.existsSync(youtubedl_path);
     if (!binary_exists) {
         const err = `Could not find path for ${youtubedl_fork} at ${youtubedl_path}`;
@@ -204,7 +225,7 @@ const runYoutubeDLProcess = async (url, args, youtubedl_fork = config_api.getCon
     }
     const runtime_args = ensureJavascriptRuntimeArgs(args, youtubedl_fork);
     logger.debug(`Spawning ${youtubedl_fork} process with ${runtime_args.length + 1} arguments`);
-    const child_process = execa(getYoutubeDLPath(youtubedl_fork), [url, ...runtime_args], {
+    const child_process = execa(youtubedl_path, [url, ...runtime_args], {
         maxBuffer: Infinity,
         stdin: 'ignore',
         buffer: true,

--- a/docker-compose-extended.yml
+++ b/docker-compose-extended.yml
@@ -16,8 +16,8 @@ services:
       write_ytdl_config: 'true'
 
       # Optional yt-dlp browser impersonation support.
-      # When true, the entrypoint installs yt-dlp's curl_cffi extra before app startup.
-      # It also enables Settings > Downloader > Use yt-dlp browser impersonation on first startup.
+      # When true, enables Settings > Downloader > Use yt-dlp browser impersonation on first startup.
+      # The Docker image already includes yt-dlp's curl_cffi extra; it is only used when impersonation is enabled.
       # ytdl_enable_ytdlp_impersonation_dependencies: 'true'
 
       # Option 1: Let the container start as root, fix permissions, then drop privileges.

--- a/docker-environment.md
+++ b/docker-environment.md
@@ -14,14 +14,13 @@ These apply to many Docker setups regardless of which database or login method y
 * `ytdl_uid` / `ytdl_gid`: app user/group IDs used inside the container
 * `ytdl_log_level`: backend log level (`error`, `warn`, `info`, `verbose`, `debug`), default `info`
 * `ytdl_umask`: set the process umask before startup (for example `'022'`)
-* `ytdl_enable_ytdlp_impersonation_dependencies`: set to `'true'` to install yt-dlp's optional `curl_cffi` browser impersonation dependency during container startup
+* `ytdl_enable_ytdlp_impersonation_dependencies`: set to `'true'` to enable yt-dlp browser impersonation on first startup when that setting does not exist yet
 
-For most setups, prefer Docker's `user: "<uid>:<gid>"` directly in your compose file together with `ytdl_uid` and `ytdl_gid` for clearer container isolation and ownership behavior.
+You can use Docker's `user: "<uid>:<gid>"` directly in your compose file together with `ytdl_uid` and `ytdl_gid` for clearer container isolation and ownership behavior.
 
-If `ytdl_enable_ytdlp_impersonation_dependencies` is enabled, let the container start as root so the entrypoint can install the Python dependency before it drops privileges.
-Custom images that already include `curl_cffi` can still run directly as a non-root user.
-The first startup with this env flag also enables the Settings > Downloader > Use yt-dlp browser impersonation option when that setting does not exist yet.
-That setting adds yt-dlp's `--impersonate=""` option; installing `curl_cffi` alone only makes impersonation targets available.
+The Docker image includes yt-dlp's optional `curl_cffi` browser impersonation dependency, but ytdl-material only uses the dependency-aware yt-dlp path when Settings > Downloader > Use yt-dlp browser impersonation is enabled.
+The first startup with `ytdl_enable_ytdlp_impersonation_dependencies` also enables that setting when it does not exist yet.
+That setting adds yt-dlp's `--impersonate=""` option; the bundled `curl_cffi` dependency only makes impersonation targets available.
 
 Subscription refresh scheduling is managed from the in-app Tasks page. It is not configured with a Docker environment variable.
 


### PR DESCRIPTION
## Summary
- bake yt-dlp's curl_cffi extra into the Docker image instead of installing it from the entrypoint
- keep existing UID/GID and Docker `user:` behavior unchanged; the env flag no longer requires startup as root
- use the system yt-dlp binary only when browser impersonation is enabled, so normal downloads keep using the existing managed appdata binary path
- update docs/comments to clarify that the env flag seeds the Settings > Downloader impersonation option and does not perform runtime installs

## Verification
- npm test -- --grep "uses the system yt-dlp binary only when impersonation is enabled|Generate args appends yt-dlp browser impersonation|Generate args does not duplicate manually configured impersonation args"
- npm test
- npm run build
- bash -n backend/entrypoint.sh
- docker compose -f docker-compose-extended.yml config
- git diff --check
- throwaway venv install/import check for `yt-dlp[default,curl-cffi]` + `curl_cffi`
