### PR TITLE
feat(categories): add defaults and reapply task

### DIFF
--- a/Public API v1.yaml
+++ b/Public API v1.yaml
@@ -1620,6 +1620,22 @@ paths:
       description: Creates a category
       security:
         - Auth query parameter: []
+  /api/createDefaultCategories:
+    post:
+      summary: Creates the default category set
+      tags:
+        - categories
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateDefaultCategoriesResponse'
+      operationId: post-api-createDefaultCategories
+      description: Creates the default category set when no categories exist
+      security:
+        - Auth query parameter: []
   /api/deleteCategory:
     post:
       summary: Deletes a category
@@ -2562,6 +2578,15 @@ components:
           $ref: '#/components/schemas/Category'
         success:
           type: boolean
+    CreateDefaultCategoriesResponse:
+      allOf:
+        - $ref: '#/components/schemas/SuccessObject'
+        - type: object
+          properties:
+            categories:
+              type: array
+              items:
+                $ref: '#/components/schemas/Category'
     CreateCategoryRequest:
       required:
         - name
@@ -2855,6 +2880,7 @@ components:
       - delete_old_files
       - import_legacy_archives
       - rebuild_database
+      - apply_categories
       - subscriptions_check
     Schedule:
       required:
@@ -3117,6 +3143,19 @@ components:
             - 'not_includes'
             - 'equals'
             - 'not_equals'
+        property:
+          type: string
+          enum:
+            - fulltitle
+            - id
+            - webpage_url
+            - view_count
+            - uploader
+            - categories
+            - _filename
+            - tags
+        value:
+          type: string
     Version:
       type: object
       properties:

--- a/backend/app.js
+++ b/backend/app.js
@@ -1709,6 +1709,24 @@ app.post('/api/createCategory', optionalJwt, async (req, res) => {
     });
 });
 
+app.post('/api/createDefaultCategories', optionalJwt, async (req, res) => {
+    const existing_categories = await db_api.getRecords('categories');
+    if (existing_categories && existing_categories.length > 0) {
+        res.send({
+            success: false,
+            categories: existing_categories,
+            error: 'Default categories can only be added when no categories exist.'
+        });
+        return;
+    }
+
+    const categories = await categories_api.createDefaultCategories();
+    res.send({
+        success: true,
+        categories: categories
+    });
+});
+
 app.post('/api/deleteCategory', optionalJwt, async (req, res) => {
     const category_uid = req.body.category_uid;
 

--- a/backend/categories.js
+++ b/backend/categories.js
@@ -1,6 +1,8 @@
 const utils = require('./utils');
 const logger = require('./logger');
 const db_api = require('./db');
+const path = require('path');
+const { v4: uuid } = require('uuid');
 /*
 
 Categories:
@@ -21,20 +23,207 @@ Rules:
 
 */
 
+const DEFAULT_CATEGORY_TEMPLATES = [
+    {
+        name: 'Music',
+        rules: [
+            rule('categories', 'includes', 'Music'),
+            rule('uploader', 'includes', 'VEVO'),
+            rule('fulltitle', 'includes', 'official music video'),
+            rule('fulltitle', 'includes', 'live performance'),
+            rule('fulltitle', 'includes', 'lyric video'),
+            rule('tags', 'includes', 'music')
+        ]
+    },
+    {
+        name: 'Technology',
+        rules: [
+            rule('categories', 'includes', 'Science & Technology'),
+            rule('uploader', 'includes', 'MKBHD'),
+            rule('uploader', 'includes', 'Linus Tech Tips'),
+            rule('fulltitle', 'includes', 'tech review'),
+            rule('fulltitle', 'includes', 'phone review'),
+            rule('fulltitle', 'includes', 'laptop review'),
+            rule('fulltitle', 'includes', 'PC build'),
+            rule('fulltitle', 'includes', 'computer setup')
+        ]
+    },
+    {
+        name: 'Sports',
+        rules: [
+            rule('categories', 'includes', 'Sports'),
+            rule('fulltitle', 'includes', 'sports highlights'),
+            rule('fulltitle', 'includes', 'match highlights'),
+            rule('fulltitle', 'includes', 'game recap'),
+            rule('fulltitle', 'includes', 'postgame'),
+            rule('uploader', 'includes', 'ESPN')
+        ]
+    },
+    {
+        name: 'Documentary',
+        rules: [
+            rule('fulltitle', 'includes', 'documentary'),
+            rule('fulltitle', 'includes', 'full documentary'),
+            rule('fulltitle', 'includes', 'explained')
+        ]
+    },
+    {
+        name: 'Education',
+        rules: [
+            rule('categories', 'includes', 'Education'),
+            rule('fulltitle', 'includes', 'tutorial'),
+            rule('fulltitle', 'includes', 'course'),
+            rule('fulltitle', 'includes', 'lecture'),
+            rule('fulltitle', 'includes', 'how to')
+        ]
+    },
+    {
+        name: 'News',
+        rules: [
+            rule('categories', 'includes', 'News & Politics'),
+            rule('uploader', 'includes', 'BBC News'),
+            rule('uploader', 'includes', 'PBS NewsHour'),
+            rule('uploader', 'includes', 'Reuters'),
+            rule('fulltitle', 'includes', 'breaking news')
+        ]
+    },
+    {
+        name: 'Gaming',
+        rules: [
+            rule('categories', 'includes', 'Gaming'),
+            rule('fulltitle', 'includes', 'gameplay'),
+            rule('fulltitle', 'includes', 'walkthrough'),
+            rule('fulltitle', 'includes', 'lets play'),
+            rule('fulltitle', 'includes', 'let\'s play'),
+            rule('uploader', 'includes', 'IGN')
+        ]
+    },
+    {
+        name: 'Entertainment',
+        rules: [
+            rule('categories', 'includes', 'Entertainment'),
+            rule('fulltitle', 'includes', 'behind the scenes'),
+            rule('fulltitle', 'includes', 'reaction')
+        ]
+    },
+    {
+        name: 'Film & TV',
+        rules: [
+            rule('categories', 'includes', 'Film & Animation'),
+            rule('fulltitle', 'includes', 'movie'),
+            rule('fulltitle', 'includes', 'film'),
+            rule('fulltitle', 'includes', 'tv show'),
+            rule('fulltitle', 'includes', 'trailer')
+        ]
+    },
+    {
+        name: 'Comedy',
+        rules: [
+            rule('categories', 'includes', 'Comedy'),
+            rule('fulltitle', 'includes', 'comedy'),
+            rule('fulltitle', 'includes', 'stand up'),
+            rule('fulltitle', 'includes', 'stand-up'),
+            rule('fulltitle', 'includes', 'sketch')
+        ]
+    },
+    {
+        name: 'Podcasts & Interviews',
+        rules: [
+            rule('fulltitle', 'includes', 'podcast'),
+            rule('fulltitle', 'includes', 'interview'),
+            rule('fulltitle', 'includes', 'conversation')
+        ]
+    },
+    {
+        name: 'Cooking',
+        rules: [
+            rule('fulltitle', 'includes', 'recipe'),
+            rule('fulltitle', 'includes', 'cooking'),
+            rule('fulltitle', 'includes', 'bake'),
+            rule('tags', 'includes', 'cooking'),
+            rule('uploader', 'includes', 'Bon App')
+        ]
+    },
+    {
+        name: 'Travel',
+        rules: [
+            rule('categories', 'includes', 'Travel & Events'),
+            rule('fulltitle', 'includes', 'travel'),
+            rule('fulltitle', 'includes', 'travel vlog'),
+            rule('fulltitle', 'includes', 'city guide')
+        ]
+    },
+    {
+        name: 'Fitness',
+        rules: [
+            rule('fulltitle', 'includes', 'workout'),
+            rule('fulltitle', 'includes', 'exercise'),
+            rule('fulltitle', 'includes', 'fitness'),
+            rule('tags', 'includes', 'fitness')
+        ]
+    },
+    {
+        name: 'DIY',
+        rules: [
+            rule('fulltitle', 'includes', 'diy'),
+            rule('fulltitle', 'includes', 'repair'),
+            rule('fulltitle', 'includes', 'build'),
+            rule('tags', 'includes', 'diy')
+        ]
+    }
+];
+
+const RULE_PROPERTY_ALIASES = {
+    fulltitle: ['fulltitle', 'title'],
+    webpage_url: ['webpage_url', 'url'],
+    _filename: ['_filename', 'path'],
+    id: ['id', 'source_id', 'uid'],
+    categories: ['categories']
+};
+
+function rule(property, comparator, value, preceding_operator = 'or') {
+    return {
+        preceding_operator: preceding_operator,
+        property: property,
+        comparator: comparator,
+        value: value
+    };
+}
+
+function cloneDefaultCategoryTemplate(category) {
+    return {
+        name: category.name,
+        uid: uuid(),
+        rules: category.rules.map((category_rule, index) => ({
+            ...category_rule,
+            preceding_operator: index === 0 ? null : category_rule.preceding_operator
+        })),
+        custom_output: ''
+    };
+}
+
 async function categorize(file_jsons) {
     // to make the logic easier, let's assume the file metadata is an array
     if (!Array.isArray(file_jsons)) file_jsons = [file_jsons];
 
-    let selected_category = null;
     const categories = await getCategories();
     if (!categories) {
         logger.warn('Categories could not be found.');
         return null;
     }
 
+    return getCategoryForMetadata(file_jsons, categories);
+}
+
+function getCategoryForMetadata(file_jsons, categories) {
+    let selected_category = null;
+    if (!Array.isArray(file_jsons)) file_jsons = [file_jsons];
+    if (!Array.isArray(categories) || categories.length === 0) return null;
+
     for (const file_json of file_jsons) {
         for (const category of categories) {
             const rules = category['rules'];
+            if (!Array.isArray(rules) || rules.length === 0) continue;
     
             // if rules for current category apply, then that is the selected category
             if (applyCategoryRules(file_json, rules, category['name'])) {
@@ -51,6 +240,16 @@ async function categorize(file_jsons) {
 async function getCategories() {
     const categories = await db_api.getRecords('categories');
     return categories ? categories : null;
+}
+
+function getDefaultCategories() {
+    return DEFAULT_CATEGORY_TEMPLATES.map(cloneDefaultCategoryTemplate);
+}
+
+async function createDefaultCategories() {
+    const categories = getDefaultCategories();
+    await db_api.insertRecordsIntoTable('categories', categories);
+    return categories;
 }
 
 async function getCategoriesAsPlaylists() {
@@ -101,16 +300,16 @@ function applyCategoryRules(file_json, rules, category_name) {
 
         switch (rule['comparator']) {
             case 'includes':
-                rule_applies = file_json[rule['property']].toLowerCase().includes(rule['value'].toLowerCase());
+                rule_applies = valueIncludes(getRulePropertyValue(file_json, rule['property']), rule['value']);
                 break;
             case 'not_includes':
-                rule_applies = !(file_json[rule['property']].toLowerCase().includes(rule['value'].toLowerCase()));
+                rule_applies = !valueIncludes(getRulePropertyValue(file_json, rule['property']), rule['value']);
                 break;
             case 'equals':
-                rule_applies = file_json[rule['property']] === rule['value'];
+                rule_applies = valueEquals(getRulePropertyValue(file_json, rule['property']), rule['value']);
                 break;
             case 'not_equals':
-                rule_applies = file_json[rule['property']] !== rule['value'];
+                rule_applies = !valueEquals(getRulePropertyValue(file_json, rule['property']), rule['value']);
                 break;
             default:
                 logger.warn(`Invalid comparison used for category ${category_name}`)
@@ -128,6 +327,93 @@ function applyCategoryRules(file_json, rules, category_name) {
     }
 
     return rules_apply;
+}
+
+function getRulePropertyValue(file_json, property) {
+    if (!file_json || !property) return null;
+    const aliases = RULE_PROPERTY_ALIASES[property] || [property];
+
+    for (const candidate_property of aliases) {
+        const value = file_json[candidate_property];
+        if (value !== undefined && value !== null) return value;
+    }
+
+    return null;
+}
+
+function normalizeComparableValues(value) {
+    if (value === undefined || value === null) return [];
+    if (Array.isArray(value)) return value.flatMap(normalizeComparableValues);
+    if (typeof value === 'object') return [JSON.stringify(value)];
+    return [String(value)];
+}
+
+function normalizeRuleValue(value) {
+    if (value === undefined || value === null) return '';
+    return String(value).trim();
+}
+
+function valueIncludes(value, rule_value) {
+    const normalized_rule_value = normalizeRuleValue(rule_value);
+    if (!normalized_rule_value) return false;
+
+    const lower_rule_value = normalized_rule_value.toLowerCase();
+    return normalizeComparableValues(value)
+        .some(candidate => candidate.toLowerCase().includes(lower_rule_value));
+}
+
+function valueEquals(value, rule_value) {
+    const normalized_rule_value = normalizeRuleValue(rule_value);
+    if (!normalized_rule_value) return false;
+
+    return normalizeComparableValues(value)
+        .some(candidate => candidate === normalized_rule_value);
+}
+
+function buildMetadataForFile(file_obj = {}) {
+    const type = file_obj.isAudio ? 'audio' : 'video';
+    const sidecar_metadata = file_obj.path ? utils.getJSON(file_obj.path, type) : null;
+    const metadata = sidecar_metadata && typeof sidecar_metadata === 'object' ? sidecar_metadata : {};
+    const merged_metadata = {
+        ...file_obj,
+        ...metadata,
+        title: metadata.title || file_obj.title,
+        fulltitle: metadata.fulltitle || metadata.title || file_obj.title,
+        webpage_url: metadata.webpage_url || file_obj.url,
+        url: metadata.webpage_url || metadata.url || file_obj.url,
+        uploader: metadata.uploader || file_obj.uploader,
+        view_count: metadata.view_count || file_obj.view_count,
+        _filename: metadata._filename || file_obj.path,
+        path: file_obj.path || metadata._filename
+    };
+
+    if (!merged_metadata.id) merged_metadata.id = file_obj.source_id || file_obj.id || file_obj.uid;
+    if (!merged_metadata._filename && file_obj.path) merged_metadata._filename = path.basename(file_obj.path);
+
+    return merged_metadata;
+}
+
+async function applyCategoriesToExistingFiles() {
+    const categories = await getCategories();
+    const files = await db_api.getRecords('files') || [];
+    let categorized_count = 0;
+    let uncategorized_count = 0;
+
+    for (const file_obj of files) {
+        const category = getCategoryForMetadata(buildMetadataForFile(file_obj), categories);
+        const stripped_category = category ? {name: category['name'], uid: category['uid']} : null;
+        await db_api.updateRecord('files', {uid: file_obj.uid}, {category: stripped_category});
+
+        if (stripped_category) categorized_count++;
+        else uncategorized_count++;
+    }
+
+    logger.info(`Applied categories to ${files.length} existing files (${categorized_count} categorized, ${uncategorized_count} uncategorized).`);
+    return {
+        file_count: files.length,
+        categorized_count: categorized_count,
+        uncategorized_count: uncategorized_count
+    };
 }
 
 // async function addTagToVideo(tag, video, user_uid) {
@@ -149,5 +435,9 @@ function applyCategoryRules(file_json, rules, category_name) {
 module.exports = {
     categorize: categorize,
     getCategories: getCategories,
-    getCategoriesAsPlaylists: getCategoriesAsPlaylists
+    getDefaultCategories: getDefaultCategories,
+    createDefaultCategories: createDefaultCategories,
+    getCategoriesAsPlaylists: getCategoriesAsPlaylists,
+    applyCategoriesToExistingFiles: applyCategoriesToExistingFiles,
+    _applyCategoryRules: applyCategoryRules
 }

--- a/backend/tasks.js
+++ b/backend/tasks.js
@@ -4,6 +4,7 @@ const youtubedl_api = require('./youtube-dl');
 const archive_api = require('./archive');
 const files_api = require('./files');
 const subscriptions_api = require('./subscriptions');
+const categories_api = require('./categories');
 const config_api = require('./config');
 const auth_api = require('./authentication/auth');
 const utils = require('./utils');
@@ -58,6 +59,10 @@ const TASKS = {
     rebuild_database: {
         run: rebuildDB,
         title: 'Rebuild database'
+    },
+    apply_categories: {
+        run: categories_api.applyCategoriesToExistingFiles,
+        title: 'Apply categories to existing files'
     },
     subscriptions_check: {
         run: checkSubscriptions,

--- a/backend/test/categories.test.js
+++ b/backend/test/categories.test.js
@@ -103,5 +103,47 @@ describe('Categories', async function() {
         const category = await categories_api.categorize([sample_video_json]);
         assert(category);
     });
-});
 
+    it('Categorize - source category arrays', async function() {
+        await db_api.removeAllRecords('categories');
+        try {
+            const new_category = {
+                name: 'Music',
+                uid: uuid(),
+                rules: [{
+                    preceding_operator: null,
+                    comparator: 'includes',
+                    property: 'categories',
+                    value: 'Music'
+                }],
+                custom_output: ''
+            };
+            await db_api.insertRecordIntoTable('categories', new_category);
+
+            const category = await categories_api.categorize([{
+                ...sample_video_json,
+                categories: ['Music']
+            }]);
+            assert(category && category.name === 'Music');
+        } finally {
+            await db_api.removeAllRecords('categories');
+        }
+    });
+
+    it('Create default categories', async function() {
+        await db_api.removeAllRecords('categories');
+        try {
+            const categories = await categories_api.createDefaultCategories();
+            const saved_categories = await db_api.getRecords('categories');
+            const music_category = saved_categories.find(category => category.name === 'Music');
+
+            assert(categories.length >= 10);
+            assert.strictEqual(saved_categories.length, categories.length);
+            assert(music_category);
+            assert(music_category.rules.some(category_rule => category_rule.property === 'categories' && category_rule.value === 'Music'));
+            assert.strictEqual(music_category.rules[0].preceding_operator, null);
+        } finally {
+            await db_api.removeAllRecords('categories');
+        }
+    });
+});

--- a/backend/test/tasks.test.js
+++ b/backend/test/tasks.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-const { assert, fs, db_api, utils, subscriptions_api, generateEmptyVideoFile } = require('./test-shared');
+const { assert, fs, uuid, db_api, utils, subscriptions_api, generateEmptyVideoFile } = require('./test-shared');
 
 describe('Tasks', function() {
     const tasks_api = require('../tasks');
@@ -35,6 +35,15 @@ describe('Tasks', function() {
         assert.strictEqual(task['schedule']['data']['hour'], 0);
         assert.strictEqual(task['schedule']['data']['minute'], 0);
         assert(!!tasks_api.TASKS['subscriptions_check']['job']);
+    });
+
+    it('Creates the apply categories task without a default schedule', async function() {
+        const task = await db_api.getRecord('tasks', {key: 'apply_categories'});
+
+        assert(task);
+        assert.strictEqual(task['title'], 'Apply categories to existing files');
+        assert.strictEqual(task['schedule'], null);
+        assert.strictEqual(tasks_api.TASKS['apply_categories']['job'], null);
     });
 
     it('Runs subscription checks from the task manager', async function() {
@@ -127,6 +136,66 @@ describe('Tasks', function() {
         await tasks_api.executeTask('duplicate_files_check');
         const duplicated_record_count = await db_api.getRecords('files', {path: 'test/missing_file.mp4'}, true);
         assert(duplicated_record_count === 1);
+    });
+
+    it('Applies categories to existing files and overwrites stale categories', async function() {
+        const matching_file_uid = 'apply-category-match';
+        const unmatched_file_uid = 'apply-category-unmatched';
+        const matching_file_path = 'video/apply-category-match.mp4';
+        const matching_info_path = 'video/apply-category-match.info.json';
+        const category_uid = uuid();
+
+        await db_api.removeAllRecords('categories');
+        await db_api.removeAllRecords('files', {uid: matching_file_uid});
+        await db_api.removeAllRecords('files', {uid: unmatched_file_uid});
+        fs.ensureDirSync('video');
+        fs.writeJSONSync(matching_info_path, {
+            title: 'Sample Music Video',
+            fulltitle: 'Sample Music Video',
+            webpage_url: 'https://example.com/watch?v=music',
+            categories: ['Music']
+        });
+
+        try {
+            await db_api.insertRecordIntoTable('categories', {
+                name: 'Music',
+                uid: category_uid,
+                rules: [{
+                    preceding_operator: null,
+                    comparator: 'includes',
+                    property: 'categories',
+                    value: 'Music'
+                }],
+                custom_output: ''
+            });
+            await db_api.insertRecordIntoTable('files', {
+                uid: matching_file_uid,
+                title: 'Old Title',
+                path: matching_file_path,
+                isAudio: false,
+                category: {name: 'Old', uid: 'old-category'}
+            });
+            await db_api.insertRecordIntoTable('files', {
+                uid: unmatched_file_uid,
+                title: 'Unmatched Video',
+                path: 'video/apply-category-unmatched.mp4',
+                isAudio: false,
+                category: {name: 'Old', uid: 'old-category'}
+            });
+
+            await tasks_api.executeRun('apply_categories');
+
+            const matching_file = await db_api.getRecord('files', {uid: matching_file_uid});
+            const unmatched_file = await db_api.getRecord('files', {uid: unmatched_file_uid});
+
+            assert.deepStrictEqual(matching_file.category, {name: 'Music', uid: category_uid});
+            assert.strictEqual(unmatched_file.category, null);
+        } finally {
+            await db_api.removeAllRecords('categories');
+            await db_api.removeAllRecords('files', {uid: matching_file_uid});
+            await db_api.removeAllRecords('files', {uid: unmatched_file_uid});
+            if (fs.existsSync(matching_info_path)) fs.unlinkSync(matching_info_path);
+        }
     });
 
     it('Import unregistered files', async function() {

--- a/src/api-types/index.ts
+++ b/src/api-types/index.ts
@@ -21,6 +21,7 @@ export type { Config } from './models/Config';
 export type { ConfigResponse } from './models/ConfigResponse';
 export type { CreateCategoryRequest } from './models/CreateCategoryRequest';
 export type { CreateCategoryResponse } from './models/CreateCategoryResponse';
+export type { CreateDefaultCategoriesResponse } from './models/CreateDefaultCategoriesResponse';
 export type { CreatePlaylistRequest } from './models/CreatePlaylistRequest';
 export type { CreatePlaylistResponse } from './models/CreatePlaylistResponse';
 export type { CropFileSettings } from './models/CropFileSettings';

--- a/src/api-types/models/CategoryRule.ts
+++ b/src/api-types/models/CategoryRule.ts
@@ -5,6 +5,8 @@
 export type CategoryRule = {
     preceding_operator?: CategoryRule.preceding_operator;
     comparator?: CategoryRule.comparator;
+    property?: CategoryRule.property;
+    value?: string;
 };
 
 export namespace CategoryRule {
@@ -21,5 +23,15 @@ export namespace CategoryRule {
         NOT_EQUALS = 'not_equals',
     }
 
+    export enum property {
+        FULLTITLE = 'fulltitle',
+        ID = 'id',
+        WEBPAGE_URL = 'webpage_url',
+        VIEW_COUNT = 'view_count',
+        UPLOADER = 'uploader',
+        CATEGORIES = 'categories',
+        _FILENAME = '_filename',
+        TAGS = 'tags',
+    }
 
 }

--- a/src/api-types/models/CreateDefaultCategoriesResponse.ts
+++ b/src/api-types/models/CreateDefaultCategoriesResponse.ts
@@ -1,0 +1,10 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { Category } from './Category';
+import type { SuccessObject } from './SuccessObject';
+
+export type CreateDefaultCategoriesResponse = (SuccessObject & {
+    categories?: Array<Category>;
+});

--- a/src/api-types/models/TaskType.ts
+++ b/src/api-types/models/TaskType.ts
@@ -11,5 +11,6 @@ export enum TaskType {
     DELETE_OLD_FILES = 'delete_old_files',
     IMPORT_LEGACY_ARCHIVES = 'import_legacy_archives',
     REBUILD_DATABASE = 'rebuild_database',
+    APPLY_CATEGORIES = 'apply_categories',
     SUBSCRIPTIONS_CHECK = 'subscriptions_check',
 }

--- a/src/app/dialogs/edit-category-dialog/edit-category-dialog.component.ts
+++ b/src/app/dialogs/edit-category-dialog/edit-category-dialog.component.ts
@@ -37,6 +37,10 @@ export class EditCategoryDialogComponent implements OnInit {
       label: 'Uploader'
     },
     {
+      value: 'categories',
+      label: 'Source category'
+    },
+    {
       value: '_filename',
       label: 'File Name'
     },

--- a/src/app/posts.services.ts
+++ b/src/app/posts.services.ts
@@ -66,6 +66,7 @@ import {
     DeleteCategoryRequest,
     CreateCategoryRequest,
     CreateCategoryResponse,
+    CreateDefaultCategoriesResponse,
     GetAllCategoriesResponse,
     AddFileToPlaylistRequest,
     IncrementViewCountRequest,
@@ -634,6 +635,10 @@ export class PostsService {
     createCategory(name) {
         const body: CreateCategoryRequest = {name: name};
         return this.http.post<CreateCategoryResponse>(this.path + 'createCategory', body, this.httpOptions);
+    }
+
+    createDefaultCategories() {
+        return this.http.post<CreateDefaultCategoriesResponse>(this.path + 'createDefaultCategories', {}, this.httpOptions);
     }
 
     deleteCategory(category_uid) {

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -163,6 +163,9 @@
                 </div>
               }
               <button style="margin-top: 10px;" mat-mini-fab (click)="openAddCategoryDialog()"><mat-icon>add</mat-icon></button>
+              @if (postsService.categories && postsService.categories.length === 0) {
+                <button style="margin-top: 10px; margin-left: 8px;" mat-button color="accent" [disabled]="addingDefaultCategories" (click)="addDefaultCategories()" i18n="Add default category set button">(Add default set)</button>
+              }
             </div>
             <div class="col-12 mt-2 mb-2">
               <mat-checkbox [(ngModel)]="new_config['Extra']['allow_playlist_categorization']" matTooltip="With this setting enabled, if a single video matches a category, the entire playlist will receive that category." i18n-matTooltip="Allow playlist categorization setting tooltip"><ng-container i18n="Allow playlist categorization setting label">Allow playlist categorization</ng-container></mat-checkbox>

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -61,6 +61,7 @@ export class SettingsComponent implements OnInit {
   latestGithubRelease = null;
   CURRENT_VERSION = CURRENT_VERSION
   downloaderInfo: Record<string, DownloaderVersionInfo> = {};
+  addingDefaultCategories = false;
 
   tabs = ['main', 'downloader', 'extra', 'database', 'notifications', 'advanced', 'users', 'logs'];
   tabIndex = 0;
@@ -189,6 +190,24 @@ export class SettingsComponent implements OnInit {
           }
         });
       }
+    });
+  }
+
+  addDefaultCategories(): void {
+    this.addingDefaultCategories = true;
+    this.postsService.createDefaultCategories().subscribe(res => {
+      this.addingDefaultCategories = false;
+      if (res['success']) {
+        this.postsService.categories = res['categories'];
+        this.postsService.openSnackBar($localize`Default categories added!`);
+      } else {
+        this.postsService.openSnackBar(res['error'] || $localize`Failed to add default categories!`);
+        this.postsService.reloadCategories();
+      }
+    }, err => {
+      this.addingDefaultCategories = false;
+      this.postsService.openSnackBar($localize`Failed to add default categories!`);
+      console.error(err);
     });
   }
 


### PR DESCRIPTION
## Summary
- add a default category set endpoint and Settings blank-state `(Add default set)` action
- teach category rules to match YouTube source category arrays and expose `Source category` in the rule editor
- add a manual `apply_categories` task that reapplies current category rules to existing files and overwrites stale categories

## Tests
- `npm run lint`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npm run test:headless`
- `npx ng build --configuration production`
- `node --check backend/app.js && node --check backend/categories.js && node --check backend/tasks.js && node --check backend/test/categories.test.js && node --check backend/test/tasks.test.js`
- `npx mocha test/categories.test.js test/tasks.test.js --exit -s 1000`

Build completed with existing warnings for Sass `@import`, the media-library SCSS budget, and `file-saver` CommonJS. Headless tests also logged existing missing font asset warnings while all 196 tests passed.