### PR TITLE
fix(docker): gate yt-dlp impersonation on env flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,9 +92,9 @@ RUN npm install -g pm2 && \
 # Install Deno system-wide for yt-dlp YouTube support
 RUN curl -fsSL https://deno.land/install.sh | DENO_INSTALL=/usr/local sh
 
-# Ensure yt-dlp, yt-dlp-ejs, and optional browser impersonation support are available.
-RUN pip install --upgrade "yt-dlp[default,curl-cffi]" yt-dlp-ejs --break-system-packages || \
-    pip install --upgrade "yt-dlp[default,curl-cffi]" yt-dlp-ejs
+# Ensure yt-dlp and yt-dlp-ejs are up to date
+RUN pip install --upgrade yt-dlp yt-dlp-ejs --break-system-packages || \
+    pip install --upgrade yt-dlp yt-dlp-ejs
 WORKDIR /app
 # User 1000 already exist from base image
 COPY --chown=$UID:$GID --from=utils [ "/usr/local/bin/ffmpeg", "/usr/local/bin/ffmpeg" ]

--- a/Public API v1.yaml
+++ b/Public API v1.yaml
@@ -2645,6 +2645,8 @@ components:
       properties:
         config_file:
           $ref: '#/components/schemas/Config'
+        ytdlp_impersonation_available:
+          type: boolean
         success:
           type: boolean
     SetConfigRequest:

--- a/backend/app.js
+++ b/backend/app.js
@@ -1232,6 +1232,7 @@ app.get('/api/config', function(req, res) {
     let config_file = config_api.getConfigFile();
     res.send({
         config_file: config_file,
+        ytdlp_impersonation_available: config_api.isYtDlpImpersonationDependencyEnvEnabled(),
         success: !!config_file
     });
 });

--- a/backend/config.js
+++ b/backend/config.js
@@ -26,6 +26,7 @@ function isTruthyEnvValue(value) {
 function isYtDlpImpersonationDependencyEnvEnabled() {
     return YTDLP_IMPERSONATION_DEPENDENCY_ENV_KEYS.some(env_key => isTruthyEnvValue(process.env[env_key]));
 }
+exports.isYtDlpImpersonationDependencyEnvEnabled = isYtDlpImpersonationDependencyEnvEnabled;
 
 function getDefaultConfig() {
     const default_config = JSON.parse(JSON.stringify(DEFAULT_CONFIG));

--- a/backend/downloader.js
+++ b/backend/downloader.js
@@ -79,7 +79,8 @@ function hasArg(args = [], target_arg = '') {
 }
 
 function isYtDlpImpersonationEnabled() {
-    return !!config_api.getConfigItem('ytdl_use_ytdlp_impersonation');
+    return config_api.isYtDlpImpersonationDependencyEnvEnabled()
+        && !!config_api.getConfigItem('ytdl_use_ytdlp_impersonation');
 }
 exports.isYtDlpImpersonationEnabled = isYtDlpImpersonationEnabled;
 

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -18,8 +18,72 @@ resolve_runtime_env() {
     printf '%s' "$default_value"
 }
 
+is_truthy() {
+    case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+        1|true|yes|on)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+python_target_has_ytdlp_impersonation() {
+    python3 - "$1" <<'PY'
+import importlib.util
+import sys
+
+sys.path.insert(0, sys.argv[1])
+missing = [
+    module
+    for module in ("yt_dlp", "curl_cffi")
+    if importlib.util.find_spec(module) is None
+]
+sys.exit(1 if missing else 0)
+PY
+}
+
+install_ytdlp_impersonation_dependencies() {
+    local enabled
+    local target_path
+
+    enabled="$(resolve_runtime_env false \
+        ytdl_enable_ytdlp_impersonation_dependencies \
+        YTDL_ENABLE_YTDLP_IMPERSONATION_DEPENDENCIES \
+        ytdl_enable_curl_cffi \
+        YTDL_ENABLE_CURL_CFFI)"
+
+    if ! is_truthy "$enabled"; then
+        return
+    fi
+
+    target_path="$(resolve_runtime_env appdata/ytdlp-impersonation/python \
+        ytdl_ytdlp_impersonation_python_path \
+        YTDL_YTDLP_IMPERSONATION_PYTHON_PATH)"
+
+    if python_target_has_ytdlp_impersonation "$target_path"; then
+        echo "[entrypoint] yt-dlp impersonation dependencies are already installed"
+        export PYTHONPATH="${target_path}${PYTHONPATH:+:${PYTHONPATH}}"
+        return
+    fi
+
+    echo "[entrypoint] Installing optional yt-dlp impersonation dependencies"
+    mkdir -p "$target_path"
+    python3 -m pip install --upgrade --target "$target_path" "yt-dlp[default,curl-cffi]" yt-dlp-ejs
+
+    if ! python_target_has_ytdlp_impersonation "$target_path"; then
+        echo "[entrypoint] ERROR: yt-dlp impersonation dependencies were not available after installation."
+        exit 1
+    fi
+
+    export PYTHONPATH="${target_path}${PYTHONPATH:+:${PYTHONPATH}}"
+}
+
 runtime_uid="$(resolve_runtime_env 1000 ytdl_uid uid UID)"
 runtime_gid="$(resolve_runtime_env 1000 ytdl_gid gid GID)"
+
+install_ytdlp_impersonation_dependencies
 
 # Check if we're running as root
 if [ "$(id -u)" = "0" ]; then

--- a/backend/test/downloader-info.test.js
+++ b/backend/test/downloader-info.test.js
@@ -84,40 +84,39 @@ describe('downloader info', function() {
         assert.strictEqual(details.loaded, false);
     });
 
-    it('uses the system yt-dlp binary only when impersonation is enabled', function() {
-        const system_binary_path = path.join('test', 'tmp-system-yt-dlp');
+    it('uses the Python yt-dlp runtime only when impersonation env and setting are enabled', function() {
         const original_impersonation = config_api.getConfigItem('ytdl_use_ytdlp_impersonation');
-        const original_lower_env = process.env.ytdl_ytdlp_impersonation_binary;
-        const original_upper_env = process.env.YTDL_YTDLP_IMPERSONATION_BINARY;
+        const original_dependency_env = process.env.ytdl_enable_ytdlp_impersonation_dependencies;
+        const original_upper_dependency_env = process.env.YTDL_ENABLE_YTDLP_IMPERSONATION_DEPENDENCIES;
 
         try {
-            fs.ensureDirSync(path.dirname(system_binary_path));
-            fs.writeFileSync(system_binary_path, '');
-            process.env.ytdl_ytdlp_impersonation_binary = system_binary_path;
-            delete process.env.YTDL_YTDLP_IMPERSONATION_BINARY;
+            delete process.env.ytdl_enable_ytdlp_impersonation_dependencies;
+            delete process.env.YTDL_ENABLE_YTDLP_IMPERSONATION_DEPENDENCIES;
 
             config_api.setConfigItem('ytdl_use_ytdlp_impersonation', false);
             assert.strictEqual(youtubedl_api.getYoutubeDLRuntimePath(fork), binary_path);
 
             config_api.setConfigItem('ytdl_use_ytdlp_impersonation', true);
-            assert.strictEqual(youtubedl_api.getYoutubeDLRuntimePath(fork), system_binary_path);
+            assert.strictEqual(youtubedl_api.getYoutubeDLRuntimePath(fork), binary_path);
+
+            process.env.ytdl_enable_ytdlp_impersonation_dependencies = 'true';
+            assert.strictEqual(youtubedl_api.getYoutubeDLRuntimePath(fork), process.platform === 'win32' ? 'python' : 'python3');
             assert.strictEqual(
                 youtubedl_api.getYoutubeDLRuntimePath('youtube-dl'),
                 path.join('appdata', 'bin', 'youtube-dl' + (process.platform === 'win32' ? '.exe' : ''))
             );
         } finally {
             config_api.setConfigItem('ytdl_use_ytdlp_impersonation', original_impersonation);
-            if (original_lower_env === undefined) {
-                delete process.env.ytdl_ytdlp_impersonation_binary;
+            if (original_dependency_env === undefined) {
+                delete process.env.ytdl_enable_ytdlp_impersonation_dependencies;
             } else {
-                process.env.ytdl_ytdlp_impersonation_binary = original_lower_env;
+                process.env.ytdl_enable_ytdlp_impersonation_dependencies = original_dependency_env;
             }
-            if (original_upper_env === undefined) {
-                delete process.env.YTDL_YTDLP_IMPERSONATION_BINARY;
+            if (original_upper_dependency_env === undefined) {
+                delete process.env.YTDL_ENABLE_YTDLP_IMPERSONATION_DEPENDENCIES;
             } else {
-                process.env.YTDL_YTDLP_IMPERSONATION_BINARY = original_upper_env;
+                process.env.YTDL_ENABLE_YTDLP_IMPERSONATION_DEPENDENCIES = original_upper_dependency_env;
             }
-            fs.removeSync(system_binary_path);
         }
     });
 });

--- a/backend/test/downloader.test.js
+++ b/backend/test/downloader.test.js
@@ -248,8 +248,10 @@ describe('Downloader', function() {
     it('Generate args appends yt-dlp browser impersonation when enabled', async function() {
         const original_default_downloader = config_api.getConfigItem('ytdl_default_downloader');
         const original_impersonation = config_api.getConfigItem('ytdl_use_ytdlp_impersonation');
+        const original_dependency_env = process.env.ytdl_enable_ytdlp_impersonation_dependencies;
 
         try {
+            process.env.ytdl_enable_ytdlp_impersonation_dependencies = 'true';
             config_api.setConfigItem('ytdl_default_downloader', 'youtube-dl');
             config_api.setConfigItem('ytdl_use_ytdlp_impersonation', true);
 
@@ -257,15 +259,49 @@ describe('Downloader', function() {
             assert(args.includes('--impersonate='));
             assert.strictEqual(downloader_api.getPreferredDownloaderFork({}), 'yt-dlp');
         } finally {
+            if (original_dependency_env === undefined) {
+                delete process.env.ytdl_enable_ytdlp_impersonation_dependencies;
+            } else {
+                process.env.ytdl_enable_ytdlp_impersonation_dependencies = original_dependency_env;
+            }
             config_api.setConfigItem('ytdl_default_downloader', original_default_downloader);
             config_api.setConfigItem('ytdl_use_ytdlp_impersonation', original_impersonation);
         }
     });
 
-    it('Generate args does not duplicate manually configured impersonation args', async function() {
+    it('Generate args does not append yt-dlp browser impersonation without the env flag', async function() {
         const original_impersonation = config_api.getConfigItem('ytdl_use_ytdlp_impersonation');
+        const original_dependency_env = process.env.ytdl_enable_ytdlp_impersonation_dependencies;
+        const original_upper_dependency_env = process.env.YTDL_ENABLE_YTDLP_IMPERSONATION_DEPENDENCIES;
 
         try {
+            delete process.env.ytdl_enable_ytdlp_impersonation_dependencies;
+            delete process.env.YTDL_ENABLE_YTDLP_IMPERSONATION_DEPENDENCIES;
+            config_api.setConfigItem('ytdl_use_ytdlp_impersonation', true);
+
+            const args = await downloader_api.generateArgs(url, 'video', {ui_uid: uuid()}, null, true);
+            assert(!args.includes('--impersonate='));
+        } finally {
+            config_api.setConfigItem('ytdl_use_ytdlp_impersonation', original_impersonation);
+            if (original_dependency_env === undefined) {
+                delete process.env.ytdl_enable_ytdlp_impersonation_dependencies;
+            } else {
+                process.env.ytdl_enable_ytdlp_impersonation_dependencies = original_dependency_env;
+            }
+            if (original_upper_dependency_env === undefined) {
+                delete process.env.YTDL_ENABLE_YTDLP_IMPERSONATION_DEPENDENCIES;
+            } else {
+                process.env.YTDL_ENABLE_YTDLP_IMPERSONATION_DEPENDENCIES = original_upper_dependency_env;
+            }
+        }
+    });
+
+    it('Generate args does not duplicate manually configured impersonation args', async function() {
+        const original_impersonation = config_api.getConfigItem('ytdl_use_ytdlp_impersonation');
+        const original_dependency_env = process.env.ytdl_enable_ytdlp_impersonation_dependencies;
+
+        try {
+            process.env.ytdl_enable_ytdlp_impersonation_dependencies = 'true';
             config_api.setConfigItem('ytdl_use_ytdlp_impersonation', true);
 
             const args = await downloader_api.generateArgs(url, 'video', {
@@ -277,6 +313,11 @@ describe('Downloader', function() {
             assert.strictEqual(args[args.indexOf('--impersonate') + 1], 'chrome');
         } finally {
             config_api.setConfigItem('ytdl_use_ytdlp_impersonation', original_impersonation);
+            if (original_dependency_env === undefined) {
+                delete process.env.ytdl_enable_ytdlp_impersonation_dependencies;
+            } else {
+                process.env.ytdl_enable_ytdlp_impersonation_dependencies = original_dependency_env;
+            }
         }
     });
 

--- a/backend/youtube-dl.js
+++ b/backend/youtube-dl.js
@@ -13,7 +13,7 @@ const config_api = require('./config.js');
 
 const is_windows = process.platform === 'win32';
 const STREAMING_ERROR_BUFFER_LIMIT = 20000;
-const DEFAULT_SYSTEM_YTDLP_PATH = is_windows ? 'yt-dlp.exe' : '/usr/local/bin/yt-dlp';
+const DEFAULT_YTDLP_IMPERSONATION_PATH = path.join('appdata', 'ytdlp-impersonation', 'python');
 
 exports.youtubedl_forks = {
     'youtube-dl': {
@@ -52,20 +52,39 @@ function getYoutubeDLEnv() {
     };
 }
 
-function getConfiguredSystemYtDlpPath() {
-    return process.env.ytdl_ytdlp_impersonation_binary
-        || process.env.YTDL_YTDLP_IMPERSONATION_BINARY
-        || DEFAULT_SYSTEM_YTDLP_PATH;
+function getYtDlpImpersonationPath() {
+    return process.env.ytdl_ytdlp_impersonation_python_path
+        || process.env.YTDL_YTDLP_IMPERSONATION_PYTHON_PATH
+        || DEFAULT_YTDLP_IMPERSONATION_PATH;
 }
 
 function isYtDlpImpersonationEnabled() {
-    return !!config_api.getConfigItem('ytdl_use_ytdlp_impersonation');
+    return config_api.isYtDlpImpersonationDependencyEnvEnabled()
+        && !!config_api.getConfigItem('ytdl_use_ytdlp_impersonation');
+}
+
+function useYtDlpImpersonationRuntime(youtubedl_fork = config_api.getConfigItem('ytdl_default_downloader')) {
+    return youtubedl_fork === 'yt-dlp' && isYtDlpImpersonationEnabled();
+}
+
+function getYoutubeDLRuntimeBaseArgs(youtubedl_fork = config_api.getConfigItem('ytdl_default_downloader')) {
+    return useYtDlpImpersonationRuntime(youtubedl_fork)
+        ? ['-m', 'yt_dlp']
+        : [];
+}
+
+function getYoutubeDLRuntimeEnv(youtubedl_fork = config_api.getConfigItem('ytdl_default_downloader')) {
+    const env = getYoutubeDLEnv();
+    if (useYtDlpImpersonationRuntime(youtubedl_fork)) {
+        const impersonation_path = getYtDlpImpersonationPath();
+        env.PYTHONPATH = env.PYTHONPATH ? `${impersonation_path}${path.delimiter}${env.PYTHONPATH}` : impersonation_path;
+    }
+    return env;
 }
 
 function getYoutubeDLRuntimePath(youtubedl_fork = config_api.getConfigItem('ytdl_default_downloader')) {
-    if (youtubedl_fork === 'yt-dlp' && isYtDlpImpersonationEnabled()) {
-        const system_ytdlp_path = getConfiguredSystemYtDlpPath();
-        if (fs.existsSync(system_ytdlp_path)) return system_ytdlp_path;
+    if (useYtDlpImpersonationRuntime(youtubedl_fork)) {
+        return is_windows ? 'python' : 'python3';
     }
 
     return getYoutubeDLPath(youtubedl_fork);
@@ -126,7 +145,9 @@ function createLineStreamHandler(stream = null, line_handler = null) {
 exports.runYoutubeDL = async (url, args, customDownloadHandler = null, youtubedl_fork = null) => {
     const selected_fork = youtubedl_fork || config_api.getConfigItem('ytdl_default_downloader');
     const output_file_path = getYoutubeDLRuntimePath(selected_fork);
-    if (!fs.existsSync(output_file_path)) await exports.checkForYoutubeDLUpdate(selected_fork);
+    if (!useYtDlpImpersonationRuntime(selected_fork) && !fs.existsSync(output_file_path)) {
+        await exports.checkForYoutubeDLUpdate(selected_fork);
+    }
     let callback = null;
     let child_process = null;
     if (customDownloadHandler) {
@@ -141,13 +162,16 @@ exports.runYoutubeDL = async (url, args, customDownloadHandler = null, youtubedl
 exports.runYoutubeDLLineStream = async (url, args, line_handlers = {}, youtubedl_fork = null) => {
     const selected_fork = youtubedl_fork || config_api.getConfigItem('ytdl_default_downloader');
     const output_file_path = getYoutubeDLRuntimePath(selected_fork);
-    if (!fs.existsSync(output_file_path)) await exports.checkForYoutubeDLUpdate(selected_fork);
+    if (!useYtDlpImpersonationRuntime(selected_fork) && !fs.existsSync(output_file_path)) {
+        await exports.checkForYoutubeDLUpdate(selected_fork);
+    }
 
     const runtime_args = ensureJavascriptRuntimeArgs(args, selected_fork);
+    const base_args = getYoutubeDLRuntimeBaseArgs(selected_fork);
     logger.debug(`Spawning ${selected_fork} process in streaming mode with ${runtime_args.length + 1} arguments`);
-    const child_process = spawn(getYoutubeDLRuntimePath(selected_fork), [url, ...runtime_args], {
+    const child_process = spawn(getYoutubeDLRuntimePath(selected_fork), [...base_args, url, ...runtime_args], {
         stdio: ['ignore', 'pipe', 'pipe'],
-        env: getYoutubeDLEnv()
+        env: getYoutubeDLRuntimeEnv(selected_fork)
     });
 
     let recent_stdout = '';
@@ -217,21 +241,22 @@ const runYoutubeDLCustom = async (url, args, customDownloadHandler) => {
 // Run youtube-dl in a subprocess (cancellable)
 const runYoutubeDLProcess = async (url, args, youtubedl_fork = config_api.getConfigItem('ytdl_default_downloader')) => {
     const youtubedl_path = getYoutubeDLRuntimePath(youtubedl_fork);
-    const binary_exists = fs.existsSync(youtubedl_path);
+    const binary_exists = useYtDlpImpersonationRuntime(youtubedl_fork) || fs.existsSync(youtubedl_path);
     if (!binary_exists) {
         const err = `Could not find path for ${youtubedl_fork} at ${youtubedl_path}`;
         logger.error(err);
         return;
     }
     const runtime_args = ensureJavascriptRuntimeArgs(args, youtubedl_fork);
+    const base_args = getYoutubeDLRuntimeBaseArgs(youtubedl_fork);
     logger.debug(`Spawning ${youtubedl_fork} process with ${runtime_args.length + 1} arguments`);
-    const child_process = execa(youtubedl_path, [url, ...runtime_args], {
+    const child_process = execa(youtubedl_path, [...base_args, url, ...runtime_args], {
         maxBuffer: Infinity,
         stdin: 'ignore',
         buffer: true,
         cleanup: true,    // Kill all child processes when parent exits
         killSignal: 'SIGKILL',  // Force kill instead of graceful SIGTERM
-        env: getYoutubeDLEnv()
+        env: getYoutubeDLRuntimeEnv(youtubedl_fork)
     });
 
     // Log when process exits

--- a/docker-compose-extended.yml
+++ b/docker-compose-extended.yml
@@ -16,8 +16,7 @@ services:
       write_ytdl_config: 'true'
 
       # Optional yt-dlp browser impersonation support.
-      # When true, enables Settings > Downloader > Use yt-dlp browser impersonation on first startup.
-      # The Docker image already includes yt-dlp's curl_cffi extra; it is only used when impersonation is enabled.
+      # Set true to install and show it; otherwise normal yt-dlp behavior is unchanged.
       # ytdl_enable_ytdlp_impersonation_dependencies: 'true'
 
       # Option 1: Let the container start as root, fix permissions, then drop privileges.

--- a/docker-environment.md
+++ b/docker-environment.md
@@ -14,13 +14,9 @@ These apply to many Docker setups regardless of which database or login method y
 * `ytdl_uid` / `ytdl_gid`: app user/group IDs used inside the container
 * `ytdl_log_level`: backend log level (`error`, `warn`, `info`, `verbose`, `debug`), default `info`
 * `ytdl_umask`: set the process umask before startup (for example `'022'`)
-* `ytdl_enable_ytdlp_impersonation_dependencies`: set to `'true'` to enable yt-dlp browser impersonation on first startup when that setting does not exist yet
+* `ytdl_enable_ytdlp_impersonation_dependencies`: set to `'true'` to install support, show the Downloader impersonation option, and enable it for new configs
 
 You can use Docker's `user: "<uid>:<gid>"` directly in your compose file together with `ytdl_uid` and `ytdl_gid` for clearer container isolation and ownership behavior.
-
-The Docker image includes yt-dlp's optional `curl_cffi` browser impersonation dependency, but ytdl-material only uses the dependency-aware yt-dlp path when Settings > Downloader > Use yt-dlp browser impersonation is enabled.
-The first startup with `ytdl_enable_ytdlp_impersonation_dependencies` also enables that setting when it does not exist yet.
-That setting adds yt-dlp's `--impersonate=""` option; the bundled `curl_cffi` dependency only makes impersonation targets available.
 
 Subscription refresh scheduling is managed from the in-app Tasks page. It is not configured with a Docker environment variable.
 

--- a/src/api-types/models/ConfigResponse.ts
+++ b/src/api-types/models/ConfigResponse.ts
@@ -6,5 +6,6 @@ import type { Config } from './Config';
 
 export type ConfigResponse = {
     config_file: Config;
+    ytdlp_impersonation_available?: boolean;
     success: boolean;
 };

--- a/src/app/posts.services.ts
+++ b/src/app/posts.services.ts
@@ -194,6 +194,7 @@ export class PostsService {
 
     // global vars
     config = null;
+    ytdlpImpersonationAvailable = false;
     subscriptions: Subscription[] = null;
     categories: Category[] = null;
     sidenav = null;
@@ -224,6 +225,7 @@ export class PostsService {
         this.getConfig().subscribe(res => {
             const result = !this.debugMode ? res['config_file'] : res;
             if (result) {
+                this.ytdlpImpersonationAvailable = !this.debugMode && !!res['ytdlp_impersonation_available'];
                 this.config = this.extractConfigRoot(result);
                 this.setPageTitle();
                 if (this.config['Advanced']['multi_user_mode']) {
@@ -323,6 +325,7 @@ export class PostsService {
         this.getConfig().subscribe(res => {
             const result = !this.debugMode ? res['config_file'] : res;
             if (result) {
+                this.ytdlpImpersonationAvailable = !this.debugMode && !!res['ytdlp_impersonation_available'];
                 this.config = this.extractConfigRoot(result);
                 this.setPageTitle();
                 this.config_reloaded.next(true);

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -186,9 +186,11 @@
             <div class="col-12 mt-2 mb-2">
               <mat-checkbox color="accent" [(ngModel)]="new_config['Downloader']['skip_join_only_videos']"><ng-container i18n="Skip join-only videos setting">Skip join-only videos</ng-container></mat-checkbox>
             </div>
+            @if (postsService.ytdlpImpersonationAvailable) {
             <div class="col-12 mt-2 mb-2">
               <mat-checkbox color="accent" [(ngModel)]="new_config['Downloader']['use_ytdlp_impersonation']"><ng-container i18n="Use yt-dlp browser impersonation setting">Use yt-dlp browser impersonation</ng-container></mat-checkbox>
             </div>
+            }
           </div>
         </div>
       }


### PR DESCRIPTION
## Summary
- install yt-dlp impersonation dependencies only when `ytdl_enable_ytdlp_impersonation_dependencies` is enabled
- hide the Downloader impersonation setting unless that env flag is enabled
- keep normal yt-dlp downloads on the existing managed binary path when the flag is absent
- simplify the Docker env docs wording

## Verification
- npm test -- --grep "uses the Python yt-dlp runtime only when impersonation env and setting are enabled|Generate args appends yt-dlp browser impersonation|Generate args does not append yt-dlp browser impersonation without the env flag|Generate args does not duplicate manually configured impersonation args"
- npm test
- npm run build
- bash -n backend/entrypoint.sh
- docker compose -f docker-compose-extended.yml config
- git diff --check
- entrypoint temp-dir install/import check for `yt-dlp[default,curl-cffi]`
