### PR TITLE
fix(downloader): stop config from clobbering env log level and unmask real download errors

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -884,8 +884,10 @@ function loadConfigValues() {
     if (!url || url === '') url = 'http://example.com'
     url_domain = new URL(url);
 
-    let logger_level = config_api.getConfigItem('ytdl_logger_level');
-    utils.updateLoggerLevel(logger_level);
+    if (!logger.hasEnvLogLevelOverride()) {
+        let logger_level = config_api.getConfigItem('ytdl_logger_level');
+        utils.updateLoggerLevel(logger_level);
+    }
 
     configureExpressTrustProxy();
 }

--- a/backend/logger.js
+++ b/backend/logger.js
@@ -7,11 +7,19 @@ function normalizeLogLevel(logLevel) {
     return Object.prototype.hasOwnProperty.call(winston.config.npm.levels, normalized) ? normalized : null;
 }
 
-function resolveLogLevelFromEnv() {
-    const raw_log_level = process.env.ytdl_log_level
+function getRawEnvLogLevel() {
+    return process.env.ytdl_log_level
         || process.env.YTDL_LOG_LEVEL
         || process.env.ytdl_logger_level
         || process.env.YTDL_LOGGER_LEVEL;
+}
+
+function hasEnvLogLevelOverride() {
+    return !!getRawEnvLogLevel();
+}
+
+function resolveLogLevelFromEnv() {
+    const raw_log_level = getRawEnvLogLevel();
 
     const normalized_log_level = normalizeLogLevel(raw_log_level);
     if (normalized_log_level) {
@@ -49,5 +57,7 @@ const logger = winston.createLogger({
 if (invalidRawLogLevel) {
     logger.warn(`Invalid log level '${invalidRawLogLevel}' from environment. Falling back to 'info'.`);
 }
+
+logger.hasEnvLogLevelOverride = hasEnvLogLevelOverride;
 
 module.exports = logger;

--- a/backend/test/logger.test.js
+++ b/backend/test/logger.test.js
@@ -1,0 +1,39 @@
+/* eslint-disable no-undef */
+const assert = require('assert');
+const logger = require('../logger');
+
+describe('Logger', function() {
+    const env_keys = ['ytdl_log_level', 'YTDL_LOG_LEVEL', 'ytdl_logger_level', 'YTDL_LOGGER_LEVEL'];
+    const original_env_values = {};
+
+    beforeEach(function() {
+        for (const key of env_keys) {
+            original_env_values[key] = process.env[key];
+            delete process.env[key];
+        }
+    });
+
+    afterEach(function() {
+        for (const key of env_keys) {
+            if (original_env_values[key] === undefined) {
+                delete process.env[key];
+            } else {
+                process.env[key] = original_env_values[key];
+            }
+        }
+    });
+
+    it('hasEnvLogLevelOverride is false when no log level env vars are set', function() {
+        assert.strictEqual(logger.hasEnvLogLevelOverride(), false);
+    });
+
+    it('hasEnvLogLevelOverride is true when ytdl_log_level is set', function() {
+        process.env.ytdl_log_level = 'debug';
+        assert.strictEqual(logger.hasEnvLogLevelOverride(), true);
+    });
+
+    it('hasEnvLogLevelOverride is true when only the uppercase env var is set', function() {
+        process.env.YTDL_LOGGER_LEVEL = 'warn';
+        assert.strictEqual(logger.hasEnvLogLevelOverride(), true);
+    });
+});

--- a/backend/test/youtube-dl.test.js
+++ b/backend/test/youtube-dl.test.js
@@ -75,5 +75,37 @@ describe('youtube-dl', function() {
         const {child_process} = await youtubedl_api.runYoutubeDL(url, args);
         assert(child_process);
     });
+
+    it('Reports the real error instead of masking it with stale info-lookup JSON when the download itself fails', async function() {
+        this.timeout(300000);
+
+        const original_fork = config_api.getConfigItem('ytdl_default_downloader');
+        config_api.setConfigItem('ytdl_default_downloader', 'yt-dlp');
+        await youtubedl_api.checkForYoutubeDLUpdate('yt-dlp');
+
+        const binary_path = path.join('appdata', 'bin', 'yt-dlp');
+        const backup_path = `${binary_path}.real-test-backup`;
+        fs.renameSync(binary_path, backup_path);
+        fs.writeFileSync(binary_path, [
+            '#!/usr/bin/env node',
+            'process.stdout.write(\'{"id":"fake","title":"fake"}\\n\');',
+            'process.stderr.write(\'ERROR: unable to download video data: HTTP Error 403: Forbidden\\n\');',
+            'process.exit(1);',
+            ''
+        ].join('\n'));
+        fs.chmodSync(binary_path, 0o755);
+
+        try {
+            const {callback} = await youtubedl_api.runYoutubeDL('https://www.youtube.com/watch?v=fake', []);
+            const {parsed_output, err} = await callback;
+            assert.strictEqual(parsed_output, null);
+            assert(err);
+            assert(err.stderr.includes('HTTP Error 403: Forbidden'));
+        } finally {
+            fs.unlinkSync(binary_path);
+            fs.renameSync(backup_path, binary_path);
+            config_api.setConfigItem('ytdl_default_downloader', original_fork);
+        }
+    });
 });
 

--- a/backend/youtube-dl.js
+++ b/backend/youtube-dl.js
@@ -282,9 +282,12 @@ const runYoutubeDLProcess = async (url, args, youtubedl_fork = config_api.getCon
             if (e.stdout) logger.debug(`stdout from failed process: ${e.stdout.substring(0, 500)}`);
             if (e.stderr) logger.debug(`stderr from failed process: ${e.stderr.substring(0, 500)}`);
 
-            // Preserve partial JSON output from playlist runs where some entries fail.
-            const fallback_output_lines = e.stdout ? e.stdout.trim().split(/\r?\n/) : null;
-            const parsed_output = fallback_output_lines ? utils.parseOutputJSON(fallback_output_lines, e) : null;
+            // Only recover partial JSON output for the known benign per-item errors
+            // (e.g. playlist runs where some entries are private/unavailable). Any other
+            // error (network failure, 403, etc.) should be reported as a real failure
+            // instead of being masked by stale info-lookup JSON that printed before the
+            // download itself failed.
+            const parsed_output = utils.parseOutputJSON(null, e);
             resolve({parsed_output: parsed_output, err: e})
         }
     });


### PR DESCRIPTION
## Summary
Two diagnostics bugs surfaced while debugging a 403 download failure on a real instance:

- **Log level env var was silently ignored.** `app.js`'s `loadConfigValues()` always reapplied the GUI/config `logger_level` setting on startup and on every config change, overwriting whatever `ytdl_log_level` (or other recognized env var) had set at boot. `logger.js` now exposes `hasEnvLogLevelOverride()`, and `loadConfigValues()` skips the config-driven level entirely when an env var is already controlling it — same precedent as `ytdl_trust_proxy`.
- **Real yt-dlp errors were masked by stale JSON.** In `youtube-dl.js`'s `runYoutubeDLProcess`, whenever the yt-dlp process exited non-zero, the code unconditionally tried to recover "partial JSON output" from stdout and treated it as a successful result — even for hard failures like a 403 on the actual video data fetch. That JSON was just the info-lookup dump that printed *before* the download itself failed, so the app believed the download succeeded and downstream code reported a confusing "Could not stat" / "Downloaded file failed to result in metadata object" error instead of the real one. The fix routes through `parseOutputJSON`'s existing safe-list check (only recovers for "This video is unavailable" / "Private video", the playlist-partial-failure case this was originally meant for) instead of bypassing it.

## Test plan
- [x] New `test/logger.test.js` covering `hasEnvLogLevelOverride()`
- [x] New test in `test/youtube-dl.test.js` that swaps in a fake failing binary (prints JSON to stdout, "HTTP Error 403: Forbidden" to stderr, exits 1) and asserts the real error is now reported instead of a masked success
- [x] Full backend suite: `npm test` — 218 passing, 24 pre-existing pending
- [x] `npm run lint`
- [x] `npx tsc -p src/tsconfig.app.json --noEmit`
- [x] `npx tsc -p src/tsconfig.spec.json --noEmit`
- [x] `node --check` on all touched backend files