### PR TITLE
fix(subscriptions): silence transient live errors

### DIFF
--- a/backend/downloader.js
+++ b/backend/downloader.js
@@ -48,6 +48,10 @@ const SKIPPABLE_SUBSCRIPTION_DOWNLOAD_ERROR_TEXT = [
     'this live event will begin',
     'no output received for video download'
 ];
+const TRANSIENT_SUBSCRIPTION_DOWNLOAD_ERROR_TEXT = [
+    'premieres in',
+    'this live event will begin'
+];
 const SUBSCRIPTION_REFRESH_QUEUED_PHASE = 'queued';
 const SUBSCRIPTION_REFRESH_COMPLETE_PHASE = 'complete';
 let filename_sanitization_non_ytdlp_warned = false;
@@ -199,6 +203,13 @@ function isSkippableSubscriptionDownloadError(error_message = '', error_type = n
     return SKIPPABLE_SUBSCRIPTION_DOWNLOAD_ERROR_TEXT.some(error_text => normalized_message.includes(error_text));
 }
 exports.isSkippableSubscriptionDownloadError = isSkippableSubscriptionDownloadError;
+
+function isTransientSubscriptionDownloadError(error_message = '') {
+    if (typeof error_message !== 'string') return false;
+
+    const normalized_message = error_message.toLowerCase();
+    return TRANSIENT_SUBSCRIPTION_DOWNLOAD_ERROR_TEXT.some(error_text => normalized_message.includes(error_text));
+}
 
 function asNonNegativeInteger(value, default_value = 0) {
     const numeric_value = Number(value);
@@ -1457,11 +1468,14 @@ exports.cancelDownload = async (download_uid) => {
 
 exports.clearDownload = async (download_uid) => {
     const download = await db_api.getRecord('download_queue', {uid: download_uid});
-    const should_archive_subscription_skip = download && download['sub_id']
-        && ((download['paused'] && !download['finished'])
-            || (download['error'] && isSkippableSubscriptionDownloadError(download['error'], download['error_type'])));
-    if (should_archive_subscription_skip) {
+    const should_archive_paused_subscription_skip = download && download['sub_id'] && download['paused'] && !download['finished'];
+    const should_archive_errored_subscription_skip = download && download['sub_id'] && download['error']
+        && isSkippableSubscriptionDownloadError(download['error'], download['error_type'])
+        && !isTransientSubscriptionDownloadError(download['error']);
+    if (should_archive_paused_subscription_skip) {
         await archiveSubscriptionDownloadBySource(download, 'after being cleared from the download queue');
+    } else if (should_archive_errored_subscription_skip) {
+        await archiveSkippedSubscriptionDownload(download, download['error'], download['error_type']);
     }
     return await db_api.removeRecord('download_queue', {uid: download_uid});
 }
@@ -1470,15 +1484,21 @@ async function handleDownloadError(download_uid, error_message, error_type = nul
     if (!download_uid) return;
     const download = await db_api.getRecord('download_queue', {uid: download_uid});
     if (!download || download['error']) return;
+    const is_skippable_subscription_error = download['sub_id'] && isSkippableSubscriptionDownloadError(error_message, error_type);
+    const is_transient_subscription_error = download['sub_id'] && isTransientSubscriptionDownloadError(error_message);
     await archiveSkippedSubscriptionDownload(download, error_message, error_type);
-    notifications_api.sendDownloadErrorNotification(download, download['user_uid'], error_message, error_type);
+    if (!is_skippable_subscription_error) {
+        notifications_api.sendDownloadErrorNotification(download, download['user_uid'], error_message, error_type);
+    }
     await db_api.updateRecord('download_queue', {uid: download['uid']}, {error: error_message, finished: true, running: false, error_type: error_type});
     await updateSubscriptionRefreshStatusForSkippedDownload(download, error_message, error_type);
+    if (is_transient_subscription_error) await db_api.removeRecord('download_queue', {uid: download['uid']});
 }
 
 async function archiveSkippedSubscriptionDownload(download = null, error_message = '', error_type = null) {
     if (!download || !download['sub_id']) return false;
     if (!isSkippableSubscriptionDownloadError(error_message, error_type)) return false;
+    if (isTransientSubscriptionDownloadError(error_message)) return false;
     return await archiveSubscriptionDownloadBySource(download, `after ${error_type || 'download failure'}`);
 }
 

--- a/backend/test/downloader.test.js
+++ b/backend/test/downloader.test.js
@@ -21,6 +21,7 @@ const {
 
 describe('Downloader', function() {
     const downloader_api = require('../downloader');
+    const notifications_api = require('../notifications');
     // These tests are intended to be unit-style. By default we do NOT hit live
     // YouTube/yt-dlp during CI because it is inherently flaky (bot checks,
     // removed videos, geo/auth restrictions, etc.).
@@ -456,6 +457,88 @@ describe('Downloader', function() {
             await archive_api.existsInArchive('youtube', prefetched_info[0].id, 'video', 'test_user', sub_id),
             true
         );
+    });
+
+    it('Does not notify for skippable subscription info lookup errors', async function() {
+        const original_runYoutubeDL = youtubedl_api.runYoutubeDL;
+        const original_sendDownloadErrorNotification = notifications_api.sendDownloadErrorNotification;
+        const prefetched_info = [{
+            _type: 'url',
+            extractor: 'youtube',
+            id: 'future-live-subscription-video',
+            webpage_url: 'https://www.youtube.com/watch?v=future-live-subscription-video',
+            title: 'Future live subscription video'
+        }];
+        const returned_download = await downloader_api.createDownload(
+            prefetched_info[0].webpage_url,
+            'video',
+            {ui_uid: uuid()},
+            'test_user',
+            sub_id,
+            'Test subscription',
+            prefetched_info
+        );
+        const sent_notifications = [];
+
+        youtubedl_api.runYoutubeDL = async () => ({
+            callback: Promise.resolve({
+                parsed_output: null,
+                err: {stderr: 'ERROR: [youtube] future-live-subscription-video: This live event will begin in 26 hours.'}
+            })
+        });
+        notifications_api.sendDownloadErrorNotification = async (...args) => {
+            sent_notifications.push(args);
+        };
+
+        try {
+            const info = await _originalGetVideoInfoByURL(prefetched_info[0].webpage_url, [], returned_download.uid);
+            assert.strictEqual(info, null);
+        } finally {
+            youtubedl_api.runYoutubeDL = original_runYoutubeDL;
+            notifications_api.sendDownloadErrorNotification = original_sendDownloadErrorNotification;
+        }
+
+        const cleared_download = await db_api.getRecord('download_queue', {uid: returned_download.uid});
+        assert.strictEqual(sent_notifications.length, 0);
+        assert.strictEqual(cleared_download, undefined);
+        assert.strictEqual(
+            await archive_api.existsInArchive('youtube', prefetched_info[0].id, 'video', 'test_user', sub_id),
+            false
+        );
+    });
+
+    it('Still notifies for non-subscription info lookup errors', async function() {
+        const original_runYoutubeDL = youtubedl_api.runYoutubeDL;
+        const original_sendDownloadErrorNotification = notifications_api.sendDownloadErrorNotification;
+        const returned_download = await downloader_api.createDownload(
+            'https://www.youtube.com/watch?v=future-live-manual-video',
+            'video',
+            {ui_uid: uuid()}
+        );
+        const sent_notifications = [];
+
+        youtubedl_api.runYoutubeDL = async () => ({
+            callback: Promise.resolve({
+                parsed_output: null,
+                err: {stderr: 'ERROR: [youtube] future-live-manual-video: This live event will begin in 26 hours.'}
+            })
+        });
+        notifications_api.sendDownloadErrorNotification = async (...args) => {
+            sent_notifications.push(args);
+        };
+
+        try {
+            const info = await _originalGetVideoInfoByURL(returned_download.url, [], returned_download.uid);
+            assert.strictEqual(info, null);
+        } finally {
+            youtubedl_api.runYoutubeDL = original_runYoutubeDL;
+            notifications_api.sendDownloadErrorNotification = original_sendDownloadErrorNotification;
+        }
+
+        const failed_download = await db_api.getRecord('download_queue', {uid: returned_download.uid});
+        assert.strictEqual(sent_notifications.length, 1);
+        assert.strictEqual(failed_download.finished, true);
+        assert.strictEqual(failed_download.error_type, 'info_retrieve_failed');
     });
 
     it('Marks queue-step exceptions as failed downloads instead of leaving them running', async function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,9 +39,9 @@
         "zone.js": "~0.16.2"
       },
       "devDependencies": {
-        "@angular-devkit/core": "^22.0.1",
-        "@angular/build": "^22.0.1",
-        "@angular/cli": "^22.0.1",
+        "@angular-devkit/core": "^22.0.2",
+        "@angular/build": "^22.0.2",
+        "@angular/cli": "^22.0.2",
         "@angular/compiler-cli": "^22.0.0",
         "@angular/language-service": "^22.0.0",
         "@eslint/js": "^10.0.1",
@@ -295,13 +295,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.2200.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2200.1.tgz",
-      "integrity": "sha512-Q3DfpgEIiHtG7uSUO8Tsm35rOeUbJfuxM9pi7cCyC8DvC/z1yNYm7/xEitlEYPzJmSLmks3eqlsaGnYhh0VLVg==",
+      "version": "0.2200.2",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2200.2.tgz",
+      "integrity": "sha512-Zqtj37XCQXQrZp8W4+b883Kc4NMOKB6rm2jKCtZwvUlZFnlb5VeRZ6IANLxoGIfHAFS564KNjepMKsb4tkDxFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.0.1",
+        "@angular-devkit/core": "22.0.2",
         "rxjs": "7.8.2"
       },
       "bin": {
@@ -314,9 +314,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "22.0.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.0.1.tgz",
-      "integrity": "sha512-77/WsCAbqGkumDfm/kkw2mFh/42DNF0hB02TvivlfiSC/KfK9DsHg7sKvTlNcuY14ZT/3iHhojLyNBc2HytuvQ==",
+      "version": "22.0.2",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.0.2.tgz",
+      "integrity": "sha512-ftckkaxbPsJmsqsbcsEV3b4j5jpDIjcCFCnSYgqdAl5/Km2Br1+J4S4qsTW13F2oUp2OFRYvH9gP+AaYQVAfWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -359,13 +359,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "22.0.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.0.1.tgz",
-      "integrity": "sha512-GWou5meX3vAvqQEkox7xYMT9tIrYBVl0StbP7rGH5yMrzngvi6eyikMiUYnmMvoEoBK9gFNnXaAKeeu2aWvb3Q==",
+      "version": "22.0.2",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.0.2.tgz",
+      "integrity": "sha512-85jWZnkWPpXhe0RnAjxBzF4GAI+OzRFVjP9g4LY5lLkKlY4YKRxt9a4Wa6LfuArP10Js/gpkvNv/7NPj14tu7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.0.1",
+        "@angular-devkit/core": "22.0.2",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.21",
         "ora": "9.4.0",
@@ -394,14 +394,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "22.0.1",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.0.1.tgz",
-      "integrity": "sha512-05oMhBuRy4qycmuhrBpz3y/OxaW0qeguKj7ArUdTFOJvi6Y1kthzcg6bF1cPPVz0TMGnoTwMf9OCHjoT2QHAKA==",
+      "version": "22.0.2",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.0.2.tgz",
+      "integrity": "sha512-EtVbjMfHhEkrf2YsECBPqqYKFuxNB3pGEebP3dFsSikoNdIn/dNCoT6ZraXwfCbt4EzJMyH740LLxsvIeoIqLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2200.1",
+        "@angular-devkit/architect": "0.2200.2",
         "@babel/core": "7.29.0",
         "@babel/helper-annotate-as-pure": "7.27.3",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -409,7 +409,7 @@
         "@vitejs/plugin-basic-ssl": "2.3.0",
         "beasties": "0.4.2",
         "browserslist": "^4.26.0",
-        "esbuild": "0.28.0",
+        "esbuild": "0.28.1",
         "https-proxy-agent": "9.0.0",
         "jsonc-parser": "3.3.1",
         "listr2": "10.2.1",
@@ -442,7 +442,7 @@
         "@angular/platform-browser": "^22.0.0",
         "@angular/platform-server": "^22.0.0",
         "@angular/service-worker": "^22.0.0",
-        "@angular/ssr": "^22.0.1",
+        "@angular/ssr": "^22.0.2",
         "istanbul-lib-instrument": "^6.0.0",
         "karma": "^6.4.0",
         "less": "^4.2.0",
@@ -529,26 +529,26 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "22.0.1",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.0.1.tgz",
-      "integrity": "sha512-E1b3yroIDkqKpRJ5M/ihQkmgrF+gTlrntLbLWkSE5XReMSGtkog16I3hewI1zV2K4TMdiDZ1lzJvkJ4CgG3wjA==",
+      "version": "22.0.2",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.0.2.tgz",
+      "integrity": "sha512-hjp2et2xcYJNESaDwWQgkLmeZ2PusStRDPWq31lLglnmsfvCtCoOqrlrp/TNTDiDhknhhpc0Q7hrU8+92ZUmcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2200.1",
-        "@angular-devkit/core": "22.0.1",
-        "@angular-devkit/schematics": "22.0.1",
+        "@angular-devkit/architect": "0.2200.2",
+        "@angular-devkit/core": "22.0.2",
+        "@angular-devkit/schematics": "22.0.2",
         "@inquirer/prompts": "8.4.2",
         "@listr2/prompt-adapter-inquirer": "4.2.3",
         "@modelcontextprotocol/sdk": "1.29.0",
-        "@schematics/angular": "22.0.1",
+        "@schematics/angular": "22.0.2",
         "@yarnpkg/lockfile": "1.1.0",
         "algoliasearch": "5.52.0",
         "ini": "6.0.0",
         "jsonc-parser": "3.3.1",
         "listr2": "10.2.1",
         "npm-package-arg": "13.0.2",
-        "pacote": "21.5.0",
+        "pacote": "21.5.1",
         "parse5-html-rewriting-stream": "8.0.1",
         "semver": "7.7.4",
         "yargs": "18.0.0",
@@ -3674,14 +3674,14 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "22.0.1",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.0.1.tgz",
-      "integrity": "sha512-JRtJ9x0CaYIBLdPERr7B66ZSSLy4phkb7KtFIcD8RC2nAmnL/elevL2wg2Miih7ww0zmhiblS3LDE/abqSLRAA==",
+      "version": "22.0.2",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.0.2.tgz",
+      "integrity": "sha512-5yVlR7i5oyYcv0OuaBL5CPTrUETSZGZiqMPHhh+0Z6VbIolwr2ps0Nqa0jlmQhNmC2OL7NDIQJilX9wJgyWwUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.0.1",
-        "@angular-devkit/schematics": "22.0.1",
+        "@angular-devkit/core": "22.0.2",
+        "@angular-devkit/schematics": "22.0.2",
         "jsonc-parser": "3.3.1",
         "typescript": "6.0.3"
       },
@@ -8356,9 +8356,9 @@
       "optional": true
     },
     "node_modules/node-gyp": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.3.0.tgz",
-      "integrity": "sha512-QNcUWM+HgJplcPzBvFBZ9VXacyGZ4+VTOb80PwWR+TlVzoHbRKULNEzpRsnaoxG3Wzr7Qh7BYxGDU3CbKib2Yg==",
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
+      "integrity": "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8743,9 +8743,9 @@
       }
     },
     "node_modules/pacote": {
-      "version": "21.5.0",
-      "resolved": "https://registry.npmjs.org/pacote/-/pacote-21.5.0.tgz",
-      "integrity": "sha512-VtZ0SB8mb5Tzw3dXDfVAIjhyVKUHZkS/ZH9/5mpKenwC9sFOXNI0JI7kEF7IMkwOnsWMFrvAZHzx1T5fmrp9FQ==",
+      "version": "21.5.1",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-21.5.1.tgz",
+      "integrity": "sha512-KvcJ9iy3crysCsgqc4+PknH/w6jkrp8JN36mpZBPwNaDRwTfMZD37YzRazNstiZUOhuF5pno9f78n9mEJBavwg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
     "zone.js": "~0.16.2"
   },
   "devDependencies": {
-    "@angular-devkit/core": "^22.0.1",
-    "@angular/build": "^22.0.1",
-    "@angular/cli": "^22.0.1",
+    "@angular-devkit/core": "^22.0.2",
+    "@angular/build": "^22.0.2",
+    "@angular/cli": "^22.0.2",
     "@angular/compiler-cli": "^22.0.0",
     "@angular/language-service": "^22.0.0",
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary
- Suppress download-error notifications for skippable subscription failures, so upcoming live events do not ping users.
- Treat future live/premiere failures as transient: they are not archived and the errored queue item is removed so later subscription checks can retry them.
- Keep normal manual download failures notifying, even when they use the same yt-dlp error text.
- Bump Angular dev tooling to 22.0.2 to satisfy the Dependencies/outdated workflow.

## Tests
- node --check backend/downloader.js && node --check backend/test/downloader.test.js
- npx mocha test/downloader.test.js --grep "skippable subscription info lookup|non-subscription info lookup|Archives skippable errored subscription downloads" --exit -s 1000 (from backend)
- npx mocha test/downloader.test.js --exit -s 1000 (from backend)
- npm run lint
- npx tsc -p src/tsconfig.app.json --noEmit
- npx tsc -p src/tsconfig.spec.json --noEmit
- frontend outdated check: no dependencies behind wanted
- backend outdated check: no dependencies behind wanted
- CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npm run test:headless
- npx ng build --configuration production

Notes: local npm emitted engine warnings because this shell is on Node v26.2.0 while the repo declares >=24 <26. Build warnings remain the existing Sass @import deprecation, media-library SCSS budget +59 bytes, and file-saver CommonJS bailout.