### PR TITLE
feat(categories): add media library quick filters

### DIFF
--- a/Public API v1.yaml
+++ b/Public API v1.yaml
@@ -1961,6 +1961,11 @@ components:
           type: boolean
           description: If set to true, only gets favorites
           default: false
+        category_filter_uids:
+          type: array
+          description: If set, only gets files in one of these categories
+          items:
+            type: string
         sub_id:
           type: string
           description: Include if you want to filter by subscription
@@ -3128,6 +3133,9 @@ components:
         custom_output:
           type: string
           description: Overrides file output for downloaded files in category
+        show_as_filter:
+          type: boolean
+          description: Shows this category as a quick filter in the media library
     CategoryRule:
       type: object
       properties:

--- a/backend/app.js
+++ b/backend/app.js
@@ -1469,11 +1469,12 @@ app.post('/api/getAllFiles', optionalJwt, async function (req, res) {
     const text_search = req.body.text_search;
     const file_type_filter = req.body.file_type_filter;
     const favorite_filter = req.body.favorite_filter;
+    const category_filter_uids = req.body.category_filter_uids;
     const sub_id = req.body.sub_id;
     const include_chapters = req.body.include_chapters === true;
     const uuid = req.isAuthenticated() ? req.user.uid : null;
 
-    const {files, file_count} = await files_api.getAllFiles(sort, range, text_search, file_type_filter, favorite_filter, sub_id, uuid);
+    const {files, file_count} = await files_api.getAllFiles(sort, range, text_search, file_type_filter, favorite_filter, sub_id, uuid, category_filter_uids);
     const parsed_files = include_chapters ? files_api.attachFileChaptersCollection(files) : files;
 
     res.send({
@@ -1698,6 +1699,7 @@ app.post('/api/createCategory', optionalJwt, async (req, res) => {
         name: name,
         uid: uuid(),
         rules: [],
+        show_as_filter: false,
         custom_output: ''
     };
 
@@ -3276,10 +3278,15 @@ app.get('/api/rss', async function (req, res) {
     const text_search = req.query.text_search ? decodeURIComponent(req.query.text_search) : null;
     const file_type_filter = req.query.file_type_filter;
     const favorite_filter = req.query.favorite_filter === 'true';
+    const category_filter_uids = Array.isArray(req.query.category_filter_uids)
+        ? req.query.category_filter_uids.map(category_uid => decodeURIComponent(category_uid))
+        : req.query.category_filter_uids
+            ? `${req.query.category_filter_uids}`.split(',').map(category_uid => decodeURIComponent(category_uid))
+            : null;
     const sub_id = req.query.sub_id ? decodeURIComponent(req.query.sub_id) : null;
     const uuid = req.query.uuid ? decodeURIComponent(req.query.uuid) : null;
 
-    const {files} = await files_api.getAllFiles(sort, range, text_search, file_type_filter, favorite_filter, sub_id, uuid);
+    const {files} = await files_api.getAllFiles(sort, range, text_search, file_type_filter, favorite_filter, sub_id, uuid, category_filter_uids);
 
     const { Feed } = await import('feed');
     const feed = new Feed({

--- a/backend/categories.js
+++ b/backend/categories.js
@@ -198,6 +198,7 @@ function cloneDefaultCategoryTemplate(category) {
             ...category_rule,
             preceding_operator: index === 0 ? null : category_rule.preceding_operator
         })),
+        show_as_filter: false,
         custom_output: ''
     };
 }

--- a/backend/files.js
+++ b/backend/files.js
@@ -1406,7 +1406,7 @@ exports.getVideosByUIDs = async (file_uids = [], user_uid = null) => {
     return ordered_uids.map(uid => file_by_uid.get(uid)).filter(Boolean);
 }
 
-exports.getAllFiles = async (sort, range, text_search, file_type_filter, favorite_filter, sub_id, uuid) => {
+exports.getAllFiles = async (sort, range, text_search, file_type_filter, favorite_filter, sub_id, uuid, category_filter_uids = null) => {
     const filter_obj = {};
     if (config_api.getConfigItem('ytdl_multi_user_mode')) {
         filter_obj['user_uid'] = uuid;
@@ -1425,6 +1425,13 @@ exports.getAllFiles = async (sort, range, text_search, file_type_filter, favorit
 
     if (favorite_filter) {
         filter_obj['favorite'] = true;
+    }
+
+    const sanitized_category_filter_uids = Array.isArray(category_filter_uids)
+        ? category_filter_uids.filter(category_uid => !!category_uid)
+        : [];
+    if (sanitized_category_filter_uids.length > 0) {
+        filter_obj['category.uid'] = {$in: sanitized_category_filter_uids};
     }
 
     if (sub_id) {

--- a/backend/test/categories.test.js
+++ b/backend/test/categories.test.js
@@ -142,6 +142,7 @@ describe('Categories', async function() {
             assert(music_category);
             assert(music_category.rules.some(category_rule => category_rule.property === 'categories' && category_rule.value === 'Music'));
             assert.strictEqual(music_category.rules[0].preceding_operator, null);
+            assert.strictEqual(music_category.show_as_filter, false);
         } finally {
             await db_api.removeAllRecords('categories');
         }

--- a/backend/test/files.test.js
+++ b/backend/test/files.test.js
@@ -494,4 +494,30 @@ describe('Files', function() {
             db_api.getRecords = original_get_records;
         }
     });
+
+    it('filters files by selected category uids', async function() {
+        const original_get_records = db_api.getRecords;
+        const captured_filters = [];
+
+        try {
+            db_api.getRecords = async (table, filter_obj, return_count) => {
+                captured_filters.push({table, filter_obj, return_count});
+                return return_count ? 0 : [];
+            };
+
+            await files_api.getAllFiles({by: 'registered', order: -1}, [0, 20], null, 'both', false, null, null, ['cat-music', 'cat-sports']);
+
+            assert.strictEqual(captured_filters.length, 2);
+            assert.deepStrictEqual(captured_filters[0].filter_obj, {
+                'category.uid': {$in: ['cat-music', 'cat-sports']}
+            });
+            assert.strictEqual(captured_filters[0].return_count, false);
+            assert.deepStrictEqual(captured_filters[1].filter_obj, {
+                'category.uid': {$in: ['cat-music', 'cat-sports']}
+            });
+            assert.strictEqual(captured_filters[1].return_count, true);
+        } finally {
+            db_api.getRecords = original_get_records;
+        }
+    });
 });

--- a/src/api-types/models/Category.ts
+++ b/src/api-types/models/Category.ts
@@ -12,4 +12,8 @@ export type Category = {
      * Overrides file output for downloaded files in category
      */
     custom_output?: string;
+    /**
+     * Shows this category as a quick filter in the media library
+     */
+    show_as_filter?: boolean;
 };

--- a/src/api-types/models/GetAllFilesRequest.ts
+++ b/src/api-types/models/GetAllFilesRequest.ts
@@ -18,6 +18,10 @@ export type GetAllFilesRequest = {
      */
     favorite_filter?: boolean;
     /**
+     * If set, only gets files in one of these categories
+     */
+    category_filter_uids?: Array<string>;
+    /**
      * Include if you want to filter by subscription
      */
     sub_id?: string;

--- a/src/app/components/media-library/media-library.component.html
+++ b/src/app/components/media-library/media-library.component.html
@@ -104,8 +104,8 @@
     </div>
     <div class="row justify-content-center library-filter-row">
       <mat-chip-listbox class="filter-list" [value]="selectedFilters" [multiple]="true" (change)="selectedFiltersChanged($event)">
-        @for (filter of fileFilters | keyvalue: originalOrder; track filter.key) {
-          <mat-chip-option [value]="filter.key" [selected]="selectedFilters.includes(filter.key)" color="accent">{{filter.value.label}}</mat-chip-option>
+        @for (filter of getVisibleFilters(); track filter.key) {
+          <mat-chip-option [value]="filter.key" [selected]="selectedFilters.includes(filter.key)" color="accent">{{filter.label}}</mat-chip-option>
         }
       </mat-chip-listbox>
     </div>

--- a/src/app/components/media-library/media-library.component.spec.ts
+++ b/src/app/components/media-library/media-library.component.spec.ts
@@ -36,6 +36,7 @@ describe('MediaLibraryComponent', () => {
       },
       card_size: 'medium',
       locale: 'en',
+      categories: [],
       theme: {
         ghost_primary: '#000',
         ghost_secondary: '#111'
@@ -53,7 +54,8 @@ describe('MediaLibraryComponent', () => {
       getAllFiles: jasmine.createSpy('getAllFiles').and.returnValue(of({files: [], file_count: 0})),
       getPlaylists: jasmine.createSpy('getPlaylists').and.returnValue(of({playlists: []})),
       files_changed: new BehaviorSubject(false),
-      playlists_changed: new BehaviorSubject(false)
+      playlists_changed: new BehaviorSubject(false),
+      categories_changed: new BehaviorSubject(false)
     };
     routerStub = {
       url: '/home',
@@ -118,7 +120,9 @@ describe('MediaLibraryComponent', () => {
       null,
       'both',
       false,
-      null
+      null,
+      false,
+      []
     );
     expect(component.paged_data.length).toBe(2);
     expect(component.file_count).toBe(40);
@@ -151,7 +155,9 @@ describe('MediaLibraryComponent', () => {
       null,
       'both',
       false,
-      null
+      null,
+      false,
+      []
     );
     expect(component.paged_data.map(file => file.uid)).toEqual(['file-1', 'file-2', 'file-3']);
   });
@@ -172,6 +178,40 @@ describe('MediaLibraryComponent', () => {
     } finally {
       postsServiceStub.getAllFiles.and.returnValue(of({files: [], file_count: 0}));
     }
+  });
+
+  it('should request selected category filters from the server', () => {
+    postsServiceStub.categories = [
+      { uid: 'cat-music', name: 'Music', show_as_filter: true },
+      { uid: 'cat-sports', name: 'Sports', show_as_filter: false }
+    ];
+    component.selectedFilters = ['category:cat-music', 'category:cat-sports', 'favorited'];
+    postsServiceStub.getAllFiles.calls.reset();
+
+    component.getAllFiles();
+
+    expect(postsServiceStub.getAllFiles).toHaveBeenCalledWith(
+      { by: 'registered', order: -1 },
+      [0, 10],
+      null,
+      'both',
+      true,
+      null,
+      false,
+      ['cat-music']
+    );
+  });
+
+  it('should expose only categories marked as library filters', () => {
+    postsServiceStub.categories = [
+      { uid: 'cat-music', name: 'Music', show_as_filter: true },
+      { uid: 'cat-sports', name: 'Sports', show_as_filter: false }
+    ];
+
+    const category_filters = component.getCategoryFilterOptions();
+
+    expect(category_filters.map(filter => filter.key)).toEqual(['category:cat-music']);
+    expect(category_filters[0].label).toBe('Music');
   });
 
   it('should queue one follow-up full refresh instead of overlapping concurrent refreshes', () => {
@@ -548,6 +588,17 @@ describe('MediaLibraryComponent', () => {
     expect(restored.snapshot.selectedFilters).toEqual(['favorited']);
     expect(restored.snapshot.anchorUid).toBe('file-1');
     expect(restored.files.map(file => file.uid)).toEqual(['file-1', 'file-2']);
+  });
+
+  it('should include category filters in player route params', () => {
+    postsServiceStub.categories = [
+      { uid: 'cat-music', name: 'Music', show_as_filter: true }
+    ];
+    component.selectedFilters = ['category:cat-music'];
+
+    const route_params = component.getPlayerRouteParams({ uid: 'file-1', isAudio: false } as any);
+
+    expect(route_params.queue_category_filter_uids).toBe('cat-music');
   });
 
   it('should not save restore state when opening the player in a new tab', () => {

--- a/src/app/components/media-library/media-library.component.ts
+++ b/src/app/components/media-library/media-library.component.ts
@@ -1,7 +1,7 @@
 import { Component, ElementRef, EventEmitter, HostListener, Input, NgZone, OnDestroy, OnInit, Output, ViewChild, ChangeDetectionStrategy } from '@angular/core';
 import { PostsService } from 'app/posts.services';
 import { Router } from '@angular/router';
-import { DatabaseFile, DeletePlaylistResponse, FileType, FileTypeFilter, Playlist, Sort } from 'api-types';
+import { Category, DatabaseFile, DeletePlaylistResponse, FileType, FileTypeFilter, Playlist, Sort } from 'api-types';
 import { Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, filter, take, takeUntil } from 'rxjs/operators';
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
@@ -24,6 +24,13 @@ interface MediaLibraryRow<T> {
   items: T[];
 }
 
+interface MediaLibraryFilter {
+  key: string;
+  label: string;
+  incompatible?: string[];
+  categoryUid?: string;
+}
+
 @Component({
     selector: 'app-media-library',
     templateUrl: './media-library.component.html',
@@ -43,6 +50,7 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
   readonly virtualRowOverscan = 2;
   readonly autoLoadBufferRows = 2;
   readonly pageSizeOptions: PageSizeOption[] = [5, 10, 25, 100, 250, this.autoPageSizeOption];
+  readonly categoryFilterPrefix = 'category:';
 
   @Input() usePaginator = true;
 
@@ -83,7 +91,7 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
   playlistSearchText = '';
   playlistSearchIsFocused = false;
 
-  fileFilters = {
+  fileFilters: Record<string, MediaLibraryFilter> = {
     video_only: {
       key: 'video_only',
       label: $localize`Video only`,
@@ -180,7 +188,11 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
     // set file type filter to cached value
     const cached_file_filter = localStorage.getItem('file_filter');
     if (this.usePaginator && cached_file_filter) {
-      this.selectedFilters = JSON.parse(cached_file_filter)
+      try {
+        this.selectedFilters = this.sanitizeSelectedFilters(JSON.parse(cached_file_filter));
+      } catch {
+        this.selectedFilters = [];
+      }
     } else {
       this.selectedFilters = [];
     }
@@ -244,6 +256,15 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
       }
     });
 
+    this.postsService.categories_changed
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(changed => {
+        if (!changed) return;
+        if (this.pruneUnavailableCategoryFilters() && this.isVideoLibraryActive()) {
+          this.getAllFiles();
+        }
+      });
+
     
     this.selected_data = this.defaultSelected.map(file => file.uid);
     this.selected_data_objs = this.defaultSelected;    
@@ -302,9 +323,7 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
       this.sortProperty = snapshot.sortProperty;
     }
     this.descendingMode = !!snapshot.descendingMode;
-    this.selectedFilters = Array.isArray(snapshot.selectedFilters)
-      ? snapshot.selectedFilters.filter(filter_key => !!this.fileFilters[filter_key])
-      : [];
+    this.selectedFilters = this.sanitizeSelectedFilters(snapshot.selectedFilters);
     this.search_text = snapshot.searchText ?? '';
     this.search_mode = !!this.search_text.trim();
     this.playlistSearchText = snapshot.playlistSearchText ?? '';
@@ -668,16 +687,96 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
   }
 
   selectedFiltersChanged(event: MatChipListboxChange): void {
+    const next_filters = this.sanitizeSelectedFilters(this.normalizeSelectedFilterValues(event.value));
     // in some cases this function will fire even if the selected filters haven't changed
-    if (event.value.length === this.selectedFilters.length) return;
-    if (event.value.length > this.selectedFilters.length) {
-      const filter_key = event.value.filter(possible_new_key => !this.selectedFilters.includes(possible_new_key))[0];
-      this.selectedFilters = this.selectedFilters.filter(existing_filter => !this.fileFilters[existing_filter].incompatible || !this.fileFilters[existing_filter].incompatible.includes(filter_key));
+    if (this.filtersAreEqual(next_filters, this.selectedFilters)) return;
+    if (next_filters.length > this.selectedFilters.length) {
+      const filter_key = next_filters.filter(possible_new_key => !this.selectedFilters.includes(possible_new_key))[0];
+      this.selectedFilters = this.selectedFilters.filter(existing_filter => {
+        const filter_definition = this.getFilterDefinition(existing_filter);
+        return !filter_definition?.incompatible || !filter_definition.incompatible.includes(filter_key);
+      });
       this.selectedFilters.push(filter_key);
     } else {
-      this.selectedFilters = event.value;
+      this.selectedFilters = next_filters;
     }
     this.filterChanged(JSON.stringify(this.selectedFilters));
+  }
+
+  getVisibleFilters(): MediaLibraryFilter[] {
+    return Object.keys(this.fileFilters)
+      .map(filter_key => this.fileFilters[filter_key])
+      .concat(this.getCategoryFilterOptions());
+  }
+
+  getCategoryFilterOptions(): MediaLibraryFilter[] {
+    if (!Array.isArray(this.postsService.categories)) {
+      return [];
+    }
+
+    return this.postsService.categories
+      .filter(category => !!category?.show_as_filter && !!category?.uid)
+      .map(category => ({
+        key: this.getCategoryFilterKey(category),
+        label: category.name || $localize`Untitled category`,
+        categoryUid: category.uid
+      }));
+  }
+
+  getCategoryFilterKey(category: Category | string): string {
+    const uid = typeof category === 'string' ? category : category?.uid;
+    return `${this.categoryFilterPrefix}${uid}`;
+  }
+
+  isCategoryFilterKey(filter_key: string): boolean {
+    return typeof filter_key === 'string' && filter_key.startsWith(this.categoryFilterPrefix);
+  }
+
+  getCategoryUidFromFilterKey(filter_key: string): string {
+    return filter_key.slice(this.categoryFilterPrefix.length);
+  }
+
+  getFilterDefinition(filter_key: string): MediaLibraryFilter | null {
+    return this.fileFilters[filter_key] || this.getCategoryFilterOptions().find(filter => filter.key === filter_key) || null;
+  }
+
+  normalizeSelectedFilterValues(filter_values: unknown): string[] {
+    if (!filter_values) return [];
+    const raw_filter_values = Array.isArray(filter_values) ? filter_values : [filter_values];
+    return raw_filter_values.filter(filter_value => typeof filter_value === 'string' && filter_value.trim() !== '') as string[];
+  }
+
+  sanitizeSelectedFilters(filter_values: unknown): string[] {
+    const visible_category_filter_keys = this.getVisibleCategoryFilterKeySet();
+    return this.normalizeSelectedFilterValues(filter_values).filter(filter_key => {
+      if (this.fileFilters[filter_key]) return true;
+      if (!this.isCategoryFilterKey(filter_key)) return false;
+      return !visible_category_filter_keys || visible_category_filter_keys.has(filter_key);
+    });
+  }
+
+  getVisibleCategoryFilterKeySet(): Set<string> | null {
+    if (!Array.isArray(this.postsService.categories)) {
+      return null;
+    }
+
+    return new Set(this.getCategoryFilterOptions().map(filter => filter.key));
+  }
+
+  pruneUnavailableCategoryFilters(): boolean {
+    const sanitized_filters = this.sanitizeSelectedFilters(this.selectedFilters);
+    if (this.filtersAreEqual(sanitized_filters, this.selectedFilters)) {
+      return false;
+    }
+
+    this.selectedFilters = sanitized_filters;
+    localStorage.setItem('file_filter', JSON.stringify(this.selectedFilters));
+    return true;
+  }
+
+  filtersAreEqual(filters_a: string[], filters_b: string[]): boolean {
+    if (filters_a.length !== filters_b.length) return false;
+    return filters_a.every((filter_key, index) => filters_b[index] === filter_key);
   }
 
   getFileTypeFilter(): string {
@@ -692,6 +791,20 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
 
   getFavoriteFilter(): boolean {
     return this.selectedFilters.includes('favorited');
+  }
+
+  getCategoryFilterUids(): string[] {
+    const category_uids = this.selectedFilters
+      .filter(filter_key => this.isCategoryFilterKey(filter_key))
+      .map(filter_key => this.getCategoryUidFromFilterKey(filter_key))
+      .filter(category_uid => !!category_uid);
+
+    if (!Array.isArray(this.postsService.categories)) {
+      return category_uids;
+    }
+
+    const visible_category_uids = new Set(this.getCategoryFilterOptions().map(filter => filter.categoryUid));
+    return category_uids.filter(category_uid => visible_category_uids.has(category_uid));
   }
 
 
@@ -723,7 +836,8 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
     const range = this.getRequestedFileRange(cache_mode, append);
     const fileTypeFilter = this.getFileTypeFilter();
     const favoriteFilter = this.getFavoriteFilter();
-    this.postsService.getAllFiles(sort, this.usePaginator ? range : null, this.search_mode ? this.search_text : null, fileTypeFilter as FileTypeFilter, favoriteFilter, this.sub_id).subscribe(res => {
+    const categoryFilterUids = this.getCategoryFilterUids();
+    this.postsService.getAllFiles(sort, this.usePaginator ? range : null, this.search_mode ? this.search_text : null, fileTypeFilter as FileTypeFilter, favoriteFilter, this.sub_id, false, categoryFilterUids).subscribe(res => {
       if (request_id !== this.latestFileRequestId) {
         return;
       }
@@ -817,6 +931,10 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
       queue_file_type_filter: this.getFileTypeFilter(),
       queue_favorite_filter: '' + this.getFavoriteFilter()
     };
+    const category_filter_uids = this.getCategoryFilterUids();
+    if (category_filter_uids.length > 0) {
+      routeParams.queue_category_filter_uids = category_filter_uids.join(',');
+    }
     if (this.search_mode && this.search_text?.trim()) {
       routeParams.queue_search = this.search_text.trim();
     }
@@ -1474,10 +1592,6 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
     this.selected_data.splice(index, 1);
     this.selected_data_objs.splice(index, 1);
     this.fileSelectionEmitter.emit({new_selection: this.selected_data, thumbnailURL: this.selected_data_objs[0].thumbnailURL});
-  }
-
-  originalOrder = (): number => {
-    return 0;
   }
 
   toggleFavorite(file_obj): void {

--- a/src/app/dialogs/edit-category-dialog/edit-category-dialog.component.html
+++ b/src/app/dialogs/edit-category-dialog/edit-category-dialog.component.html
@@ -6,6 +6,12 @@
     <input matInput [(ngModel)]="category['name']" required>
   </mat-form-field>
 
+  <div class="quick-filter-option">
+    <mat-checkbox color="accent" [(ngModel)]="category['show_as_filter']">
+      <ng-container i18n="Show category as library filter">Show as library filter</ng-container>
+    </mat-checkbox>
+  </div>
+
   <mat-divider></mat-divider>
 
   <h6 style="margin-top: 20px;" i18n="Rules">Rules</h6>

--- a/src/app/dialogs/edit-category-dialog/edit-category-dialog.component.scss
+++ b/src/app/dialogs/edit-category-dialog/edit-category-dialog.component.scss
@@ -27,3 +27,7 @@
     position: relative;
     top: 8px;
 }
+
+.quick-filter-option {
+    margin-bottom: 14px;
+}

--- a/src/app/player/player.component.ts
+++ b/src/app/player/player.component.ts
@@ -75,6 +75,7 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
   queue_sort_order = -1;
   queue_file_type_filter: FileTypeFilter = null;
   queue_favorite_filter = false;
+  queue_category_filter_uids: string[] = [];
   queue_search = null;
   queue_sub_id = null;
 
@@ -138,6 +139,7 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
     this.queue_sort_order = this.parseSortOrder(this.route.snapshot.paramMap.get('queue_sort_order'));
     this.queue_file_type_filter = this.parseFileTypeFilter(this.route.snapshot.paramMap.get('queue_file_type_filter'));
     this.queue_favorite_filter = this.route.snapshot.paramMap.get('queue_favorite_filter') === 'true';
+    this.queue_category_filter_uids = this.parseCategoryFilterUids(this.route.snapshot.paramMap.get('queue_category_filter_uids'));
     this.queue_search = this.route.snapshot.paramMap.get('queue_search');
     this.queue_sub_id = this.route.snapshot.paramMap.get('queue_sub_id');
 
@@ -683,7 +685,7 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
     const textSearch = this.queue_search?.trim() ? this.queue_search.trim() : null;
     const queueSubID = this.queue_sub_id || null;
 
-    this.postsService.getAllFiles(sort, null, textSearch, fileTypeFilter, this.queue_favorite_filter, queueSubID, false).subscribe(res => {
+    this.postsService.getAllFiles(sort, null, textSearch, fileTypeFilter, this.queue_favorite_filter, queueSubID, false, this.queue_category_filter_uids).subscribe(res => {
       if (!this.autoplay_enabled) {
         this.autoplay_queue_loading = false;
         this.pending_autoplay_advance = false;
@@ -1249,6 +1251,16 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
       return this.db_file.isAudio ? FileTypeFilter.AUDIO_ONLY : FileTypeFilter.VIDEO_ONLY;
     }
     return FileTypeFilter.BOTH;
+  }
+
+  parseCategoryFilterUids(raw_value: string | null): string[] {
+    if (!raw_value) {
+      return [];
+    }
+
+    return raw_value.split(',')
+      .map(category_uid => category_uid.trim())
+      .filter(category_uid => !!category_uid);
   }
 
   repeatCurrentVideo(): void {

--- a/src/app/posts.services.ts
+++ b/src/app/posts.services.ts
@@ -189,6 +189,7 @@ export class PostsService {
 
     files_changed = new BehaviorSubject<boolean>(false);
     playlists_changed = new BehaviorSubject<boolean>(false);
+    categories_changed = new BehaviorSubject<boolean>(false);
 
     // app status
     initialized = false;
@@ -456,8 +457,17 @@ export class PostsService {
         return this.http.post<GetFileResponse>(this.path + 'getFile', body, this.httpOptions);
     }
 
-    getAllFiles(sort: Sort = null, range: number[] = null, text_search: string = null, file_type_filter: FileTypeFilter = FileTypeFilter.BOTH, favorite_filter = false, sub_id: string = null, include_chapters = false) {
-        const body: GetAllFilesRequest = {sort: sort, range: range, text_search: text_search, file_type_filter: file_type_filter, favorite_filter: favorite_filter, sub_id: sub_id, include_chapters: include_chapters};
+    getAllFiles(sort: Sort = null, range: number[] = null, text_search: string = null, file_type_filter: FileTypeFilter = FileTypeFilter.BOTH, favorite_filter = false, sub_id: string = null, include_chapters = false, category_filter_uids: string[] = null) {
+        const body: GetAllFilesRequest = {
+            sort: sort,
+            range: range,
+            text_search: text_search,
+            file_type_filter: file_type_filter,
+            favorite_filter: favorite_filter,
+            sub_id: sub_id,
+            include_chapters: include_chapters,
+            category_filter_uids: category_filter_uids
+        };
         return this.http.post<GetAllFilesResponse>(this.path + 'getAllFiles', body, this.httpOptions);
     }
 
@@ -659,6 +669,7 @@ export class PostsService {
     reloadCategories() {
         this.getAllCategories().subscribe(res => {
             this.categories = res['categories'];
+            this.categories_changed.next(true);
         });
     }
 

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -153,8 +153,13 @@
                   @for (category of postsService.categories; track category) {
                     <div class="category-box" cdkDrag>
                       <div class="category-custom-placeholder" *cdkDragPlaceholder></div>
-                      {{category['name']}}
+                      <span class="category-name">
+                        {{category['name']}}
+                      </span>
                       <span style="float: right">
+                        @if (category['show_as_filter']) {
+                          <button mat-icon-button disabled matTooltip="Shown as library filter" i18n-matTooltip="Shown as library filter tooltip"><mat-icon>home</mat-icon></button>
+                        }
                         <button mat-icon-button (click)="openEditCategoryDialog(category)"><mat-icon>edit</mat-icon></button>
                         <button mat-icon-button (click)="deleteCategory(category)"><mat-icon>cancel</mat-icon></button>
                       </span>

--- a/src/app/settings/settings.component.scss
+++ b/src/app/settings/settings.component.scss
@@ -111,6 +111,12 @@
     font-size: 14px;
 }
 
+.category-name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .cdk-drag-preview {
     box-sizing: border-box;
     border-radius: 4px;

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -199,6 +199,7 @@ export class SettingsComponent implements OnInit {
       this.addingDefaultCategories = false;
       if (res['success']) {
         this.postsService.categories = res['categories'];
+        this.postsService.categories_changed.next(true);
         this.postsService.openSnackBar($localize`Default categories added!`);
       } else {
         this.postsService.openSnackBar(res['error'] || $localize`Failed to add default categories!`);


### PR DESCRIPTION
## Summary
- add a per-category “Show as library filter” option and settings-list home indicator
- render enabled categories as media-library filter chips that combine with audio/video/favorite filters
- pass selected category filters through file queries and player queue routing

## Tests
- `npm run lint`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npm run test:headless`
- `npx ng build --configuration production`
- `node --check backend/app.js && node --check backend/files.js && node --check backend/categories.js && node --check backend/test/files.test.js && node --check backend/test/categories.test.js`
- `npx mocha test/files.test.js test/categories.test.js --exit -s 1000`
- `CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npx ng test --watch=false --browsers ChromiumHeadless --include src/app/components/media-library/media-library.component.spec.ts --include src/app/player/player.component.spec.ts`

Build completed with existing warnings for Sass `@import`, the media-library SCSS budget, and `file-saver` CommonJS. Headless tests logged existing missing font asset warnings while all 199 tests passed.