### PR TITLE
fix(subscriptions): suppress task completion notification

### DIFF
--- a/backend/tasks.js
+++ b/backend/tasks.js
@@ -67,6 +67,7 @@ const TASKS = {
     subscriptions_check: {
         run: checkSubscriptions,
         title: 'Check subscriptions',
+        notifyOnFinish: false,
         defaultSchedule: () => JSON.parse(JSON.stringify(DEFAULT_SUBSCRIPTIONS_CHECK_SCHEDULE))
     }
 }
@@ -277,7 +278,7 @@ exports.executeRun = async (task_key) => {
     await db_api.updateRecord('tasks', {key: task_key}, {data: TASKS[task_key]['confirm'] ? data : null, last_ran: Date.now()/1000, running: false});
     logger.verbose(`Finished running task ${task_key}`);
     const task_obj = await db_api.getRecord('tasks', {key: task_key});
-    await notifications_api.sendTaskNotification(task_obj, false);
+    if (TASKS[task_key]['notifyOnFinish'] !== false) await notifications_api.sendTaskNotification(task_obj, false);
 
     if (task_obj['options'] && task_obj['options']['auto_confirm']) {
         exports.executeConfirm(task_key);
@@ -296,7 +297,7 @@ exports.executeConfirm = async (task_key) => {
     await TASKS[task_key].confirm(data);
     await db_api.updateRecord('tasks', {key: task_key}, {confirming: false, last_confirmed: Date.now()/1000, data: null});
     logger.verbose(`Finished confirming task ${task_key}`);
-    await notifications_api.sendTaskNotification(task_obj, false);
+    if (TASKS[task_key]['notifyOnFinish'] !== false) await notifications_api.sendTaskNotification(task_obj, false);
 }
 
 exports.updateTaskSchedule = async (task_key, schedule) => {

--- a/backend/test/tasks.test.js
+++ b/backend/test/tasks.test.js
@@ -3,6 +3,7 @@ const { assert, fs, uuid, db_api, utils, subscriptions_api, generateEmptyVideoFi
 
 describe('Tasks', function() {
     const tasks_api = require('../tasks');
+    const notifications_api = require('../notifications');
     beforeEach(async function() {
         // await db_api.connectToDB();
         await db_api.removeAllRecords('tasks');
@@ -64,6 +65,29 @@ describe('Tasks', function() {
             assert.strictEqual(task['running'], false);
         } finally {
             subscriptions_api.checkSubscriptions = original_check_subscriptions;
+        }
+    });
+
+    it('Does not send a generic task notification after checking subscriptions', async function() {
+        const original_check_subscriptions = subscriptions_api.checkSubscriptions;
+        const original_send_task_notification = notifications_api.sendTaskNotification;
+        const notified_task_keys = [];
+
+        subscriptions_api.checkSubscriptions = async () => {
+            return {success: true, checked: true, checked_count: 1, sub_ids: ['test-subscription']};
+        };
+        notifications_api.sendTaskNotification = async (task_obj) => {
+            notified_task_keys.push(task_obj.key);
+        };
+
+        try {
+            await tasks_api.executeRun('subscriptions_check');
+            await tasks_api.executeRun('dummy_task');
+
+            assert.deepStrictEqual(notified_task_keys, ['dummy_task']);
+        } finally {
+            subscriptions_api.checkSubscriptions = original_check_subscriptions;
+            notifications_api.sendTaskNotification = original_send_task_notification;
         }
     });
 


### PR DESCRIPTION
## Summary
- Skip task-finished notifications for the subscriptions_check task so only per-video download notifications are sent.
- Add a backend regression test proving subscription checks stay silent while other tasks still notify.

## Tests
- node --check backend/tasks.js && node --check backend/test/tasks.test.js
- npx mocha test/tasks.test.js --exit -s 1000 (from backend)
- npm run lint
- npx tsc -p src/tsconfig.app.json --noEmit
- npx tsc -p src/tsconfig.spec.json --noEmit
- CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npm run test:headless
- npx ng build --configuration production

Build warnings: existing Sass @import deprecation, media-library SCSS budget +59 bytes, file-saver CommonJS bailout.