### PR TITLE
feat(downloader): add extractor client fallback option

### DIFF
--- a/backend/appdata/default.json
+++ b/backend/appdata/default.json
@@ -22,7 +22,7 @@
       "playlist_chunk_size": 100,
       "skip_join_only_videos": false,
       "use_ytdlp_impersonation": false,
-      "use_youtube_client_fallback": false
+      "use_extractor_client_fallback": false
     },
     "Extra": {
       "title_top": "ytdl-material",

--- a/backend/appdata/default.json
+++ b/backend/appdata/default.json
@@ -21,7 +21,8 @@
       "download_rate_limit": "",
       "playlist_chunk_size": 100,
       "skip_join_only_videos": false,
-      "use_ytdlp_impersonation": false
+      "use_ytdlp_impersonation": false,
+      "use_youtube_client_fallback": false
     },
     "Extra": {
       "title_top": "ytdl-material",

--- a/backend/config.js
+++ b/backend/config.js
@@ -263,7 +263,7 @@ const DEFAULT_CONFIG = {
         "download_rate_limit": "",
         "skip_join_only_videos": false,
         "use_ytdlp_impersonation": false,
-        "use_youtube_client_fallback": false
+        "use_extractor_client_fallback": false
       },
       "Extra": {
         "title_top": "ytdl-material",

--- a/backend/config.js
+++ b/backend/config.js
@@ -262,7 +262,8 @@ const DEFAULT_CONFIG = {
         "playlist_chunk_size": 20,
         "download_rate_limit": "",
         "skip_join_only_videos": false,
-        "use_ytdlp_impersonation": false
+        "use_ytdlp_impersonation": false,
+        "use_youtube_client_fallback": false
       },
       "Extra": {
         "title_top": "ytdl-material",

--- a/backend/consts.js
+++ b/backend/consts.js
@@ -86,6 +86,10 @@ exports.CONFIG_ITEMS = {
         'key': 'ytdl_use_ytdlp_impersonation',
         'path': 'YtdlMaterial.Downloader.use_ytdlp_impersonation'
     },
+    'ytdl_use_youtube_client_fallback': {
+        'key': 'ytdl_use_youtube_client_fallback',
+        'path': 'YtdlMaterial.Downloader.use_youtube_client_fallback'
+    },
 
     // Extra
     'ytdl_title_top': {

--- a/backend/consts.js
+++ b/backend/consts.js
@@ -86,9 +86,9 @@ exports.CONFIG_ITEMS = {
         'key': 'ytdl_use_ytdlp_impersonation',
         'path': 'YtdlMaterial.Downloader.use_ytdlp_impersonation'
     },
-    'ytdl_use_youtube_client_fallback': {
-        'key': 'ytdl_use_youtube_client_fallback',
-        'path': 'YtdlMaterial.Downloader.use_youtube_client_fallback'
+    'ytdl_use_extractor_client_fallback': {
+        'key': 'ytdl_use_extractor_client_fallback',
+        'path': 'YtdlMaterial.Downloader.use_extractor_client_fallback'
     },
 
     // Extra

--- a/backend/downloader.js
+++ b/backend/downloader.js
@@ -35,6 +35,7 @@ const ANSI_ESCAPE_SEQUENCE_REGEX = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
 const DEFAULT_INVALID_FILENAME_CHARS = '\\/:*?"<>|';
 const METADATA_FIELDS_FOR_FILENAME_SANITIZATION = 'title,fulltitle,playlist_title,uploader,channel,series,chapter,album,artist';
 const DEFAULT_YTDLP_IMPERSONATION_ARG = '--impersonate=';
+const YOUTUBE_CLIENT_FALLBACK_ARG_VALUE = 'youtube:player_client=tv,web';
 const SKIPPABLE_SUBSCRIPTION_DOWNLOAD_ERROR_TYPES = new Set(['join_only', 'no_output', 'no_downloadable_items']);
 const SKIPPABLE_SUBSCRIPTION_DOWNLOAD_ERROR_TEXT = [
     'join this channel',
@@ -97,6 +98,19 @@ function appendYtDlpImpersonationArgs(download_args = [], downloader_fork = conf
     return download_args.concat([DEFAULT_YTDLP_IMPERSONATION_ARG]);
 }
 exports.appendYtDlpImpersonationArgs = appendYtDlpImpersonationArgs;
+
+// Works around YouTube experiments (e.g. binding the GVS PO Token to the video ID for
+// the web_safari client) that cause yt-dlp to extract info successfully but get a 403
+// when it tries to download the actual video data.
+function appendYoutubeClientFallbackArgs(download_args = [], downloader_fork = config_api.getConfigItem('ytdl_default_downloader')) {
+    if (!Array.isArray(download_args)) return [];
+    if (downloader_fork !== 'yt-dlp') return download_args;
+    if (!config_api.getConfigItem('ytdl_use_youtube_client_fallback')) return download_args;
+    if (hasArg(download_args, '--extractor-args')) return download_args;
+
+    return download_args.concat(['--extractor-args', YOUTUBE_CLIENT_FALLBACK_ARG_VALUE]);
+}
+exports.appendYoutubeClientFallbackArgs = appendYoutubeClientFallbackArgs;
 
 function normalizeArchiveExtractor(value = null) {
     if (typeof value !== 'string') return null;
@@ -2313,6 +2327,7 @@ exports.generateArgs = async (url, type, options, user_uid = null, simulated = f
     }
 
     downloadConfig = appendYtDlpImpersonationArgs(downloadConfig, default_downloader);
+    downloadConfig = appendYoutubeClientFallbackArgs(downloadConfig, default_downloader);
 
     // filter out incompatible args
     downloadConfig = filterArgs(downloadConfig, is_audio);

--- a/backend/downloader.js
+++ b/backend/downloader.js
@@ -35,7 +35,7 @@ const ANSI_ESCAPE_SEQUENCE_REGEX = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
 const DEFAULT_INVALID_FILENAME_CHARS = '\\/:*?"<>|';
 const METADATA_FIELDS_FOR_FILENAME_SANITIZATION = 'title,fulltitle,playlist_title,uploader,channel,series,chapter,album,artist';
 const DEFAULT_YTDLP_IMPERSONATION_ARG = '--impersonate=';
-const YOUTUBE_CLIENT_FALLBACK_ARG_VALUE = 'youtube:player_client=tv,web';
+const EXTRACTOR_CLIENT_FALLBACK_ARG_VALUE = 'youtube:player_client=tv,web';
 const SKIPPABLE_SUBSCRIPTION_DOWNLOAD_ERROR_TYPES = new Set(['join_only', 'no_output', 'no_downloadable_items']);
 const SKIPPABLE_SUBSCRIPTION_DOWNLOAD_ERROR_TEXT = [
     'join this channel',
@@ -99,18 +99,18 @@ function appendYtDlpImpersonationArgs(download_args = [], downloader_fork = conf
 }
 exports.appendYtDlpImpersonationArgs = appendYtDlpImpersonationArgs;
 
-// Works around YouTube experiments (e.g. binding the GVS PO Token to the video ID for
+// Works around extractor experiments (e.g. binding the GVS PO Token to the video ID for
 // the web_safari client) that cause yt-dlp to extract info successfully but get a 403
 // when it tries to download the actual video data.
-function appendYoutubeClientFallbackArgs(download_args = [], downloader_fork = config_api.getConfigItem('ytdl_default_downloader')) {
+function appendExtractorClientFallbackArgs(download_args = [], downloader_fork = config_api.getConfigItem('ytdl_default_downloader')) {
     if (!Array.isArray(download_args)) return [];
     if (downloader_fork !== 'yt-dlp') return download_args;
-    if (!config_api.getConfigItem('ytdl_use_youtube_client_fallback')) return download_args;
+    if (!config_api.getConfigItem('ytdl_use_extractor_client_fallback')) return download_args;
     if (hasArg(download_args, '--extractor-args')) return download_args;
 
-    return download_args.concat(['--extractor-args', YOUTUBE_CLIENT_FALLBACK_ARG_VALUE]);
+    return download_args.concat(['--extractor-args', EXTRACTOR_CLIENT_FALLBACK_ARG_VALUE]);
 }
-exports.appendYoutubeClientFallbackArgs = appendYoutubeClientFallbackArgs;
+exports.appendExtractorClientFallbackArgs = appendExtractorClientFallbackArgs;
 
 function normalizeArchiveExtractor(value = null) {
     if (typeof value !== 'string') return null;
@@ -2327,7 +2327,7 @@ exports.generateArgs = async (url, type, options, user_uid = null, simulated = f
     }
 
     downloadConfig = appendYtDlpImpersonationArgs(downloadConfig, default_downloader);
-    downloadConfig = appendYoutubeClientFallbackArgs(downloadConfig, default_downloader);
+    downloadConfig = appendExtractorClientFallbackArgs(downloadConfig, default_downloader);
 
     // filter out incompatible args
     downloadConfig = filterArgs(downloadConfig, is_audio);

--- a/backend/test/downloader.test.js
+++ b/backend/test/downloader.test.js
@@ -322,6 +322,52 @@ describe('Downloader', function() {
         }
     });
 
+    it('Generate args appends the YouTube client fallback when enabled', async function() {
+        const original_fallback = config_api.getConfigItem('ytdl_use_youtube_client_fallback');
+        const original_downloader = config_api.getConfigItem('ytdl_default_downloader');
+        try {
+            config_api.setConfigItem('ytdl_use_youtube_client_fallback', true);
+            config_api.setConfigItem('ytdl_default_downloader', 'yt-dlp');
+
+            const args = await downloader_api.generateArgs(url, 'video', {ui_uid: uuid()}, null, true);
+            const extractor_args_index = args.indexOf('--extractor-args');
+            assert(extractor_args_index !== -1);
+            assert.strictEqual(args[extractor_args_index + 1], 'youtube:player_client=tv,web');
+        } finally {
+            config_api.setConfigItem('ytdl_use_youtube_client_fallback', original_fallback);
+            config_api.setConfigItem('ytdl_default_downloader', original_downloader);
+        }
+    });
+
+    it('Generate args omits the YouTube client fallback when disabled', async function() {
+        const original_fallback = config_api.getConfigItem('ytdl_use_youtube_client_fallback');
+        try {
+            config_api.setConfigItem('ytdl_use_youtube_client_fallback', false);
+
+            const args = await downloader_api.generateArgs(url, 'video', {ui_uid: uuid()}, null, true);
+            assert(!args.includes('--extractor-args'));
+        } finally {
+            config_api.setConfigItem('ytdl_use_youtube_client_fallback', original_fallback);
+        }
+    });
+
+    it('Generate args does not duplicate a manually configured extractor-args override', async function() {
+        const original_fallback = config_api.getConfigItem('ytdl_use_youtube_client_fallback');
+        try {
+            config_api.setConfigItem('ytdl_use_youtube_client_fallback', true);
+
+            const args = await downloader_api.generateArgs(url, 'video', {
+                customArgs: '--extractor-args,,youtube:player_client=android',
+                ui_uid: uuid()
+            }, null, true);
+            const extractor_args_matches = args.filter(arg => arg === '--extractor-args');
+            assert.strictEqual(extractor_args_matches.length, 1);
+            assert.strictEqual(args[args.indexOf('--extractor-args') + 1], 'youtube:player_client=android');
+        } finally {
+            config_api.setConfigItem('ytdl_use_youtube_client_fallback', original_fallback);
+        }
+    });
+
     it('Download file', async function() {
         this.timeout(300000);
         await downloader_api.setupDownloads();

--- a/backend/test/downloader.test.js
+++ b/backend/test/downloader.test.js
@@ -322,11 +322,11 @@ describe('Downloader', function() {
         }
     });
 
-    it('Generate args appends the YouTube client fallback when enabled', async function() {
-        const original_fallback = config_api.getConfigItem('ytdl_use_youtube_client_fallback');
+    it('Generate args appends the extractor client fallback when enabled', async function() {
+        const original_fallback = config_api.getConfigItem('ytdl_use_extractor_client_fallback');
         const original_downloader = config_api.getConfigItem('ytdl_default_downloader');
         try {
-            config_api.setConfigItem('ytdl_use_youtube_client_fallback', true);
+            config_api.setConfigItem('ytdl_use_extractor_client_fallback', true);
             config_api.setConfigItem('ytdl_default_downloader', 'yt-dlp');
 
             const args = await downloader_api.generateArgs(url, 'video', {ui_uid: uuid()}, null, true);
@@ -334,27 +334,27 @@ describe('Downloader', function() {
             assert(extractor_args_index !== -1);
             assert.strictEqual(args[extractor_args_index + 1], 'youtube:player_client=tv,web');
         } finally {
-            config_api.setConfigItem('ytdl_use_youtube_client_fallback', original_fallback);
+            config_api.setConfigItem('ytdl_use_extractor_client_fallback', original_fallback);
             config_api.setConfigItem('ytdl_default_downloader', original_downloader);
         }
     });
 
-    it('Generate args omits the YouTube client fallback when disabled', async function() {
-        const original_fallback = config_api.getConfigItem('ytdl_use_youtube_client_fallback');
+    it('Generate args omits the extractor client fallback when disabled', async function() {
+        const original_fallback = config_api.getConfigItem('ytdl_use_extractor_client_fallback');
         try {
-            config_api.setConfigItem('ytdl_use_youtube_client_fallback', false);
+            config_api.setConfigItem('ytdl_use_extractor_client_fallback', false);
 
             const args = await downloader_api.generateArgs(url, 'video', {ui_uid: uuid()}, null, true);
             assert(!args.includes('--extractor-args'));
         } finally {
-            config_api.setConfigItem('ytdl_use_youtube_client_fallback', original_fallback);
+            config_api.setConfigItem('ytdl_use_extractor_client_fallback', original_fallback);
         }
     });
 
     it('Generate args does not duplicate a manually configured extractor-args override', async function() {
-        const original_fallback = config_api.getConfigItem('ytdl_use_youtube_client_fallback');
+        const original_fallback = config_api.getConfigItem('ytdl_use_extractor_client_fallback');
         try {
-            config_api.setConfigItem('ytdl_use_youtube_client_fallback', true);
+            config_api.setConfigItem('ytdl_use_extractor_client_fallback', true);
 
             const args = await downloader_api.generateArgs(url, 'video', {
                 customArgs: '--extractor-args,,youtube:player_client=android',
@@ -364,7 +364,7 @@ describe('Downloader', function() {
             assert.strictEqual(extractor_args_matches.length, 1);
             assert.strictEqual(args[args.indexOf('--extractor-args') + 1], 'youtube:player_client=android');
         } finally {
-            config_api.setConfigItem('ytdl_use_youtube_client_fallback', original_fallback);
+            config_api.setConfigItem('ytdl_use_extractor_client_fallback', original_fallback);
         }
     });
 

--- a/docker-environment.md
+++ b/docker-environment.md
@@ -95,7 +95,7 @@ When using env-managed Docker setups with `write_ytdl_config='true'`, you can cl
 * `ytdl_min_sleep_between_downloads`: minimum seconds to wait before starting the next queued download step (default `0`, disabled)
 * `ytdl_warn_on_duplicate`: set to `'true'` to warn on duplicate downloads and reuse existing files in playlists instead of downloading them again (default `'false'`)
 * `ytdl_max_playlist_chunks`: cap automatic playlist chunk creation (default `20`, min `1`)
-* `ytdl_use_youtube_client_fallback`: set to `'true'` to add yt-dlp `--extractor-args youtube:player_client=tv,web` as a workaround for 403 download errors (default `'false'`)
+* `ytdl_use_extractor_client_fallback`: set to `'true'` to add yt-dlp `--extractor-args youtube:player_client=tv,web` as a workaround for 403 download errors (default `'false'`)
 
 ## OIDC
 

--- a/docker-environment.md
+++ b/docker-environment.md
@@ -95,6 +95,7 @@ When using env-managed Docker setups with `write_ytdl_config='true'`, you can cl
 * `ytdl_min_sleep_between_downloads`: minimum seconds to wait before starting the next queued download step (default `0`, disabled)
 * `ytdl_warn_on_duplicate`: set to `'true'` to warn on duplicate downloads and reuse existing files in playlists instead of downloading them again (default `'false'`)
 * `ytdl_max_playlist_chunks`: cap automatic playlist chunk creation (default `20`, min `1`)
+* `ytdl_use_youtube_client_fallback`: set to `'true'` to add yt-dlp `--extractor-args youtube:player_client=tv,web` as a workaround for 403 download errors (default `'false'`)
 
 ## OIDC
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,9 +39,9 @@
         "zone.js": "~0.16.2"
       },
       "devDependencies": {
-        "@angular-devkit/core": "^22.0.3",
-        "@angular/build": "^22.0.3",
-        "@angular/cli": "^22.0.3",
+        "@angular-devkit/core": "^22.0.4",
+        "@angular/build": "^22.0.4",
+        "@angular/cli": "^22.0.4",
         "@angular/compiler-cli": "^22.0.2",
         "@angular/language-service": "^22.0.2",
         "@eslint/js": "^10.0.1",
@@ -295,13 +295,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.2200.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2200.3.tgz",
-      "integrity": "sha512-Ru+ucNkTZr98gmeaBYjq3zZwh32yGofAeB8+GJL/ZNy0x+7NzK6b+OatdzwT4l7mCWFC5vL8iYu0B4++M66Jpg==",
+      "version": "0.2200.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2200.4.tgz",
+      "integrity": "sha512-X/iEQiZ0pRmpjUt11jCM+mtOLRl4XxI9hnM0IC9aAcsm5AzRBb9WY6QIEqOSficjxC/+MI7MGwrerrcP6QN8UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.0.3",
+        "@angular-devkit/core": "22.0.4",
         "rxjs": "7.8.2"
       },
       "bin": {
@@ -314,9 +314,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.0.3.tgz",
-      "integrity": "sha512-pBjo1JKwI8GbNdTo/Z0g+ZekqlTBCJWmzIC5fgGW9q5eRjl1y+5N5jlX8UAyyMCeUTTwsfpQdkAM2jyi/jcvjA==",
+      "version": "22.0.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.0.4.tgz",
+      "integrity": "sha512-zA2UJSMAU3su5uJTOn5ul/gCLRcw6/uIQ6EC5v/Ju/ePjgDIw9R3y3MAvWQ4Ibi/fXiq0FVxpF8hE7RUclYmJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -359,13 +359,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.0.3.tgz",
-      "integrity": "sha512-aIp5sQDHdhyLbeVJF/k3w079XhW91mNAo2OliZllBCjoYhkIXNnWECOx5y2nXtCChyFJA2+ZgNST7NIDvtz1/w==",
+      "version": "22.0.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.0.4.tgz",
+      "integrity": "sha512-VRxL1hD/Q3TQglM6EfQ0ksAW4OIvtKyZgtaUpyGsJRfD6tGmLFn7MDnmyyq1ceLX/Clq+3tzH/wN0tF6rcE0jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.0.3",
+        "@angular-devkit/core": "22.0.4",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.21",
         "ora": "9.4.0",
@@ -394,14 +394,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.0.3.tgz",
-      "integrity": "sha512-pwFDRCp+r8JK+fCtScPldizcS75wSpn3u/4goDf2FRa4Y9wzTvq6T0XpFHqdpgq6HcIlIZWwAqqW6XqEM9/pKQ==",
+      "version": "22.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.0.4.tgz",
+      "integrity": "sha512-hst/KhP5mMPajY32l7qmyW/5fuqrMHCjHEeNhMMNqP82+j8jPBFfMEL26AH9w2kIIdKGpC3WKN5JgLotyFD7tQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2200.3",
+        "@angular-devkit/architect": "0.2200.4",
         "@babel/core": "7.29.0",
         "@babel/helper-annotate-as-pure": "7.27.3",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -417,7 +417,7 @@
         "mrmime": "2.0.1",
         "parse5-html-rewriting-stream": "8.0.1",
         "picomatch": "4.0.4",
-        "piscina": "5.1.4",
+        "piscina": "5.2.0",
         "rollup": "4.60.2",
         "sass": "1.99.0",
         "semver": "7.7.4",
@@ -442,7 +442,7 @@
         "@angular/platform-browser": "^22.0.0",
         "@angular/platform-server": "^22.0.0",
         "@angular/service-worker": "^22.0.0",
-        "@angular/ssr": "^22.0.3",
+        "@angular/ssr": "^22.0.4",
         "istanbul-lib-instrument": "^6.0.0",
         "karma": "^6.4.0",
         "less": "^4.2.0",
@@ -529,19 +529,19 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.0.3.tgz",
-      "integrity": "sha512-YgFzfQu3Il6Aka8IdH4pk7faieICaca5Wklke0jMTKBUxzLGWw82X7+J/Lox7FERb6LHtxiHpa6ttXqerCZvgg==",
+      "version": "22.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.0.4.tgz",
+      "integrity": "sha512-3eJy6VoNlgskKFzvqy3AJsYXFRhSBLLGObF2iTpJymsukuxWUen7hlVVVWrO5++bW1LEgd6PTCCD5fdT2UuRiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2200.3",
-        "@angular-devkit/core": "22.0.3",
-        "@angular-devkit/schematics": "22.0.3",
+        "@angular-devkit/architect": "0.2200.4",
+        "@angular-devkit/core": "22.0.4",
+        "@angular-devkit/schematics": "22.0.4",
         "@inquirer/prompts": "8.4.2",
         "@listr2/prompt-adapter-inquirer": "4.2.3",
         "@modelcontextprotocol/sdk": "1.29.0",
-        "@schematics/angular": "22.0.3",
+        "@schematics/angular": "22.0.4",
         "@yarnpkg/lockfile": "1.1.0",
         "algoliasearch": "5.52.0",
         "ini": "6.0.0",
@@ -2565,6 +2565,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2582,6 +2585,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2599,6 +2605,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2616,6 +2625,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2633,6 +2645,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2650,6 +2665,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2667,6 +2685,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3675,14 +3696,14 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.0.3.tgz",
-      "integrity": "sha512-iAUqIoRcK1CCHDm5E4Q1SI7rpVtsHJ+0qv5ll72wV3C1eCNdeDuGV0lX7PXEEkwd4y//s6yqI9o7f6VZZd6Fbw==",
+      "version": "22.0.4",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.0.4.tgz",
+      "integrity": "sha512-P3V3tkqIR+n0GJSv0ibf34/zMtKbFp6kaTjBe5cm/RyXuHbmdaPYjk8PNphkGMypDtWCof1RtNnW/hl832Wnew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.0.3",
-        "@angular-devkit/schematics": "22.0.3",
+        "@angular-devkit/core": "22.0.4",
+        "@angular-devkit/schematics": "22.0.4",
         "jsonc-parser": "3.3.1",
         "typescript": "6.0.3"
       },
@@ -8954,9 +8975,9 @@
       }
     },
     "node_modules/piscina": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.1.4.tgz",
-      "integrity": "sha512-7uU4ZnKeQq22t9AsmHGD2w4OYQGonwFnTypDypaWi7Qr2EvQIFVtG8J5D/3bE7W123Wdc9+v4CZDu5hJXVCtBg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.2.0.tgz",
+      "integrity": "sha512-DszUCKeVN/5G5QKo6jAVHL8fmKnkJvQ0ACiVgY7YGCq3TUB2oznAOayvZPIAdEThvhczkXR+qm3IHsNXpFCYfA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
     "zone.js": "~0.16.2"
   },
   "devDependencies": {
-    "@angular-devkit/core": "^22.0.3",
-    "@angular/build": "^22.0.3",
-    "@angular/cli": "^22.0.3",
+    "@angular-devkit/core": "^22.0.4",
+    "@angular/build": "^22.0.4",
+    "@angular/cli": "^22.0.4",
     "@angular/compiler-cli": "^22.0.2",
     "@angular/language-service": "^22.0.2",
     "@eslint/js": "^10.0.1",

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -194,6 +194,9 @@
             <div class="col-12 mt-2 mb-2">
               <mat-checkbox color="accent" [(ngModel)]="new_config['Downloader']['skip_join_only_videos']"><ng-container i18n="Skip join-only videos setting">Skip join-only videos</ng-container></mat-checkbox>
             </div>
+            <div class="col-12 mt-2 mb-2">
+              <mat-checkbox color="accent" [(ngModel)]="new_config['Downloader']['use_youtube_client_fallback']" matTooltip="Adds --extractor-args youtube:player_client=tv,web (yt-dlp only) to work around YouTube experiments that cause downloads to fail with HTTP 403 errors." i18n-matTooltip="Use YouTube client fallback setting tooltip"><ng-container i18n="Use YouTube client fallback setting">Use YouTube client fallback</ng-container></mat-checkbox>
+            </div>
             @if (postsService.ytdlpImpersonationAvailable) {
             <div class="col-12 mt-2 mb-2">
               <mat-checkbox color="accent" [(ngModel)]="new_config['Downloader']['use_ytdlp_impersonation']"><ng-container i18n="Use yt-dlp browser impersonation setting">Use yt-dlp browser impersonation</ng-container></mat-checkbox>

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -195,7 +195,7 @@
               <mat-checkbox color="accent" [(ngModel)]="new_config['Downloader']['skip_join_only_videos']"><ng-container i18n="Skip join-only videos setting">Skip join-only videos</ng-container></mat-checkbox>
             </div>
             <div class="col-12 mt-2 mb-2">
-              <mat-checkbox color="accent" [(ngModel)]="new_config['Downloader']['use_youtube_client_fallback']" matTooltip="Adds --extractor-args youtube:player_client=tv,web (yt-dlp only) to work around YouTube experiments that cause downloads to fail with HTTP 403 errors." i18n-matTooltip="Use YouTube client fallback setting tooltip"><ng-container i18n="Use YouTube client fallback setting">Use YouTube client fallback</ng-container></mat-checkbox>
+              <mat-checkbox color="accent" [(ngModel)]="new_config['Downloader']['use_extractor_client_fallback']" matTooltip="Adds --extractor-args youtube:player_client=tv,web (yt-dlp only) to work around extractor experiments that cause downloads to fail with HTTP 403 errors." i18n-matTooltip="Use extractor client fallback setting tooltip"><ng-container i18n="Use extractor client fallback setting">Use extractor client fallback</ng-container></mat-checkbox>
             </div>
             @if (postsService.ytdlpImpersonationAvailable) {
             <div class="col-12 mt-2 mb-2">

--- a/src/assets/default.json
+++ b/src/assets/default.json
@@ -22,7 +22,7 @@
       "download_rate_limit": "",
       "skip_join_only_videos": false,
       "use_ytdlp_impersonation": false,
-      "use_youtube_client_fallback": false
+      "use_extractor_client_fallback": false
     },
     "Extra": {
       "title_top": "ytdl-material",

--- a/src/assets/default.json
+++ b/src/assets/default.json
@@ -21,7 +21,8 @@
       "playlist_chunk_size": 20,
       "download_rate_limit": "",
       "skip_join_only_videos": false,
-      "use_ytdlp_impersonation": false
+      "use_ytdlp_impersonation": false,
+      "use_youtube_client_fallback": false
     },
     "Extra": {
       "title_top": "ytdl-material",


### PR DESCRIPTION
## Summary
- Adds an opt-in **Use extractor client fallback** checkbox (Settings → Downloader) that appends `--extractor-args youtube:player_client=tv,web` to yt-dlp downloads.
- Works around an extractor-side experiment (binding the GVS PO Token to the video ID for the `web_safari` client) that lets info/metadata extraction succeed but causes the actual video data download to fail with `HTTP Error 403: Forbidden`.
- Applies to single video, subscription, and channel downloads, since they all share `generateArgs`. Disabled by default. Also settable via the `ytdl_use_extractor_client_fallback` env var when `write_ytdl_config` is enabled.
- Skips silently for non-yt-dlp downloader forks, and won't duplicate `--extractor-args` if one is already supplied via custom args.

## Test plan
- [x] `npx mocha test/downloader.test.js` — 76 passing (2 pre-existing pending, unrelated)
- [x] `npm run lint`
- [x] `npx tsc -p src/tsconfig.app.json --noEmit`
- [x] `npx tsc -p src/tsconfig.spec.json --noEmit`
- [x] `CHROMIUM_BIN=$(command -v chromium) npm run test:headless` — 199/199 passing
- [x] `npx ng build --configuration production` — succeeds
- [x] `node --check` on all touched backend files