### PR TITLE
fix(deps): combine dependency updates (#322–#325)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -23,7 +23,7 @@
         "config": "^4.4.2",
         "execa": "^9.6.1",
         "express": "^5.2.1",
-        "express-rate-limit": "^8.5.2",
+        "express-rate-limit": "^8.6.0",
         "express-session": "^1.19.0",
         "feed": "^6.0.0",
         "fluent-ffmpeg": "^2.1.3",
@@ -2091,11 +2091,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
       "license": "MIT",
       "dependencies": {
+        "debug": "^4.4.3",
         "ip-address": "^10.2.0"
       },
       "engines": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -21,7 +21,7 @@
         "command-exists": "^1.2.9",
         "compression": "^1.8.1",
         "config": "^4.4.2",
-        "execa": "^9.6.1",
+        "execa": "^10.0.0",
         "express": "^5.2.1",
         "express-rate-limit": "^8.5.2",
         "express-session": "^1.19.0",
@@ -2010,26 +2010,27 @@
       }
     },
     "node_modules/execa": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
-      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-10.0.0.tgz",
+      "integrity": "sha512-Cxl6MKxB1dr1H0FHmiizJ+lavKF7pV+fcDZFyqMB8d5m7qUPm/OtZYcD5vPWePKxSnTQ57KuBd9mtdZ3oNCvyQ==",
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/merge-streams": "^4.0.0",
-        "cross-spawn": "^7.0.6",
         "figures": "^6.1.0",
-        "get-stream": "^9.0.0",
+        "get-stream": "^9.0.1",
         "human-signals": "^8.0.1",
         "is-plain-obj": "^4.1.0",
         "is-stream": "^4.0.1",
         "npm-run-path": "^6.0.0",
-        "pretty-ms": "^9.2.0",
+        "path-key": "^4.0.0",
+        "pretty-ms": "^9.3.0",
         "signal-exit": "^4.1.0",
         "strip-final-newline": "^4.0.0",
-        "yoctocolors": "^2.1.1"
+        "which-command": "^0.1.0",
+        "yoctocolors": "^2.1.2"
       },
       "engines": {
-        "node": "^18.19.0 || >=20.5.0"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
@@ -2042,6 +2043,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5404,6 +5417,21 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-command": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/which-command/-/which-command-0.1.0.tgz",
+      "integrity": "sha512-XZyoF5/5hZtXitIwzrU4NKK+Wtbb9aB9CezUEw2Q0wlYK8NUYQxC1rRXgNueYLtBAJwXIb+/tFVk4dozciNJMA==",
+      "license": "MIT",
+      "bin": {
+        "which-command": "cli.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/which-command?sponsor=1"
       }
     },
     "node_modules/winston": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@discordjs/builders": "^1.14.1",
         "@discordjs/core": "^2.6.0",
-        "@scalar/express-api-reference": "^0.10.10",
+        "@scalar/express-api-reference": "^0.10.11",
         "archiver": "^8.0.0",
         "async": "^3.2.3",
         "async-mutex": "^0.5.0",
@@ -407,60 +407,60 @@
       }
     },
     "node_modules/@scalar/client-side-rendering": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@scalar/client-side-rendering/-/client-side-rendering-0.3.3.tgz",
-      "integrity": "sha512-QMTKZdwtSSV619jV1jKeRCOd358cgJqRBTHQ663CF7EUCZ354qH4js883K3RYg5/eO4oWxOuka308KIj0sZ/Kg==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@scalar/client-side-rendering/-/client-side-rendering-0.3.4.tgz",
+      "integrity": "sha512-kb3B+FGjvAUr2DU0fe9dVKBLwot1TjOO+iHCTmY8r8FUJySmYKGQYCicRzzilOyTjvKspiZBCEr03PWaWW+1gw==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/schemas": "0.7.3",
-        "@scalar/types": "0.16.3",
-        "@scalar/validation": "0.6.1"
+        "@scalar/schemas": "0.7.4",
+        "@scalar/types": "0.16.4",
+        "@scalar/validation": "0.6.2"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/express-api-reference": {
-      "version": "0.10.10",
-      "resolved": "https://registry.npmjs.org/@scalar/express-api-reference/-/express-api-reference-0.10.10.tgz",
-      "integrity": "sha512-gzdAElT6wMDAPppKd7CtIgutvWMYOlQXyjWThBzFSCI3k/s7Zemx4AnxANjqhfwWaGSLer4sR9YSutNoJOTpjA==",
+      "version": "0.10.11",
+      "resolved": "https://registry.npmjs.org/@scalar/express-api-reference/-/express-api-reference-0.10.11.tgz",
+      "integrity": "sha512-4+M9rGFewfG9eymtSSs7T+lnQ8z+d1urnhxOkUVkXfi2vnxD9pcvWIUMyLRl6iPwNkBpGquYhTqgGSXYS30ujQ==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/client-side-rendering": "0.3.3"
+        "@scalar/client-side-rendering": "0.3.4"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/helpers": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.9.1.tgz",
-      "integrity": "sha512-UKSLIPfN++f+zzbsZ+F6I0lNrR4yX4PtokjHgGwGiHapxT5VJqAF4zFTIP2KCd27XG7KnAIA7qq62O4xRBxc6w==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.9.2.tgz",
+      "integrity": "sha512-hjyMpMZjTBZQhyByZmz5oUgRKUQJO5V5AOiJxsVEGbUmgA7sJRQeTrXLB+BEwzaKS5nm2opJeNyMBYLFNK4hiQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/schemas": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@scalar/schemas/-/schemas-0.7.3.tgz",
-      "integrity": "sha512-B6S/zUptiRfMsmMy92u/LefpULus1h0q3od9l5xgZc+pslkfFhfFns+QsU0UJX3Lqp3tTsf64c3tIRqH7cZgVA==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@scalar/schemas/-/schemas-0.7.4.tgz",
+      "integrity": "sha512-Or31zxR+ceGGhkVU5XBO2Zv7oyGDtjsJOjM2Rr0WRZ1/tRsQc2/FsVv+9kPmCA7sqFL8BKWlNfTXcPITI7WRHw==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.9.1",
-        "@scalar/validation": "0.6.1"
+        "@scalar/helpers": "0.9.2",
+        "@scalar/validation": "0.6.2"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/types": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.16.3.tgz",
-      "integrity": "sha512-8TVNlK8AdvIekrapAoEVwy+IVRbMTSDYnpprskAJV4XanmZ52Kru6RmS6d+tbEBfMo2dTgQ9cV9P0kqsAu/AuA==",
+      "version": "0.16.4",
+      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.16.4.tgz",
+      "integrity": "sha512-fLf0ANAC3iQq0sIVdmH6aGM+pFSLyD8GfGBxSWcLpI0jE0iFAzX2A3p0qVZm7vqBT4TQnn0fSwg5U+h+FZ52BA==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.9.1",
+        "@scalar/helpers": "0.9.2",
         "nanoid": "^5.1.6",
         "type-fest": "^5.3.1",
         "zod": "^4.3.5"
@@ -470,9 +470,9 @@
       }
     },
     "node_modules/@scalar/validation": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@scalar/validation/-/validation-0.6.1.tgz",
-      "integrity": "sha512-XeJ+pvxag0rguuRT6hxNSXIsxleB8Gcs6WQ55vFRkB4qo2CCO+wIli+uipzM3pILu5cP7agcL3pgADiZzd1ZNg==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@scalar/validation/-/validation-0.6.2.tgz",
+      "integrity": "sha512-Sc1TkcwGV6aVCO51AyKeaGiP8gpwAHxEtO5d3tZzPV+KsnlC/YokQxFxwBrbIXw73k9hmcExnJyGu3k5i6n6VA==",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -49,7 +49,7 @@
         "pg": "^8.22.0",
         "progress": "^2.0.3",
         "ps-node": "^0.1.6",
-        "rate-limit-redis": "^5.0.0",
+        "rate-limit-redis": "^6.0.0",
         "read-last-lines": "^1.8.0",
         "redis": "^6.1.0",
         "rxjs": "^7.8.2",
@@ -4372,15 +4372,15 @@
       }
     },
     "node_modules/rate-limit-redis": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/rate-limit-redis/-/rate-limit-redis-5.0.0.tgz",
-      "integrity": "sha512-+M9el8KZjZ2HXM6/E38jFGmozBbN4C200iLE8+80TgS+8PzSfAAvD1zkx2oWu6YEgSrdiJJNrd4LCFm5vjVJkg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rate-limit-redis/-/rate-limit-redis-6.0.0.tgz",
+      "integrity": "sha512-cBRaXOD5CRprQPQjiVEkKbDY1O9vnOqClSlfm32iydZ2N82EpHM+9VbWTesUZV9TVbfaSH1R5m78BTd0zyesoQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 16"
       },
       "peerDependencies": {
-        "express-rate-limit": ">= 8.5.0"
+        "express-rate-limit": ">= 8.6.0"
       }
     },
     "node_modules/raw-body": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -37,7 +37,7 @@
     "config": "^4.4.2",
     "execa": "^9.6.1",
     "express": "^5.2.1",
-    "express-rate-limit": "^8.5.2",
+    "express-rate-limit": "^8.6.0",
     "express-session": "^1.19.0",
     "feed": "^6.0.0",
     "fluent-ffmpeg": "^2.1.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@discordjs/builders": "^1.14.1",
     "@discordjs/core": "^2.6.0",
-    "@scalar/express-api-reference": "^0.10.10",
+    "@scalar/express-api-reference": "^0.10.11",
     "archiver": "^8.0.0",
     "async": "^3.2.3",
     "async-mutex": "^0.5.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -35,7 +35,7 @@
     "command-exists": "^1.2.9",
     "compression": "^1.8.1",
     "config": "^4.4.2",
-    "execa": "^9.6.1",
+    "execa": "^10.0.0",
     "express": "^5.2.1",
     "express-rate-limit": "^8.5.2",
     "express-session": "^1.19.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -63,7 +63,7 @@
     "pg": "^8.22.0",
     "progress": "^2.0.3",
     "ps-node": "^0.1.6",
-    "rate-limit-redis": "^5.0.0",
+    "rate-limit-redis": "^6.0.0",
     "read-last-lines": "^1.8.0",
     "redis": "^6.1.0",
     "rxjs": "^7.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5924,12 +5924,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
-      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "debug": "^4.4.3",
         "ip-address": "^10.2.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
       "picomatch": "4.0.4"
     },
     "esbuild": "0.28.1",
-    "express-rate-limit": "8.5.1",
+    "express-rate-limit": "8.6.0",
     "ngx-avatars": {
       "@angular/common": "21.2.0",
       "@angular/core": "21.2.0"


### PR DESCRIPTION
## Summary

Combines the four open Dependabot updates into one compatible dependency set:

- #322 — `@scalar/express-api-reference` 0.10.10 → 0.10.11 (backend)
- #323 — `express-rate-limit` 8.5.2 → 8.6.0 (backend)
- #324 — `execa` 9.6.1 → 10.0.0 (backend)
- #325 — `rate-limit-redis` 5.0.0 → 6.0.0 (backend)
- Updates the manually maintained root `express-rate-limit` override from 8.5.1 → 8.6.0, which exact-override dependency checks do not report

The original Dependabot commits are preserved in this branch. The unified lockfile was verified against a fresh Node 24/npm 11 package-lock regeneration.

## Why these need to land together

`rate-limit-redis` 6 requires `express-rate-limit >=8.6.0`. In isolation, #325 has an invalid backend lockfile and fails both Dependencies and Docker CI. The individual PRs also leave the other currently wanted backend updates behind, which makes Dependencies CI fail. The combined tree resolves both conditions.

## Validation

All local validation used Node 24:

- Clean `npm ci --ignore-scripts` in root and backend
- Dependencies workflow current-vs-wanted checks: clean in root and backend
- `npm run lint`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- Chromium headless tests: 201 passing
- Backend Mocha: 218 passing, 24 pending
- `npx ng build --configuration production` (pre-existing warnings only)
- Execa 10 subprocess smoke test
- rate-limit-redis 6 initialization/increment smoke test through the repository adapter
- `npm ls` confirms the backend peer dependency is deduplicated on `express-rate-limit@8.6.0`

No backend JavaScript files changed, so the backend `node --check` requirement is not applicable.

Supersedes #322, #323, #324, and #325.