### PR TITLE
feat(downloader): add hardware-accelerated transcoding support

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -36,6 +36,7 @@ const youtubedl_api = require('./youtube-dl');
 const archive_api = require('./archive');
 const files_api = require('./files');
 const notifications_api = require('./notifications');
+const transcoding_api = require('./transcoding');
 
 var app = express();
 const CONFIG_ROOT_KEY = 'YtdlMaterial';
@@ -814,6 +815,8 @@ async function setConfigFromEnv() {
 
 async function loadConfig() {
     loadConfigValues();
+    // non-blocking hardware transcoding flight test
+    transcoding_api.initialize();
     initializeDocumentationAPI();
     await initializeRateLimiters();
 
@@ -1235,6 +1238,7 @@ app.get('/api/config', function(req, res) {
     res.send({
         config_file: config_file,
         ytdlp_impersonation_available: config_api.isYtDlpImpersonationDependencyEnvEnabled(),
+        transcoding_status: transcoding_api.getStatus(),
         success: !!config_file
     });
 });

--- a/backend/appdata/default.json
+++ b/backend/appdata/default.json
@@ -22,7 +22,8 @@
       "playlist_chunk_size": 100,
       "skip_join_only_videos": false,
       "use_ytdlp_impersonation": false,
-      "use_extractor_client_fallback": false
+      "use_extractor_client_fallback": false,
+      "transcoding": false
     },
     "Extra": {
       "title_top": "ytdl-material",

--- a/backend/config.js
+++ b/backend/config.js
@@ -296,7 +296,8 @@ const DEFAULT_CONFIG = {
         "download_rate_limit": "",
         "skip_join_only_videos": false,
         "use_ytdlp_impersonation": false,
-        "js_runtimes": ""
+        "js_runtimes": "",
+        "transcoding": false
       },
       "Extra": {
         "title_top": "ytdl-material",

--- a/backend/config.js
+++ b/backend/config.js
@@ -62,6 +62,13 @@ const RETIRED_CONFIG_ITEMS = [
             + ' causes the HTTP 403 download errors it was meant to prevent. yt-dlp now selects its own clients.'
             + ' If you still need to pin one, add it to your global custom args, for example:'
             + ' --extractor-args,,youtube:player_client=default'
+    },
+    {
+        path: 'YtdlMaterial.Advanced.allow_advanced_download',
+        disabled_warning: 'The \'allow advanced download\' setting has been removed. Advanced download options are'
+            + ' now always available from the Download button menu, so users who previously could not reach them'
+            + ' will see them. Access is still controlled by the \'advanced_download\' user permission, which can'
+            + ' be revoked per role under Settings if you want to keep it hidden.'
     }
 ];
 
@@ -81,7 +88,11 @@ function removeRetiredConfigItems() {
         const element_name = getElementNameInConfig(retired_item.path);
         if (!parent_object || !(element_name in parent_object)) continue;
 
-        if (parent_object[element_name] && retired_item.enabled_warning) logger.warn(retired_item.enabled_warning);
+        // Which stored value is worth warning about depends on the setting: removing an
+        // opt-in matters to whoever turned it on, removing an opt-out matters to whoever
+        // turned it off.
+        const stored_warning = parent_object[element_name] ? retired_item.enabled_warning : retired_item.disabled_warning;
+        if (stored_warning) logger.warn(stored_warning);
         delete parent_object[element_name];
         removed_any = true;
     }
@@ -387,7 +398,6 @@ const DEFAULT_CONFIG = {
         "use_default_downloading_agent": true,
         "custom_downloading_agent": "",
         "multi_user_mode": false,
-        "allow_advanced_download": false,
         "use_cookies": false,
         "jwt_expiration": 86400,
         "logger_level": "info"

--- a/backend/consts.js
+++ b/backend/consts.js
@@ -90,6 +90,10 @@ exports.CONFIG_ITEMS = {
         'key': 'ytdl_js_runtimes',
         'path': 'YtdlMaterial.Downloader.js_runtimes'
     },
+    'ytdl_transcoding': {
+        'key': 'ytdl_transcoding',
+        'path': 'YtdlMaterial.Downloader.transcoding'
+    },
 
     // Extra
     'ytdl_title_top': {

--- a/backend/consts.js
+++ b/backend/consts.js
@@ -377,10 +377,6 @@ exports.CONFIG_ITEMS = {
         'key': 'ytdl_multi_user_mode',
         'path': 'YtdlMaterial.Advanced.multi_user_mode'
     },
-    'ytdl_allow_advanced_download': {
-        'key': 'ytdl_allow_advanced_download',
-        'path': 'YtdlMaterial.Advanced.allow_advanced_download'
-    },
     'ytdl_use_cookies': {
         'key': 'ytdl_use_cookies',
         'path': 'YtdlMaterial.Advanced.use_cookies'

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -80,10 +80,54 @@ install_ytdlp_impersonation_dependencies() {
     export PYTHONPATH="${target_path}${PYTHONPATH:+:${PYTHONPATH}}"
 }
 
+install_transcoding_drivers() {
+    local transcoding_mode
+    transcoding_mode="$(resolve_runtime_env "" ytdl_transcoding YTDL_TRANSCODING | tr '[:upper:]' '[:lower:]')"
+
+    # Only VAAPI/QSV need userspace drivers inside the container.
+    # NVENC (libcuda) and AMF (libamfrt) runtimes come from the host via the container runtime.
+    case "$transcoding_mode" in
+        vaapi|qsv|intel|quicksync)
+            ;;
+        *)
+            return
+            ;;
+    esac
+
+    # Skip if a VA driver is already present (from a previous start or a derived image)
+    if ls /usr/lib/*/dri/*_drv_video.so >/dev/null 2>&1; then
+        echo "[entrypoint] VAAPI/QSV userspace drivers are already installed"
+        return
+    fi
+
+    if [ "$(id -u)" != "0" ]; then
+        echo "[entrypoint] WARNING: ytdl_transcoding is set to '$transcoding_mode' but the container is not running as root, so VAAPI/QSV drivers cannot be installed automatically. Hardware acceleration will likely fail its flight test."
+        return
+    fi
+
+    echo "[entrypoint] Installing VAAPI/QSV userspace drivers for ytdl_transcoding='$transcoding_mode'"
+    export DEBIAN_FRONTEND=noninteractive
+    if ! apt-get update; then
+        echo "[entrypoint] WARNING: apt-get update failed; hardware acceleration drivers were not installed."
+        return
+    fi
+    apt-get install -y --no-install-recommends mesa-va-drivers || echo "[entrypoint] WARNING: mesa-va-drivers could not be installed"
+    apt-get install -y --no-install-recommends intel-media-va-driver-non-free || \
+        apt-get install -y --no-install-recommends intel-media-va-driver || \
+        echo "[entrypoint] WARNING: intel-media-va-driver could not be installed"
+    case "$transcoding_mode" in
+        qsv|intel|quicksync)
+            apt-get install -y --no-install-recommends libmfx-gen1.2 || echo "[entrypoint] WARNING: libmfx-gen1.2 could not be installed"
+            ;;
+    esac
+    rm -rf /var/lib/apt/lists/*
+}
+
 runtime_uid="$(resolve_runtime_env 1000 ytdl_uid uid UID)"
 runtime_gid="$(resolve_runtime_env 1000 ytdl_gid gid GID)"
 
 install_ytdlp_impersonation_dependencies
+install_transcoding_drivers
 
 # Check if we're running as root
 if [ "$(id -u)" = "0" ]; then

--- a/backend/test/config.test.js
+++ b/backend/test/config.test.js
@@ -71,6 +71,18 @@ describe('Config', async function() {
         assert(!('use_extractor_client_fallback' in updated_config['YtdlMaterial']['Downloader']));
     });
 
+    it('Strips the retired allow advanced download setting on initialize', async function() {
+        const config_json = config_api.getConfigFile();
+        // stored as false, which is the value that changes behavior now that it is removed
+        config_json['YtdlMaterial']['Advanced']['allow_advanced_download'] = false;
+        config_api.setConfigFile(config_json);
+
+        config_api.initialize();
+
+        const updated_config = config_api.getConfigFile();
+        assert(!('allow_advanced_download' in updated_config['YtdlMaterial']['Advanced']));
+    });
+
     it('Leaves the config alone when no retired settings are stored', async function() {
         config_api.initialize();
         const before = JSON.stringify(config_api.getConfigFile());

--- a/backend/test/transcoding.test.js
+++ b/backend/test/transcoding.test.js
@@ -1,0 +1,58 @@
+/* eslint-disable no-undef */
+const { assert, config_api } = require('./test-shared');
+const transcoding_api = require('../transcoding');
+
+describe('Transcoding', function() {
+    it('normalizeTranscodingMode', function() {
+        assert(transcoding_api.normalizeTranscodingMode('nvenc') === 'nvenc');
+        assert(transcoding_api.normalizeTranscodingMode('NVENC') === 'nvenc');
+        assert(transcoding_api.normalizeTranscodingMode(' vaapi ') === 'vaapi');
+        assert(transcoding_api.normalizeTranscodingMode('QSV') === 'qsv');
+        assert(transcoding_api.normalizeTranscodingMode('amf') === 'amf');
+
+        // aliases
+        assert(transcoding_api.normalizeTranscodingMode('nvidia') === 'nvenc');
+        assert(transcoding_api.normalizeTranscodingMode('cuda') === 'nvenc');
+        assert(transcoding_api.normalizeTranscodingMode('amd') === 'amf');
+        assert(transcoding_api.normalizeTranscodingMode('intel') === 'qsv');
+        assert(transcoding_api.normalizeTranscodingMode('quicksync') === 'qsv');
+
+        // disabled values
+        assert(transcoding_api.normalizeTranscodingMode(false) === null);
+        assert(transcoding_api.normalizeTranscodingMode(undefined) === null);
+        assert(transcoding_api.normalizeTranscodingMode(null) === null);
+        assert(transcoding_api.normalizeTranscodingMode('') === null);
+        assert(transcoding_api.normalizeTranscodingMode('off') === null);
+        assert(transcoding_api.normalizeTranscodingMode('none') === null);
+        assert(transcoding_api.normalizeTranscodingMode('false') === null);
+
+        // unknown values fall back to software
+        assert(transcoding_api.normalizeTranscodingMode('garbage') === null);
+    });
+
+    it('getHardwareFfmpegSettings requires a passed flight test', async function() {
+        const original_value = config_api.getConfigItem('ytdl_transcoding');
+        try {
+            config_api.setConfigItem('ytdl_transcoding', 'nvenc');
+            // no flight test has succeeded, so hardware settings must not be handed out
+            assert(transcoding_api.getHardwareFfmpegSettings('.mp4') === null);
+        } finally {
+            config_api.setConfigItem('ytdl_transcoding', original_value === undefined ? false : original_value);
+        }
+    });
+
+    it('runFlightTest with transcoding disabled', async function() {
+        const original_value = config_api.getConfigItem('ytdl_transcoding');
+        try {
+            config_api.setConfigItem('ytdl_transcoding', false);
+            const result = await transcoding_api.runFlightTest();
+            assert(result === null);
+            const status = transcoding_api.getStatus();
+            assert(status.mode === null);
+            assert(status.checked === false);
+            assert(status.in_progress === false);
+        } finally {
+            config_api.setConfigItem('ytdl_transcoding', original_value === undefined ? false : original_value);
+        }
+    });
+});

--- a/backend/test/transcoding.test.js
+++ b/backend/test/transcoding.test.js
@@ -79,6 +79,59 @@ describe('Transcoding', function() {
         }
     });
 
+    it('every mode declares both encode and decode option sets', function() {
+        for (const [mode, mode_info] of Object.entries(transcoding_api.TRANSCODING_MODES)) {
+            assert(Array.isArray(mode_info.input_options), `${mode} is missing input_options`);
+            assert(Array.isArray(mode_info.decode_input_options), `${mode} is missing decode_input_options`);
+            assert(Array.isArray(mode_info.video_filters), `${mode} is missing video_filters`);
+            assert(typeof mode_info.video_encoder === 'string' && mode_info.video_encoder);
+
+            // decode acceleration must be requested through -hwaccel, and must not pin frames
+            // to GPU memory since the filter chains and encoders here expect system memory
+            if (mode_info.decode_input_options.length > 0) {
+                assert(mode_info.decode_input_options.includes('-hwaccel'), `${mode} decode options must use -hwaccel`);
+                assert(!mode_info.decode_input_options.includes('-hwaccel_output_format'),
+                    `${mode} must not pin decoded frames to GPU memory`);
+            }
+        }
+    });
+
+    it('hardware decode stays off until its own flight test passes', async function() {
+        const original_value = config_api.getConfigItem('ytdl_transcoding');
+        try {
+            config_api.setConfigItem('ytdl_transcoding', 'nvenc');
+            const status = transcoding_api.getStatus();
+            // encode may or may not be available in CI, but decode must never be assumed
+            assert(status.decode_available === false);
+
+            const settings = transcoding_api.getHardwareFfmpegSettings('.mp4');
+            if (settings) {
+                assert(settings.hardware_decode === false);
+                assert(!settings.input_options.includes('-hwaccel'));
+            }
+        } finally {
+            config_api.setConfigItem('ytdl_transcoding', original_value === undefined ? false : original_value);
+        }
+    });
+
+    it('runFlightTest reports decode availability without claiming encode failed', async function() {
+        const original_value = config_api.getConfigItem('ytdl_transcoding');
+        try {
+            config_api.setConfigItem('ytdl_transcoding', 'nvenc');
+            await transcoding_api.runFlightTest();
+            const status = transcoding_api.getStatus();
+
+            assert(status.checked === true);
+            assert(status.in_progress === false);
+            // decode can only be available if encode was, never the other way around
+            if (status.decode_available) assert(status.available === true);
+            // a decode failure must not be recorded as an encode failure
+            if (status.available === false) assert(status.decode_available === false);
+        } finally {
+            config_api.setConfigItem('ytdl_transcoding', original_value === undefined ? false : original_value);
+        }
+    });
+
     it('runFlightTest with transcoding disabled', async function() {
         const original_value = config_api.getConfigItem('ytdl_transcoding');
         try {

--- a/backend/test/transcoding.test.js
+++ b/backend/test/transcoding.test.js
@@ -41,6 +41,44 @@ describe('Transcoding', function() {
         }
     });
 
+    it('describeHardwareSkipReason explains why software encoding was chosen', async function() {
+        const original_value = config_api.getConfigItem('ytdl_transcoding');
+        try {
+            config_api.setConfigItem('ytdl_transcoding', false);
+            assert(transcoding_api.describeHardwareSkipReason('.mp4').includes('disabled'));
+
+            config_api.setConfigItem('ytdl_transcoding', 'nvenc');
+            // ineligible container is reported ahead of any flight test state
+            const ext_reason = transcoding_api.describeHardwareSkipReason('.webm');
+            assert(ext_reason.includes('.webm'));
+            assert(ext_reason.includes('hardware-eligible'));
+
+            // eligible container, but no flight test has passed in this process
+            const flight_reason = transcoding_api.describeHardwareSkipReason('.mp4');
+            assert(flight_reason !== null);
+            assert(flight_reason.includes('flight test'));
+        } finally {
+            config_api.setConfigItem('ytdl_transcoding', original_value === undefined ? false : original_value);
+        }
+    });
+
+    it('getHardwareFfmpegSettings and describeHardwareSkipReason always agree', async function() {
+        const original_value = config_api.getConfigItem('ytdl_transcoding');
+        try {
+            for (const mode of [false, 'nvenc', 'vaapi', 'garbage']) {
+                config_api.setConfigItem('ytdl_transcoding', mode);
+                for (const ext of ['.mp4', '.webm', '.mkv', '']) {
+                    const settings = transcoding_api.getHardwareFfmpegSettings(ext);
+                    const skip_reason = transcoding_api.describeHardwareSkipReason(ext);
+                    // exactly one of the two must be non-null, or the log would lie
+                    assert((settings === null) === (skip_reason !== null));
+                }
+            }
+        } finally {
+            config_api.setConfigItem('ytdl_transcoding', original_value === undefined ? false : original_value);
+        }
+    });
+
     it('runFlightTest with transcoding disabled', async function() {
         const original_value = config_api.getConfigItem('ytdl_transcoding');
         try {

--- a/backend/transcoding.js
+++ b/backend/transcoding.js
@@ -1,0 +1,197 @@
+const { spawn } = require('child_process');
+
+const config_api = require('./config');
+const logger = require('./logger');
+
+const FLIGHT_TEST_TIMEOUT_MS = 30000;
+const DEFAULT_VAAPI_DEVICE = '/dev/dri/renderD128';
+
+// Containers that can hold the h264 streams produced by the hardware encoders below
+const HW_ELIGIBLE_EXTS = ['.mp4', '.m4v', '.mkv', '.mov', '.ts'];
+
+const TRANSCODING_MODES = {
+    amf: {
+        label: 'AMD AMF',
+        video_encoder: 'h264_amf',
+        input_options: [],
+        video_filters: []
+    },
+    nvenc: {
+        label: 'Nvidia NVENC',
+        video_encoder: 'h264_nvenc',
+        input_options: [],
+        video_filters: []
+    },
+    qsv: {
+        label: 'Intel Quicksync (QSV)',
+        video_encoder: 'h264_qsv',
+        input_options: [],
+        video_filters: []
+    },
+    vaapi: {
+        label: 'VAAPI',
+        video_encoder: 'h264_vaapi',
+        input_options: ['-vaapi_device', DEFAULT_VAAPI_DEVICE],
+        video_filters: ['format=nv12', 'hwupload']
+    }
+};
+
+const MODE_ALIASES = {
+    amd: 'amf',
+    nvidia: 'nvenc',
+    cuda: 'nvenc',
+    intel: 'qsv',
+    quicksync: 'qsv'
+};
+
+const DISABLED_VALUES = ['off', 'none', 'false', 'no', '0', 'disabled'];
+
+const flight_test_status = {
+    mode: null,
+    label: null,
+    in_progress: false,
+    checked: false,
+    available: null,
+    error: null,
+    last_checked: null
+};
+
+let config_change_subscription_active = false;
+
+exports.TRANSCODING_MODES = TRANSCODING_MODES;
+
+exports.normalizeTranscodingMode = (raw_value) => {
+    if (!raw_value || typeof raw_value !== 'string') return null;
+    const normalized_value = raw_value.trim().toLowerCase();
+    if (normalized_value === '' || DISABLED_VALUES.includes(normalized_value)) return null;
+    const mode = TRANSCODING_MODES[normalized_value] ? normalized_value : MODE_ALIASES[normalized_value];
+    if (!mode) {
+        logger.warn(`Unknown transcoding mode '${raw_value}'. Falling back to software processing. Valid modes: ${Object.keys(TRANSCODING_MODES).join(', ')}`);
+        return null;
+    }
+    return mode;
+}
+
+exports.getTranscodingMode = () => {
+    return exports.normalizeTranscodingMode(config_api.getConfigItem('ytdl_transcoding'));
+}
+
+// Returns the ffmpeg settings needed to hardware encode a file with the given extension,
+// or null if the file should use software processing instead
+exports.getHardwareFfmpegSettings = (ext) => {
+    const mode = exports.getTranscodingMode();
+    if (!mode) return null;
+    if (!HW_ELIGIBLE_EXTS.includes((ext || '').toLowerCase())) return null;
+    // hardware encoding is only used once the flight test confirmed it works
+    if (!flight_test_status.checked || !flight_test_status.available || flight_test_status.mode !== mode) return null;
+    const mode_info = TRANSCODING_MODES[mode];
+    return {
+        mode: mode,
+        input_options: [...mode_info.input_options],
+        video_filters: [...mode_info.video_filters],
+        video_encoder: mode_info.video_encoder
+    };
+}
+
+exports.getStatus = () => {
+    return {...flight_test_status};
+}
+
+// Encodes a tiny generated clip with the configured hardware encoder to check whether
+// the GPU and its drivers are actually usable inside this environment
+exports.runFlightTest = async () => {
+    const mode = exports.getTranscodingMode();
+    flight_test_status.mode = mode;
+    flight_test_status.label = mode ? TRANSCODING_MODES[mode].label : null;
+    flight_test_status.checked = false;
+    flight_test_status.available = null;
+    flight_test_status.error = null;
+    if (!mode) {
+        flight_test_status.in_progress = false;
+        return null;
+    }
+
+    const mode_info = TRANSCODING_MODES[mode];
+    const args = [
+        '-hide_banner', '-v', 'error',
+        ...mode_info.input_options,
+        '-f', 'lavfi', '-i', 'color=black:size=320x240:rate=30:duration=0.25'
+    ];
+    if (mode_info.video_filters.length > 0) args.push('-vf', mode_info.video_filters.join(','));
+    args.push('-c:v', mode_info.video_encoder, '-frames:v', '4', '-f', 'null', '-');
+
+    flight_test_status.in_progress = true;
+    logger.info(`Running hardware transcoding flight test for ${mode_info.label}...`);
+
+    const result = await runFfmpegFlightTest(args);
+
+    flight_test_status.in_progress = false;
+    flight_test_status.checked = true;
+    flight_test_status.available = result.success;
+    flight_test_status.error = result.success ? null : result.error;
+    flight_test_status.last_checked = Date.now();
+
+    if (result.success) {
+        logger.info(`Hardware transcoding flight test succeeded for ${mode_info.label}. Hardware acceleration enabled.`);
+    } else {
+        logger.warn(`Hardware transcoding flight test failed for ${mode_info.label}. Falling back to software processing. Error: ${result.error}`);
+    }
+
+    return flight_test_status.available;
+}
+
+// ffmpeg emits a wall of stderr on failure; the first line names the actual problem
+// (e.g. 'Cannot load libcuda.so.1' or 'No VA display found for device /dev/dri/renderD128')
+function getPrimaryErrorLine(stderr) {
+    const first_line = (stderr || '').trim().split('\n')[0] || '';
+    return first_line.substring(0, 300);
+}
+
+function runFfmpegFlightTest(args) {
+    return new Promise(resolve => {
+        const ffmpeg_binary = process.env.FFMPEG_PATH || 'ffmpeg';
+        let stderr = '';
+        let finished = false;
+
+        const finish = (success, error) => {
+            if (finished) return;
+            finished = true;
+            resolve({success: success, error: error});
+        };
+
+        let ffmpeg_process = null;
+        try {
+            ffmpeg_process = spawn(ffmpeg_binary, args);
+        } catch (err) {
+            finish(false, err.message);
+            return;
+        }
+
+        const timeout = setTimeout(() => {
+            ffmpeg_process.kill('SIGKILL');
+            finish(false, `Flight test timed out after ${FLIGHT_TEST_TIMEOUT_MS / 1000} seconds`);
+        }, FLIGHT_TEST_TIMEOUT_MS);
+
+        ffmpeg_process.stderr.on('data', data => stderr += data.toString());
+        ffmpeg_process.on('error', err => {
+            clearTimeout(timeout);
+            finish(false, err.message);
+        });
+        ffmpeg_process.on('close', code => {
+            clearTimeout(timeout);
+            if (code === 0) finish(true, null);
+            else finish(false, getPrimaryErrorLine(stderr) || `ffmpeg exited with code ${code}`);
+        });
+    });
+}
+
+// Kicks off the boot flight test without blocking startup, and re-runs it whenever
+// the transcoding setting changes
+exports.initialize = () => {
+    exports.runFlightTest();
+    if (config_change_subscription_active) return;
+    config_change_subscription_active = true;
+    config_api.config_updated.subscribe(change => {
+        if (change && change.key === 'ytdl_transcoding') exports.runFlightTest();
+    });
+}

--- a/backend/transcoding.js
+++ b/backend/transcoding.js
@@ -76,17 +76,37 @@ exports.getTranscodingMode = () => {
     return exports.normalizeTranscodingMode(config_api.getConfigItem('ytdl_transcoding'));
 }
 
+// Explains why hardware encoding will not be used for the given extension, or null when it
+// will be. Falling back to software is silent by nature, so callers use this to say why.
+exports.describeHardwareSkipReason = (ext) => {
+    const mode = exports.getTranscodingMode();
+    if (!mode) return 'hardware transcoding is disabled';
+    if (!HW_ELIGIBLE_EXTS.includes((ext || '').toLowerCase())) {
+        return `'${ext}' is not a hardware-eligible container (${HW_ELIGIBLE_EXTS.join(', ')})`;
+    }
+    if (!flight_test_status.checked) return 'the hardware flight test has not finished yet';
+    if (!flight_test_status.available) {
+        return `the hardware flight test failed${flight_test_status.error ? ` (${flight_test_status.error})` : ''}`;
+    }
+    if (flight_test_status.mode !== mode) {
+        return `the flight test ran for '${flight_test_status.mode}' but the configured mode is now '${mode}'`;
+    }
+    return null;
+}
+
 // Returns the ffmpeg settings needed to hardware encode a file with the given extension,
 // or null if the file should use software processing instead
 exports.getHardwareFfmpegSettings = (ext) => {
+    const skip_reason = exports.describeHardwareSkipReason(ext);
+    if (skip_reason) {
+        logger.debug(`Using software encoding because ${skip_reason}.`);
+        return null;
+    }
     const mode = exports.getTranscodingMode();
-    if (!mode) return null;
-    if (!HW_ELIGIBLE_EXTS.includes((ext || '').toLowerCase())) return null;
-    // hardware encoding is only used once the flight test confirmed it works
-    if (!flight_test_status.checked || !flight_test_status.available || flight_test_status.mode !== mode) return null;
     const mode_info = TRANSCODING_MODES[mode];
     return {
         mode: mode,
+        label: mode_info.label,
         input_options: [...mode_info.input_options],
         video_filters: [...mode_info.video_filters],
         video_encoder: mode_info.video_encoder

--- a/backend/transcoding.js
+++ b/backend/transcoding.js
@@ -1,4 +1,7 @@
 const { spawn } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 
 const config_api = require('./config');
 const logger = require('./logger');
@@ -9,29 +12,44 @@ const DEFAULT_VAAPI_DEVICE = '/dev/dri/renderD128';
 // Containers that can hold the h264 streams produced by the hardware encoders below
 const HW_ELIGIBLE_EXTS = ['.mp4', '.m4v', '.mkv', '.mov', '.ts'];
 
+// Each mode has two independent halves. `input_options` and `video_encoder` accelerate the
+// encode and are what the base flight test proves. `decode_input_options` additionally moves
+// decoding onto the GPU, which is the expensive half for high resolution or AV1 sources.
+//
+// Decode options deliberately omit -hwaccel_output_format: without it the decoded frames are
+// returned to system memory, so the existing filters (VAAPI's hwupload in particular) and the
+// encoder still receive frames in the layout they expect. Keeping frames on the GPU would be
+// faster still, but it requires filter chains matched to each mode and breaks the moment a
+// source needs a filter that has no hardware equivalent.
+//
+// AMF has no decode counterpart on the platforms this image targets, so it stays encode-only.
 const TRANSCODING_MODES = {
     amf: {
         label: 'AMD AMF',
         video_encoder: 'h264_amf',
         input_options: [],
+        decode_input_options: [],
         video_filters: []
     },
     nvenc: {
         label: 'Nvidia NVENC',
         video_encoder: 'h264_nvenc',
         input_options: [],
+        decode_input_options: ['-hwaccel', 'cuda'],
         video_filters: []
     },
     qsv: {
         label: 'Intel Quicksync (QSV)',
         video_encoder: 'h264_qsv',
         input_options: [],
+        decode_input_options: ['-hwaccel', 'qsv'],
         video_filters: []
     },
     vaapi: {
         label: 'VAAPI',
         video_encoder: 'h264_vaapi',
         input_options: ['-vaapi_device', DEFAULT_VAAPI_DEVICE],
+        decode_input_options: ['-hwaccel', 'vaapi'],
         video_filters: ['format=nv12', 'hwupload']
     }
 };
@@ -52,6 +70,10 @@ const flight_test_status = {
     in_progress: false,
     checked: false,
     available: null,
+    // hardware decode is tested separately: a GPU that can encode cannot be assumed to
+    // decode, so this stays false unless its own flight test passed
+    decode_available: false,
+    decode_error: null,
     error: null,
     last_checked: null
 };
@@ -94,9 +116,11 @@ exports.describeHardwareSkipReason = (ext) => {
     return null;
 }
 
-// Returns the ffmpeg settings needed to hardware encode a file with the given extension,
-// or null if the file should use software processing instead
-exports.getHardwareFfmpegSettings = (ext) => {
+// Returns the ffmpeg settings needed to hardware process a file with the given extension, or
+// null if the file should use software processing instead. Hardware decoding is included only
+// when its own flight test passed; pass allow_hardware_decode: false to get the encode-only
+// settings, which is what callers retry with when a decode-accelerated run fails.
+exports.getHardwareFfmpegSettings = (ext, {allow_hardware_decode = true} = {}) => {
     const skip_reason = exports.describeHardwareSkipReason(ext);
     if (skip_reason) {
         logger.debug(`Using software encoding because ${skip_reason}.`);
@@ -104,12 +128,17 @@ exports.getHardwareFfmpegSettings = (ext) => {
     }
     const mode = exports.getTranscodingMode();
     const mode_info = TRANSCODING_MODES[mode];
+    const use_hardware_decode = allow_hardware_decode
+        && flight_test_status.decode_available
+        && mode_info.decode_input_options.length > 0;
+
     return {
         mode: mode,
         label: mode_info.label,
-        input_options: [...mode_info.input_options],
+        input_options: [...mode_info.input_options, ...(use_hardware_decode ? mode_info.decode_input_options : [])],
         video_filters: [...mode_info.video_filters],
-        video_encoder: mode_info.video_encoder
+        video_encoder: mode_info.video_encoder,
+        hardware_decode: use_hardware_decode
     };
 }
 
@@ -126,6 +155,8 @@ exports.runFlightTest = async () => {
     flight_test_status.checked = false;
     flight_test_status.available = null;
     flight_test_status.error = null;
+    flight_test_status.decode_available = false;
+    flight_test_status.decode_error = null;
     if (!mode) {
         flight_test_status.in_progress = false;
         return null;
@@ -155,9 +186,63 @@ exports.runFlightTest = async () => {
         logger.info(`Hardware transcoding flight test succeeded for ${mode_info.label}. Hardware acceleration enabled.`);
     } else {
         logger.warn(`Hardware transcoding flight test failed for ${mode_info.label}. Falling back to software processing. Error: ${result.error}`);
+        return flight_test_status.available;
+    }
+
+    // Encoding works. Decoding is a separate capability, so test it separately rather than
+    // assuming it: a GPU that encodes h264 may still not decode every source codec.
+    if (mode_info.decode_input_options.length === 0) {
+        logger.info(`${mode_info.label} has no hardware decoding support. Decoding will use the CPU.`);
+        return flight_test_status.available;
+    }
+
+    const decode_result = await runDecodeFlightTest(mode_info);
+    flight_test_status.decode_available = decode_result.success;
+    flight_test_status.decode_error = decode_result.success ? null : decode_result.error;
+
+    if (decode_result.success) {
+        logger.info(`Hardware decoding flight test succeeded for ${mode_info.label}. Decoding will use the GPU.`);
+    } else {
+        logger.info(`Hardware decoding is unavailable for ${mode_info.label}, so decoding will use the CPU. Encoding is still hardware accelerated. Reason: ${decode_result.error}`);
     }
 
     return flight_test_status.available;
+}
+
+// The base flight test decodes a generated pattern, which exercises no real codec path. To
+// know whether hardware decoding works we have to hand ffmpeg an actually encoded file, so
+// encode one in software first and then decode it back through the hardware pipeline.
+async function runDecodeFlightTest(mode_info) {
+    const sample_path = path.join(os.tmpdir(), `ytdl-material-hwdecode-probe-${process.pid}.mp4`);
+
+    try {
+        const encode_sample = await runFfmpegFlightTest([
+            '-hide_banner', '-v', 'error', '-y',
+            '-f', 'lavfi', '-i', 'color=black:size=320x240:rate=30:duration=0.25',
+            '-c:v', 'libx264', '-pix_fmt', 'yuv420p', '-frames:v', '4',
+            sample_path
+        ]);
+        if (!encode_sample.success) {
+            return {success: false, error: `could not build a probe file (${encode_sample.error})`};
+        }
+
+        const args = [
+            '-hide_banner', '-v', 'error',
+            ...mode_info.input_options,
+            ...mode_info.decode_input_options,
+            '-i', sample_path
+        ];
+        if (mode_info.video_filters.length > 0) args.push('-vf', mode_info.video_filters.join(','));
+        args.push('-c:v', mode_info.video_encoder, '-frames:v', '4', '-f', 'null', '-');
+
+        return await runFfmpegFlightTest(args);
+    } finally {
+        try {
+            await fs.promises.unlink(sample_path);
+        } catch (e) {
+            // probe file may never have been created; nothing to clean up
+        }
+    }
 }
 
 // ffmpeg emits a wall of stderr on failure; the first line names the actual problem

--- a/backend/utils.js
+++ b/backend/utils.js
@@ -8,6 +8,7 @@ const winston = require('winston');
 
 const config_api = require('./config');
 const logger = require('./logger');
+const transcoding_api = require('./transcoding');
 const CONSTS = require('./consts');
 
 const is_windows = process.platform === 'win32';
@@ -461,6 +462,16 @@ exports.createEdgeNGrams = (str) => {
 // ffmpeg helper functions
 
 exports.cropFile = async (file_path, start, end, ext) => {
+    const hardware_settings = transcoding_api.getHardwareFfmpegSettings(ext);
+    const crop_success = await cropFileAttempt(file_path, start, end, ext, hardware_settings);
+    if (!crop_success && hardware_settings) {
+        logger.warn(`Hardware-accelerated crop failed for '${file_path}'. Retrying with software processing.`);
+        return await cropFileAttempt(file_path, start, end, ext, null);
+    }
+    return crop_success;
+}
+
+function cropFileAttempt(file_path, start, end, ext, hardware_settings) {
     return new Promise(resolve => {
         const temp_file_path = `${file_path}.cropped${ext}`;
         let base_ffmpeg_call = ffmpeg(file_path);
@@ -469,6 +480,15 @@ exports.cropFile = async (file_path, start, end, ext) => {
         }
         if (end) {
             base_ffmpeg_call = base_ffmpeg_call.duration(end - start);
+        }
+        if (hardware_settings) {
+            if (hardware_settings.input_options.length > 0) {
+                base_ffmpeg_call = base_ffmpeg_call.inputOptions(hardware_settings.input_options);
+            }
+            if (hardware_settings.video_filters.length > 0) {
+                base_ffmpeg_call = base_ffmpeg_call.videoFilters(hardware_settings.video_filters);
+            }
+            base_ffmpeg_call = base_ffmpeg_call.videoCodec(hardware_settings.video_encoder);
         }
         base_ffmpeg_call
             .on('end', () => {
@@ -480,6 +500,11 @@ exports.cropFile = async (file_path, start, end, ext) => {
             .on('error', (err) => {
                 logger.error(`Failed to crop ${file_path}.`);
                 logger.error(err);
+                try {
+                    fs.removeSync(temp_file_path);
+                } catch (e) {
+                    // Non-fatal.
+                }
                 resolve(false);
             }).save(temp_file_path);
     });

--- a/backend/utils.js
+++ b/backend/utils.js
@@ -463,11 +463,24 @@ exports.createEdgeNGrams = (str) => {
 
 exports.cropFile = async (file_path, start, end, ext) => {
     const hardware_settings = transcoding_api.getHardwareFfmpegSettings(ext);
-    const crop_success = await cropFileAttempt(file_path, start, end, ext, hardware_settings);
+    const start_time = Date.now();
+
+    // Cropping re-encodes and can run for minutes with no other output, so announce it up
+    // front. Without this a long crop is indistinguishable from a hung download.
+    logger.info(`Cropping '${file_path}' using ${hardware_settings
+        ? `${hardware_settings.label} hardware encoding (${hardware_settings.video_encoder})`
+        : 'software encoding'}. This can take a while for large files.`);
+
+    let crop_success = await cropFileAttempt(file_path, start, end, ext, hardware_settings);
     if (!crop_success && hardware_settings) {
         logger.warn(`Hardware-accelerated crop failed for '${file_path}'. Retrying with software processing.`);
-        return await cropFileAttempt(file_path, start, end, ext, null);
+        crop_success = await cropFileAttempt(file_path, start, end, ext, null);
     }
+
+    const elapsed_seconds = ((Date.now() - start_time) / 1000).toFixed(1);
+    if (crop_success) logger.info(`Cropping for '${file_path}' complete in ${elapsed_seconds}s.`);
+    else logger.error(`Cropping for '${file_path}' failed after ${elapsed_seconds}s.`);
+
     return crop_success;
 }
 
@@ -491,8 +504,12 @@ function cropFileAttempt(file_path, start, end, ext, hardware_settings) {
             base_ffmpeg_call = base_ffmpeg_call.videoCodec(hardware_settings.video_encoder);
         }
         base_ffmpeg_call
+            // the resolved command line is the only definitive record of which encoder ran
+            .on('start', (command_line) => {
+                logger.debug(`ffmpeg crop command: ${command_line}`);
+            })
             .on('end', () => {
-                logger.verbose(`Cropping for '${file_path}' complete.`);
+                logger.verbose(`Cropping attempt for '${file_path}' finished.`);
                 fs.unlinkSync(file_path);
                 fs.moveSync(temp_file_path, file_path);
                 resolve(true);

--- a/backend/utils.js
+++ b/backend/utils.js
@@ -461,20 +461,42 @@ exports.createEdgeNGrams = (str) => {
 
 // ffmpeg helper functions
 
+function describeCropProcessing(hardware_settings) {
+    if (!hardware_settings) return 'software encoding';
+    const decode_label = hardware_settings.hardware_decode ? 'hardware decoding' : 'software decoding';
+    return `${hardware_settings.label} (${hardware_settings.video_encoder}) with ${decode_label}`;
+}
+
 exports.cropFile = async (file_path, start, end, ext) => {
-    const hardware_settings = transcoding_api.getHardwareFfmpegSettings(ext);
     const start_time = Date.now();
+
+    // Degrade one step at a time rather than straight to software. A GPU that cannot decode
+    // a particular source can usually still encode it, so a failed hardware decode should
+    // cost the hardware encode too only if that fails as well.
+    const attempts = [];
+    const full_settings = transcoding_api.getHardwareFfmpegSettings(ext);
+    if (full_settings) {
+        attempts.push(full_settings);
+        if (full_settings.hardware_decode) {
+            attempts.push(transcoding_api.getHardwareFfmpegSettings(ext, {allow_hardware_decode: false}));
+        }
+    }
+    attempts.push(null);
 
     // Cropping re-encodes and can run for minutes with no other output, so announce it up
     // front. Without this a long crop is indistinguishable from a hung download.
-    logger.info(`Cropping '${file_path}' using ${hardware_settings
-        ? `${hardware_settings.label} hardware encoding (${hardware_settings.video_encoder})`
-        : 'software encoding'}. This can take a while for large files.`);
+    logger.info(`Cropping '${file_path}' using ${describeCropProcessing(attempts[0])}. This can take a while for large files.`);
 
-    let crop_success = await cropFileAttempt(file_path, start, end, ext, hardware_settings);
-    if (!crop_success && hardware_settings) {
-        logger.warn(`Hardware-accelerated crop failed for '${file_path}'. Retrying with software processing.`);
-        crop_success = await cropFileAttempt(file_path, start, end, ext, null);
+    let crop_success = false;
+    for (let i = 0; i < attempts.length; i++) {
+        crop_success = await cropFileAttempt(file_path, start, end, ext, attempts[i]);
+        if (crop_success) {
+            if (i > 0) logger.info(`Cropping for '${file_path}' succeeded using ${describeCropProcessing(attempts[i])}.`);
+            break;
+        }
+        if (i + 1 < attempts.length) {
+            logger.warn(`Crop using ${describeCropProcessing(attempts[i])} failed for '${file_path}'. Retrying with ${describeCropProcessing(attempts[i + 1])}.`);
+        }
     }
 
     const elapsed_seconds = ((Date.now() - start_time) / 1000).toFixed(1);

--- a/docker-compose-extended.yml
+++ b/docker-compose-extended.yml
@@ -49,6 +49,11 @@ services:
       # Caps the number of automatic playlist chunks that may be created.
       # ytdl_max_playlist_chunks: '20'
 
+      # Hardware acceleration for video processing (optional). One of amf, nvenc, qsv, vaapi.
+      # See docker-environment.md for the required GPU passthrough (devices/group_add or the
+      # NVIDIA container toolkit) that must accompany this setting.
+      # ytdl_transcoding: 'vaapi'
+
       # File creation mask before startup.
       # Common values: 022 for standard shared-read permissions, 002 for group-writable.
       # ytdl_umask: '022'

--- a/docker-environment.md
+++ b/docker-environment.md
@@ -105,6 +105,54 @@ When using env-managed Docker setups with `write_ytdl_config='true'`, you can cl
 Anything you set there takes precedence and is never overwritten. See the [wiki](https://github.com/voc0der/ytdl-material/wiki#environment-specific-guideshelp) for how to pick a client.
 * `ytdl_js_runtimes`: pin the JavaScript runtime yt-dlp uses to solve YouTube's JS challenge, passed through as `--js-runtimes` (for example `deno` or `node`). Leave empty to let yt-dlp auto-detect an installed runtime, which is the default and is recommended. Pinning a runtime that is not installed causes downloads to fail with `unable to download video data: HTTP Error 403: Forbidden`; run `yt-dlp -v` and check the `JS Challenge Providers` line to see which runtimes are actually available (default empty)
 
+## Hardware Acceleration (Transcoding)
+
+* `ytdl_transcoding`: hardware acceleration mode used for ffmpeg video processing such as cropping. One of `'false'` (default, software only), `'amf'` (AMD AMF), `'nvenc'` (Nvidia NVENC), `'qsv'` (Intel Quicksync), or `'vaapi'` (Video Acceleration API). Also configurable in Settings under the Downloader tab.
+
+On startup the backend runs a non-blocking flight test that encodes a tiny generated clip with the configured hardware encoder. If the test fails (missing GPU passthrough, missing drivers, unsupported hardware), video processing automatically falls back to software encoding and a warning with the ffmpeg error is shown in the Settings Downloader tab.
+
+Notes:
+
+* Hardware acceleration requires the amd64 or arm64 image. The armhf/armel images ship a software-only ffmpeg build.
+* For `'vaapi'` and `'qsv'`, the entrypoint installs the userspace GPU drivers on first start (requires the container to start as root, the default, and network access). NVENC and AMF runtimes are provided by the host instead.
+* Hardware encoding is applied to video files in h264-compatible containers (mp4, mkv, mov, ts). Other formats keep using software encoding.
+
+### VAAPI / QSV (Intel and AMD GPUs)
+
+Pass the render device(s) into the container and add the `render`/`video` group IDs (find yours with `cat /etc/group | grep -E 'render|video' | cut -d: -f3`):
+
+```yaml
+environment:
+  ytdl_transcoding: 'vaapi' # or 'qsv' on Intel
+group_add:
+  - 44
+  - 106
+devices:
+  - /dev/dri/renderD128:/dev/dri/renderD128
+  - /dev/dri/card0:/dev/dri/card0
+```
+
+### NVENC (Nvidia GPUs)
+
+Requires the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) on the host:
+
+```yaml
+environment:
+  ytdl_transcoding: 'nvenc'
+  NVIDIA_DRIVER_CAPABILITIES: 'compute,video,utility'
+deploy:
+  resources:
+    reservations:
+      devices:
+        - driver: nvidia
+          count: all
+          capabilities: [gpu]
+```
+
+### AMF (AMD GPUs)
+
+AMF on Linux requires the AMD proprietary Vulkan/AMF runtime (`libamfrt64.so.1` from amdgpu-pro) to be available inside the container in addition to `/dev/dri` passthrough. Most AMD users on Linux should prefer `'vaapi'` instead.
+
 ## OIDC
 
 Only use this section if you want users to sign in through an external identity provider such as Authelia, Authentik, Keycloak, or another SSO provider. If you are happy with ytdl-material's built-in login, you do not need any OIDC settings.

--- a/docker-environment.md
+++ b/docker-environment.md
@@ -109,7 +109,22 @@ Anything you set there takes precedence and is never overwritten. See the [wiki]
 
 * `ytdl_transcoding`: hardware acceleration mode used for ffmpeg video processing such as cropping. One of `'false'` (default, software only), `'amf'` (AMD AMF), `'nvenc'` (Nvidia NVENC), `'qsv'` (Intel Quicksync), or `'vaapi'` (Video Acceleration API). Also configurable in Settings under the Downloader tab.
 
-On startup the backend runs a non-blocking flight test that encodes a tiny generated clip with the configured hardware encoder. If the test fails (missing GPU passthrough, missing drivers, unsupported hardware), video processing automatically falls back to software encoding and a warning with the ffmpeg error is shown in the Settings Downloader tab.
+On startup the backend runs two non-blocking flight tests:
+
+1. **Encode** — encodes a tiny generated clip with the configured hardware encoder. If this fails (missing GPU passthrough, missing drivers, unsupported hardware), video processing falls back entirely to software and a warning with the ffmpeg error is shown in the Settings Downloader tab.
+2. **Decode** — encodes a small real clip in software, then decodes it back through the hardware pipeline (`-hwaccel`). Decoding is a separate GPU capability from encoding, so it is never assumed. If this fails, encoding still uses the GPU and only decoding falls back to the CPU.
+
+Decoding is usually the expensive half for 4K or AV1 sources, so enabling it is where most of the speedup comes from. AMF is encode-only and does not attempt hardware decoding.
+
+At runtime, a crop degrades one step at a time: hardware decode + hardware encode, then software decode + hardware encode, then fully software. A GPU too old to decode a given codec is therefore no slower than before.
+
+To confirm what is actually being used:
+
+```bash
+docker logs <container> 2>&1 | grep -E 'flight test|Cropping|software encoding'
+```
+
+Each crop logs the encoder and whether decoding is on the GPU. At `debug` log level the resolved ffmpeg command line is logged too, which is the definitive record of which encoder ran.
 
 Notes:
 

--- a/docker-utils/ffmpeg-fetch.sh
+++ b/docker-utils/ffmpeg-fetch.sh
@@ -5,17 +5,25 @@ set -eu
 # and also optimizing some code with this commit.
 # xoxo :D
 
+# amd64/arm64 use BtbN's GPL builds because they include the hardware encoders
+# (h264_amf, h264_nvenc, h264_qsv, h264_vaapi) needed for the ytdl_transcoding setting.
+# armhf/armel fall back to John van Sickle's static builds, which are software-only.
 case $(uname -m) in
   x86_64)
-    ARCH=amd64;;
+    ARCH=amd64
+    FFMPEG_URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n7.1-latest-linux64-gpl-7.1.tar.xz";;
   aarch64)
-    ARCH=arm64;;
+    ARCH=arm64
+    FFMPEG_URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n7.1-latest-linuxarm64-gpl-7.1.tar.xz";;
   armhf)
-    ARCH=armhf;;
+    ARCH=armhf
+    FFMPEG_URL="https://johnvansickle.com/ffmpeg/old-releases/ffmpeg-5.1.1-${ARCH}-static.tar.xz";;
   armv7)
-    ARCH=armel;;
+    ARCH=armel
+    FFMPEG_URL="https://johnvansickle.com/ffmpeg/old-releases/ffmpeg-5.1.1-${ARCH}-static.tar.xz";;
   armv7l)
-    ARCH=armel;;
+    ARCH=armel
+    FFMPEG_URL="https://johnvansickle.com/ffmpeg/old-releases/ffmpeg-5.1.1-${ARCH}-static.tar.xz";;
   *)
     echo "Unsupported architecture: $(uname -m)"
     exit 1
@@ -24,15 +32,15 @@ esac
 echo "(INFO) Architecture detected: $ARCH"
 echo "(1/5) READY - Acquire temp dependencies in ffmpeg obtain layer"
 apt-get update && apt-get -y install --no-install-recommends ca-certificates curl xz-utils
-echo "(2/5) DOWNLOAD - Acquire latest ffmpeg and ffprobe from John van Sickle's master-sourced builds in ffmpeg obtain layer"
+echo "(2/5) DOWNLOAD - Acquire ffmpeg and ffprobe from ${FFMPEG_URL} in ffmpeg obtain layer"
 curl -fL -o ffmpeg.txz \
     --connect-timeout 5 \
-    --max-time 120 \
+    --max-time 300 \
     --retry 5 \
     --retry-delay 0 \
-    --retry-max-time 40 \
+    --retry-max-time 120 \
     --retry-all-errors \
-    "https://johnvansickle.com/ffmpeg/old-releases/ffmpeg-5.1.1-${ARCH}-static.tar.xz"
+    "$FFMPEG_URL"
 mkdir /tmp/ffmpeg
 tar xf ffmpeg.txz -C /tmp/ffmpeg
 echo "(3/5) CLEANUP - Remove temp dependencies from ffmpeg obtain layer"

--- a/src/app/main/main.component.css
+++ b/src/app/main/main.component.css
@@ -175,6 +175,30 @@ mat-form-field.mat-mdc-form-field {
     border-radius: 0px 0px 16px 16px;
 }
 
+.advanced-panel {
+    padding-top: 8px;
+}
+
+.advanced-panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 4px;
+}
+
+.advanced-panel-title {
+    font-size: 15px;
+    opacity: 0.75;
+}
+
+.advanced-panel-close {
+    opacity: 0.55;
+}
+
+.advanced-panel-close:hover {
+    opacity: 1;
+}
+
 .url-input {
     padding-right: 25px;
     overflow-y: hidden;

--- a/src/app/main/main.component.html
+++ b/src/app/main/main.component.html
@@ -1,6 +1,6 @@
 <br/>
 <div class="big demo-basic">
-  <mat-card id="card" style="margin-right: 20px; margin-left: 20px;" [ngClass]="(allowAdvancedDownload) ? 'no-border-radius-bottom' : 'border-radius-both'">
+  <mat-card id="card" style="margin-right: 20px; margin-left: 20px;" [ngClass]="isAdvancedModeActive() ? 'no-border-radius-bottom' : 'border-radius-both'">
     <mat-card-content style="padding: 0px 8px 0px 8px;">
       <div style="position: relative; margin-right: 15px; margin-top: 20px;">
         <form class="example-form">
@@ -132,6 +132,12 @@
                 <span i18n="Main download button option for autoplay">Autoplay</span>
               </button>
             }
+            @if (allowAdvancedDownload) {
+              <button mat-menu-item (click)="toggleAdvancedMode()" [disabled]="!!current_download">
+                <mat-icon>{{advancedMode ? 'check_box' : 'check_box_outline_blank'}}</mat-icon>
+                <span i18n="Main download button option for advanced mode">Advanced</span>
+              </button>
+            }
             @if (hasAdditionalDownloadMenuActions()) {
               <mat-divider></mat-divider>
             }
@@ -162,17 +168,19 @@
     </mat-card-actions>
   </mat-card>
 </div>
-@if (allowAdvancedDownload) {
+@if (isAdvancedModeActive()) {
   <div class="big demo-basic">
     <form style="margin-left: 20px; margin-right: 20px;">
-      <mat-expansion-panel class="big no-border-radius-top">
-        <mat-expansion-panel-header>
-          <mat-panel-title>
-            <ng-container i18n="Advanced download mode panel">
-                        Advanced
-                    </ng-container>
-          </mat-panel-title>
-        </mat-expansion-panel-header>
+      <mat-card class="big no-border-radius-top advanced-panel">
+        <div class="advanced-panel-header">
+          <span class="advanced-panel-title" i18n="Advanced download mode panel">Advanced</span>
+          <button type="button" class="advanced-panel-close" mat-icon-button (click)="closeAdvancedMode()"
+            matTooltip="Close advanced mode and clear these options"
+            i18n-matTooltip="Close advanced mode tooltip"
+            aria-label="Close advanced mode" i18n-aria-label="Close advanced mode label">
+            <mat-icon>close</mat-icon>
+          </button>
+        </div>
         @if (this.simulatedOutput) {
           <p>
             <ng-container i18n="Simulated command label">
@@ -267,7 +275,7 @@
               </div>
             </div>
           </div>
-        </mat-expansion-panel>
+        </mat-card>
       </form>
     </div>
   }

--- a/src/app/main/main.component.spec.ts
+++ b/src/app/main/main.component.spec.ts
@@ -649,4 +649,203 @@ describe('MainComponent', () => {
 
     expect(open_dialog_spy).toHaveBeenCalled();
   });
+
+  describe('advanced download mode', () => {
+    const ADVANCED_STORAGE_KEYS = [
+      'advancedMode', 'customArgsEnabled', 'replaceArgs', 'customOutputEnabled',
+      'youtubeAuthEnabled', 'customArgs', 'customOutput', 'youtubeUsername'
+    ];
+
+    // downloadFile(url, type, quality, qualityConfig, customArgs, additionalArgs,
+    //              customOutput, username, password, cropFileSettings, ...)
+    const CUSTOM_ARGS_INDEX = 4;
+    const ADDITIONAL_ARGS_INDEX = 5;
+    const CUSTOM_OUTPUT_INDEX = 6;
+    const USERNAME_INDEX = 7;
+    const PASSWORD_INDEX = 8;
+    const CROP_SETTINGS_INDEX = 9;
+
+    beforeEach(() => {
+      for (const key of ADVANCED_STORAGE_KEYS) localStorage.removeItem(key);
+      component.allowAdvancedDownload = true;
+      component.url = 'https://www.youtube.com/watch?v=advancedmode';
+    });
+
+    afterEach(() => {
+      for (const key of ADVANCED_STORAGE_KEYS) localStorage.removeItem(key);
+    });
+
+    function fillAdvancedOptions(): void {
+      component.customArgsEnabled = true;
+      component.customArgs = '--write-thumbnail';
+      component.customOutputEnabled = true;
+      component.customOutput = 'custom/path';
+      component.youtubeAuthEnabled = true;
+      component.youtubeUsername = 'user';
+      component.youtubePassword = 'secret';
+      component.cropFile = true;
+      component.cropFileStart = 10;
+      component.cropFileEnd = 40;
+    }
+
+    it('starts closed and is not active until opened', () => {
+      expect(component.advancedMode).toBeFalse();
+      expect(component.isAdvancedModeActive()).toBeFalse();
+    });
+
+    it('opens and closes through the download menu toggle', () => {
+      component.toggleAdvancedMode();
+      expect(component.advancedMode).toBeTrue();
+      expect(component.isAdvancedModeActive()).toBeTrue();
+      expect(localStorage.getItem('advancedMode')).toBe('true');
+
+      component.toggleAdvancedMode();
+      expect(component.advancedMode).toBeFalse();
+      expect(localStorage.getItem('advancedMode')).toBe('false');
+    });
+
+    it('is never active when the feature is not permitted', () => {
+      component.advancedMode = true;
+      component.allowAdvancedDownload = false;
+
+      expect(component.isAdvancedModeActive()).toBeFalse();
+    });
+
+    it('refuses to open when the feature is not permitted', () => {
+      component.allowAdvancedDownload = false;
+
+      component.toggleAdvancedMode();
+
+      expect(component.advancedMode).toBeFalse();
+    });
+
+    it('clears every advanced option when closed', () => {
+      component.toggleAdvancedMode();
+      fillAdvancedOptions();
+
+      component.closeAdvancedMode();
+
+      expect(component.customArgsEnabled).toBeFalse();
+      expect(component.customArgs).toBeNull();
+      expect(component.replaceArgs).toBeFalse();
+      expect(component.customOutputEnabled).toBeFalse();
+      expect(component.customOutput).toBeNull();
+      expect(component.youtubeAuthEnabled).toBeFalse();
+      expect(component.youtubeUsername).toBeNull();
+      expect(component.youtubePassword).toBeNull();
+      expect(component.cropFile).toBeFalse();
+      expect(component.cropFileStart).toBeNull();
+      expect(component.cropFileEnd).toBeNull();
+    });
+
+    it('passes advanced options through the download request while open', () => {
+      const download_file_spy = spyOn((component as any).postsService, 'downloadFile')
+        .and.returnValue(of({download: {uid: 'queued-advanced'}}));
+      component.toggleAdvancedMode();
+      fillAdvancedOptions();
+
+      component.downloadClicked();
+
+      expect(download_file_spy).toHaveBeenCalled();
+      const args = download_file_spy.calls.argsFor(0);
+      // customArgs is only used to replace args; otherwise they are additional
+      expect(args[CUSTOM_ARGS_INDEX]).toBeNull();
+      expect(args[ADDITIONAL_ARGS_INDEX]).toBe('--write-thumbnail');
+      expect(args[CUSTOM_OUTPUT_INDEX]).toBe('custom/path');
+      expect(args[USERNAME_INDEX]).toBe('user');
+      expect(args[PASSWORD_INDEX]).toBe('secret');
+      expect(args[CROP_SETTINGS_INDEX]).toEqual({cropFileStart: 10, cropFileEnd: 40});
+    });
+
+    it('sends custom args as replacement args when replace is checked', () => {
+      const download_file_spy = spyOn((component as any).postsService, 'downloadFile')
+        .and.returnValue(of({download: {uid: 'queued-replace'}}));
+      component.toggleAdvancedMode();
+      fillAdvancedOptions();
+      component.replaceArgs = true;
+
+      component.downloadClicked();
+
+      const args = download_file_spy.calls.argsFor(0);
+      expect(args[CUSTOM_ARGS_INDEX]).toBe('--write-thumbnail');
+      expect(args[ADDITIONAL_ARGS_INDEX]).toBeNull();
+    });
+
+    it('sends no advanced options once advanced mode is closed', () => {
+      const download_file_spy = spyOn((component as any).postsService, 'downloadFile')
+        .and.returnValue(of({download: {uid: 'queued-closed'}}));
+      component.toggleAdvancedMode();
+      fillAdvancedOptions();
+      component.closeAdvancedMode();
+
+      component.downloadClicked();
+
+      const args = download_file_spy.calls.argsFor(0);
+      expect(args[CUSTOM_ARGS_INDEX]).toBeNull();
+      expect(args[ADDITIONAL_ARGS_INDEX]).toBeNull();
+      expect(args[CUSTOM_OUTPUT_INDEX]).toBeNull();
+      expect(args[USERNAME_INDEX]).toBeNull();
+      expect(args[PASSWORD_INDEX]).toBeNull();
+      expect(args[CROP_SETTINGS_INDEX]).toBeNull();
+    });
+
+    it('ignores stale advanced values that were never cleared', () => {
+      const download_file_spy = spyOn((component as any).postsService, 'downloadFile')
+        .and.returnValue(of({download: {uid: 'queued-stale'}}));
+      // simulates values surviving in component state without the panel being open
+      fillAdvancedOptions();
+      component.advancedMode = false;
+
+      component.downloadClicked();
+
+      const args = download_file_spy.calls.argsFor(0);
+      expect(args[ADDITIONAL_ARGS_INDEX]).toBeNull();
+      expect(args[CUSTOM_OUTPUT_INDEX]).toBeNull();
+      expect(args[USERNAME_INDEX]).toBeNull();
+      expect(args[PASSWORD_INDEX]).toBeNull();
+      expect(args[CROP_SETTINGS_INDEX]).toBeNull();
+    });
+
+    it('keeps the simulated command in sync with what a download would send', () => {
+      const generate_args_spy = spyOn((component as any).postsService, 'generateArgs')
+        .and.returnValue(of({args: []}));
+      fillAdvancedOptions();
+      component.advancedMode = false;
+
+      component.getSimulatedOutput();
+
+      const args = generate_args_spy.calls.argsFor(0);
+      expect(args[CUSTOM_ARGS_INDEX]).toBeNull();
+      expect(args[ADDITIONAL_ARGS_INDEX]).toBeNull();
+      expect(args[CUSTOM_OUTPUT_INDEX]).toBeNull();
+      expect(args[CROP_SETTINGS_INDEX]).toBeNull();
+    });
+
+    it('does not restore advanced options from storage when the feature is off', async () => {
+      localStorage.setItem('advancedMode', 'true');
+      localStorage.setItem('customArgsEnabled', 'true');
+      localStorage.setItem('customArgs', '--stale-arg');
+      (component as any).postsService.config['Advanced']['allow_advanced_download'] = false;
+
+      await component.loadConfig();
+
+      expect(component.advancedMode).toBeFalse();
+      expect(component.isAdvancedModeActive()).toBeFalse();
+      expect(component.customArgsEnabled).toBeFalse();
+      expect(component.customArgs).toBeNull();
+    });
+
+    it('restores advanced options from storage when advanced mode was left open', async () => {
+      localStorage.setItem('advancedMode', 'true');
+      localStorage.setItem('customArgsEnabled', 'true');
+      localStorage.setItem('customArgs', '--restored-arg');
+      (component as any).postsService.config['Advanced']['allow_advanced_download'] = true;
+
+      await component.loadConfig();
+
+      expect(component.advancedMode).toBeTrue();
+      expect(component.customArgsEnabled).toBeTrue();
+      expect(component.customArgs).toBe('--restored-arg');
+    });
+  });
 });

--- a/src/app/main/main.component.spec.ts
+++ b/src/app/main/main.component.spec.ts
@@ -821,14 +821,15 @@ describe('MainComponent', () => {
       expect(args[CROP_SETTINGS_INDEX]).toBeNull();
     });
 
-    it('does not restore advanced options from storage when the feature is off', async () => {
+    it('does not restore advanced options from storage without the user permission', async () => {
       localStorage.setItem('advancedMode', 'true');
       localStorage.setItem('customArgsEnabled', 'true');
       localStorage.setItem('customArgs', '--stale-arg');
-      (component as any).postsService.config['Advanced']['allow_advanced_download'] = false;
+      (component as any).postsService.hasPermission = (permission: string) => permission !== 'advanced_download';
 
       await component.loadConfig();
 
+      expect(component.allowAdvancedDownload).toBeFalse();
       expect(component.advancedMode).toBeFalse();
       expect(component.isAdvancedModeActive()).toBeFalse();
       expect(component.customArgsEnabled).toBeFalse();
@@ -839,13 +840,22 @@ describe('MainComponent', () => {
       localStorage.setItem('advancedMode', 'true');
       localStorage.setItem('customArgsEnabled', 'true');
       localStorage.setItem('customArgs', '--restored-arg');
-      (component as any).postsService.config['Advanced']['allow_advanced_download'] = true;
 
       await component.loadConfig();
 
       expect(component.advancedMode).toBeTrue();
       expect(component.customArgsEnabled).toBeTrue();
       expect(component.customArgs).toBe('--restored-arg');
+    });
+
+    it('is available on permission alone, with no global setting to enable', async () => {
+      // the removed allow_advanced_download setting must not be consulted, even if a stale
+      // copy is still present in a config that has not been migrated yet
+      (component as any).postsService.config['Advanced']['allow_advanced_download'] = false;
+
+      await component.loadConfig();
+
+      expect(component.allowAdvancedDownload).toBeTrue();
     });
   });
 });

--- a/src/app/main/main.component.ts
+++ b/src/app/main/main.component.ts
@@ -43,6 +43,7 @@ export class MainComponent implements OnInit {
   cropFile = false;
   cropFileStart = null;
   cropFileEnd = null;
+  advancedMode = false;
   urlError = false;
   path: string | string[] = '';
   url = '';
@@ -222,7 +223,11 @@ export class MainComponent implements OnInit {
     localStorage.setItem('cached_filemanager_enabled', this.fileManagerEnabled.toString());
     this.cachedFileManagerEnabled = this.fileManagerEnabled;
 
-    if (this.allowAdvancedDownload) {
+    this.advancedMode = this.allowAdvancedDownload && localStorage.getItem('advancedMode') === 'true';
+
+    // Advanced options only exist while advanced mode is open. Restoring them otherwise
+    // would leave hidden options silently applied to every download.
+    if (this.isAdvancedModeActive()) {
       if (localStorage.getItem('customArgsEnabled') !== null) {
         this.customArgsEnabled = localStorage.getItem('customArgsEnabled') === 'true';
       }
@@ -353,6 +358,83 @@ export class MainComponent implements OnInit {
     return this.sponsorBlockDownloadsEnabled || this.hasPlaylistUrlInInput() || this.hasChannelSearchPlaylistUrlInInput();
   }
 
+  // Advanced options apply only while the panel is open and the feature is permitted.
+  // Everything that reads an advanced field goes through this so a hidden panel can
+  // never contribute args to a download.
+  isAdvancedModeActive(): boolean {
+    return this.allowAdvancedDownload && this.advancedMode;
+  }
+
+  toggleAdvancedMode(): void {
+    this.setAdvancedMode(!this.advancedMode);
+  }
+
+  closeAdvancedMode(): void {
+    this.setAdvancedMode(false);
+  }
+
+  private setAdvancedMode(next_value: boolean): void {
+    if (!this.allowAdvancedDownload) next_value = false;
+    this.advancedMode = next_value;
+    localStorage.setItem('advancedMode', next_value.toString());
+
+    // Closing the panel clears the options rather than hiding them, so what the user
+    // sees and what gets downloaded cannot drift apart.
+    if (!next_value) this.resetAdvancedOptions();
+
+    this.argsChanged();
+  }
+
+  private resetAdvancedOptions(): void {
+    this.customArgsEnabled = false;
+    this.customArgs = null;
+    this.replaceArgs = false;
+    this.customOutputEnabled = false;
+    this.customOutput = null;
+    this.youtubeAuthEnabled = false;
+    this.youtubeUsername = null;
+    this.youtubePassword = null;
+    this.cropFile = false;
+    this.cropFileStart = null;
+    this.cropFileEnd = null;
+
+    localStorage.setItem('customArgsEnabled', 'false');
+    localStorage.setItem('replaceArgs', 'false');
+    localStorage.setItem('customOutputEnabled', 'false');
+    localStorage.setItem('youtubeAuthEnabled', 'false');
+  }
+
+  // Single source of truth for the advanced values a download should use. Shared by the
+  // real download and the simulated command so the preview cannot disagree with reality.
+  getAdvancedDownloadOptions(): {
+    customArgs: string,
+    additionalArgs: string,
+    customOutput: string,
+    youtubeUsername: string,
+    youtubePassword: string,
+    cropFileSettings: {cropFileStart: number, cropFileEnd: number}
+  } {
+    if (!this.isAdvancedModeActive()) {
+      return {
+        customArgs: null,
+        additionalArgs: null,
+        customOutput: null,
+        youtubeUsername: null,
+        youtubePassword: null,
+        cropFileSettings: null
+      };
+    }
+
+    return {
+      customArgs: (this.customArgsEnabled && this.replaceArgs ? this.customArgs : null),
+      additionalArgs: (this.customArgsEnabled && !this.replaceArgs ? this.customArgs : null),
+      customOutput: (this.customOutputEnabled ? this.customOutput : null),
+      youtubeUsername: (this.youtubeAuthEnabled && this.youtubeUsername ? this.youtubeUsername : null),
+      youtubePassword: (this.youtubeAuthEnabled && this.youtubePassword ? this.youtubePassword : null),
+      cropFileSettings: (this.cropFile ? {cropFileStart: this.cropFileStart, cropFileEnd: this.cropFileEnd} : null)
+    };
+  }
+
   hasPlaylistUrlInInput(): boolean {
     return this.getPlaylistDownloadUrl(this.url || '') !== null;
   }
@@ -402,14 +484,11 @@ export class MainComponent implements OnInit {
     this.urlError = false;
 
     // get common args
-    const customArgs = (this.customArgsEnabled && this.replaceArgs ? this.customArgs : null);
-    const additionalArgs = (this.customArgsEnabled && !this.replaceArgs ? this.customArgs : null);
-    const customOutput = (this.customOutputEnabled ? this.customOutput : null);
-    const youtubeUsername = (this.youtubeAuthEnabled && this.youtubeUsername ? this.youtubeUsername : null);
-    const youtubePassword = (this.youtubeAuthEnabled && this.youtubePassword ? this.youtubePassword : null);
+    const {customArgs, additionalArgs, customOutput, youtubeUsername, youtubePassword, cropFileSettings}
+      = this.getAdvancedDownloadOptions();
 
     // set advanced inputs
-    if (this.allowAdvancedDownload) {
+    if (this.isAdvancedModeActive()) {
       if (customArgs) {
         localStorage.setItem('customArgs', customArgs);
       }
@@ -427,15 +506,6 @@ export class MainComponent implements OnInit {
     const selectedAudioLanguage = this.getSelectedAudioLanguage();
     const selectedSubtitleLanguage = this.audioOnly ? null : this.getSelectedSubtitleLanguage();
     const selectedSubtitleType = this.audioOnly ? null : this.getSelectedSubtitleType();
-
-    let cropFileSettings = null;
-
-    if (this.cropFile) {
-      cropFileSettings = {
-        cropFileStart: this.cropFileStart,
-        cropFileEnd: this.cropFileEnd
-      }
-    }
 
     const selected_quality = this.selectedQuality;
     const selected_audio_language = selectedAudioLanguage;
@@ -844,12 +914,10 @@ export class MainComponent implements OnInit {
     const urls = this.getURLArray(this.url);
     if (urls.length > 1) return;
 
-    // this function should be very similar to downloadClicked()
-    const customArgs = (this.customArgsEnabled && this.replaceArgs ? this.customArgs : null);
-    const additionalArgs = (this.customArgsEnabled && !this.replaceArgs ? this.customArgs : null);
-    const customOutput = (this.customOutputEnabled ? this.customOutput : null);
-    const youtubeUsername = (this.youtubeAuthEnabled && this.youtubeUsername ? this.youtubeUsername : null);
-    const youtubePassword = (this.youtubeAuthEnabled && this.youtubePassword ? this.youtubePassword : null);
+    // shares getAdvancedDownloadOptions() with downloadClicked() so the previewed command
+    // always matches what an actual download would run
+    const {customArgs, additionalArgs, customOutput, youtubeUsername, youtubePassword, cropFileSettings}
+      = this.getAdvancedDownloadOptions();
 
     const type = this.audioOnly ? 'audio' : 'video';
 
@@ -857,15 +925,6 @@ export class MainComponent implements OnInit {
     const selectedAudioLanguage = this.getSelectedAudioLanguage();
     const selectedSubtitleLanguage = this.audioOnly ? null : this.getSelectedSubtitleLanguage();
     const selectedSubtitleType = this.audioOnly ? null : this.getSelectedSubtitleType();
-
-    let cropFileSettings = null;
-
-    if (this.cropFile) {
-      cropFileSettings = {
-        cropFileStart: this.cropFileStart,
-        cropFileEnd: this.cropFileEnd
-      }
-    }
 
     this.postsService.generateArgs(this.url, type as FileType, (customQualityConfiguration || this.selectedQuality === '' || typeof this.selectedQuality !== 'string' ? null : this.selectedQuality),
       customQualityConfiguration, customArgs, additionalArgs, customOutput, youtubeUsername, youtubePassword, cropFileSettings, false, selectedAudioLanguage, selectedSubtitleLanguage, selectedSubtitleType).subscribe(res => {

--- a/src/app/main/main.component.ts
+++ b/src/app/main/main.component.ts
@@ -213,8 +213,9 @@ export class MainComponent implements OnInit {
     this.youtubeAPIKey = this.youtubeSearchEnabled ? this.postsService.config['API']['youtube_API_key'] : null;
     this.sponsorBlockDownloadsEnabled = !!(this.postsService.config['API'] && this.postsService.config['API']['use_sponsorblock_API']);
     this.allowQualitySelect = this.postsService.config['Extra']['allow_quality_select'];
-    this.allowAdvancedDownload = this.postsService.config['Advanced']['allow_advanced_download']
-                                  && this.postsService.hasPermission('advanced_download');
+    // Advanced download mode is always available; access is governed by the per-user
+    // permission alone, not by a global on/off setting.
+    this.allowAdvancedDownload = this.postsService.hasPermission('advanced_download');
     this.useDefaultDownloadingAgent = this.postsService.config['Advanced']['use_default_downloading_agent'];
     this.customDownloadingAgent = this.postsService.config['Advanced']['custom_downloading_agent'];
 

--- a/src/app/posts.services.ts
+++ b/src/app/posts.services.ts
@@ -150,6 +150,16 @@ export interface RemoveDuplicatesResponse {
     removed_uids: string[];
 }
 
+export interface TranscodingStatus {
+    mode: string | null;
+    label: string | null;
+    in_progress: boolean;
+    checked: boolean;
+    available: boolean | null;
+    error: string | null;
+    last_checked: number | null;
+}
+
 @Injectable()
 export class PostsService {
     path = '';
@@ -197,6 +207,7 @@ export class PostsService {
     // global vars
     config = null;
     ytdlpImpersonationAvailable = false;
+    transcodingStatus: TranscodingStatus = null;
     subscriptions: Subscription[] = null;
     categories: Category[] = null;
     sidenav = null;
@@ -228,6 +239,7 @@ export class PostsService {
             const result = !this.debugMode ? res['config_file'] : res;
             if (result) {
                 this.ytdlpImpersonationAvailable = !this.debugMode && !!res['ytdlp_impersonation_available'];
+                this.transcodingStatus = !this.debugMode ? (res['transcoding_status'] || null) : null;
                 this.config = this.extractConfigRoot(result);
                 this.setPageTitle();
                 if (this.config['Advanced']['multi_user_mode']) {
@@ -328,6 +340,7 @@ export class PostsService {
             const result = !this.debugMode ? res['config_file'] : res;
             if (result) {
                 this.ytdlpImpersonationAvailable = !this.debugMode && !!res['ytdlp_impersonation_available'];
+                this.transcodingStatus = !this.debugMode ? (res['transcoding_status'] || null) : null;
                 this.config = this.extractConfigRoot(result);
                 this.setPageTitle();
                 this.config_reloaded.next(true);

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -139,6 +139,31 @@
                 <button class="args-edit-button" (click)="openArgsModifierDialog()" mat-icon-button><mat-icon>edit</mat-icon></button>
               </mat-form-field>
             </div>
+            <div class="col-12 mt-2 mb-4">
+              <mat-form-field class="text-field" color="accent">
+                <mat-label i18n="Hardware acceleration setting label">Hardware acceleration</mat-label>
+                <mat-select color="accent" [(ngModel)]="new_config['Downloader']['transcoding']">
+                  <mat-option [value]="false"><ng-container i18n="Hardware acceleration none option">None</ng-container></mat-option>
+                  <mat-option value="amf">AMD AMF</mat-option>
+                  <mat-option value="nvenc">Nvidia NVENC</mat-option>
+                  <mat-option value="qsv">Intel Quicksync (QSV)</mat-option>
+                  <mat-option value="vaapi">Video Acceleration API (VAAPI)</mat-option>
+                </mat-select>
+                <mat-hint><ng-container i18n="Hardware acceleration setting hint">Uses your GPU to speed up video processing such as cropping. The GPU must be passed through to the container.</ng-container></mat-hint>
+              </mat-form-field>
+            </div>
+            @if (transcodingWarning) {
+              <div class="col-12 mt-2 mb-2 transcoding-warning">
+                <mat-icon class="transcoding-warning-icon">warning</mat-icon>
+                <span>{{transcodingWarning}}</span>
+              </div>
+            }
+            @if (transcodingTestPending) {
+              <div class="col-12 mt-2 mb-2 transcoding-pending">
+                <mat-icon class="transcoding-pending-icon">hourglass_empty</mat-icon>
+                <span i18n="Hardware acceleration test pending message">The hardware acceleration flight test is still running. Refresh this page shortly to see the result.</span>
+              </div>
+            }
           </div>
         </div>
       }

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -666,9 +666,6 @@
                 </mat-select>
               </mat-form-field>
             </div>
-            <div class="col-12 mb-1">
-              <mat-checkbox color="accent" [(ngModel)]="new_config['Advanced']['allow_advanced_download']"><ng-container i18n="Allow advanced downloading setting">Allow advanced download</ng-container></mat-checkbox>
-            </div>
           </div>
         </div>
       }

--- a/src/app/settings/settings.component.scss
+++ b/src/app/settings/settings.component.scss
@@ -215,3 +215,27 @@
     white-space: pre-wrap;
     word-break: break-word;
 }
+
+.transcoding-warning {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+    color: #c62828;
+}
+
+.transcoding-warning-icon {
+    flex-shrink: 0;
+}
+
+.transcoding-pending {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+    opacity: 0.75;
+}
+
+.transcoding-pending-icon {
+    flex-shrink: 0;
+}

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -80,6 +80,18 @@ export class SettingsComponent implements OnInit {
     this._settingsSame = val;
   }
 
+  get transcodingWarning(): string {
+    const status = this.postsService.transcodingStatus;
+    if (!status || !status.mode || !status.checked || status.available !== false) return null;
+    const warning = $localize`The hardware acceleration flight test failed for ${status.label}:mode:. Video processing will fall back to software encoding.`;
+    return status.error ? `${warning} (${status.error})` : warning;
+  }
+
+  get transcodingTestPending(): boolean {
+    const status = this.postsService.transcodingStatus;
+    return !!(status && status.mode && !status.checked);
+  }
+
   constructor(public postsService: PostsService, private snackBar: MatSnackBar, private sanitizer: DomSanitizer,
     private dialog: MatDialog, private router: Router, private route: ActivatedRoute) {
       // invert index to tab

--- a/src/assets/default.json
+++ b/src/assets/default.json
@@ -22,7 +22,8 @@
       "download_rate_limit": "",
       "skip_join_only_videos": false,
       "use_ytdlp_impersonation": false,
-      "js_runtimes": ""
+      "js_runtimes": "",
+      "transcoding": false
     },
     "Extra": {
       "title_top": "ytdl-material",

--- a/src/assets/default.json
+++ b/src/assets/default.json
@@ -118,7 +118,6 @@
       "use_default_downloading_agent": true,
       "custom_downloading_agent": "",
       "multi_user_mode": true,
-      "allow_advanced_download": true,
       "jwt_expiration": 86400,
       "logger_level": "debug",
       "use_cookies": false,


### PR DESCRIPTION
Closes #328

## What this does

Adds a single `ytdl_transcoding` setting (default `false`) that enables GPU-accelerated ffmpeg video processing (e.g. cropping). Supported modes: `amf`, `nvenc`, `qsv`, `vaapi` (aliases like `nvidia`/`intel`/`quicksync` also accepted). Configurable via Docker env var or in **Settings → Downloader → Hardware acceleration**.

Usually better to add it pre-flight with `ytdl_transcoding: vaapi` or `ytdl_transcoding: nvenc`, etc.

### Boot flight test

On startup the backend runs a **non-blocking flight test**: it encodes a tiny generated clip with the configured hardware encoder (30s timeout). The result is exposed on `/api/config`:

- Test passes → hardware encoding is used for video files in h264-compatible containers (mp4/mkv/mov/ts).
- Test fails → everything falls back to software encoding, and the Settings Downloader tab shows a warning with the actual ffmpeg error (e.g. `Cannot load libcuda.so.1`, `No VA display found for device /dev/dri/renderD128`).
- Changing the setting re-runs the test automatically; a hardware crop that fails at runtime also retries in software.

### Docker changes

- **ffmpeg swap (amd64/arm64):** the johnvansickle 5.1.1 static build has zero hardware encoders, so those arches now pull BtbN's ffmpeg 7.1 GPL build (has `h264_amf`/`h264_nvenc`/`h264_qsv`/`h264_vaapi`). armhf/armel keep the old software-only build. Costs ~+120 MB uncompressed.
- **Drivers are NOT baked into the image** (would be ~200-300 MB for everyone). Instead the entrypoint installs VAAPI/QSV userspace drivers at container start only when `ytdl_transcoding` is set to a mode that needs them — same pattern as the yt-dlp impersonation deps. NVENC/AMF runtimes come from the host.

## How to test with the PR image

Once `docker-pr` publishes `ytdl-material:pr-<N>`:

```yaml
# VAAPI (Intel/AMD) — group IDs from: cat /etc/group | grep -E 'render|video' | cut -d: -f3
environment:
  ytdl_transcoding: 'vaapi'   # or 'qsv' on Intel
group_add:
  - 44
  - 106
devices:
  - /dev/dri/renderD128:/dev/dri/renderD128
  - /dev/dri/card0:/dev/dri/card0
```

```yaml
# NVENC (requires NVIDIA Container Toolkit)
environment:
  ytdl_transcoding: 'nvenc'
  NVIDIA_DRIVER_CAPABILITIES: 'compute,video,utility'
deploy:
  resources:
    reservations:
      devices:
        - driver: nvidia
          count: all
          capabilities: [gpu]
```

Then check the boot log for the flight test result, the Settings → Downloader tab for the dropdown/warning, and crop a video to compare speed. Full docs in `docker-environment.md`.

## Validation

- `npm run lint`, `tsc` (app + spec), 201/201 headless tests, production build all pass
- Backend: `node --check` on all touched files; new `backend/test/transcoding.test.js` (mode normalization, flight-test gating) passes along with existing utils/config suites
- Flight test verified end-to-end locally against real ffmpeg (graceful failure + error capture on a machine without the GPU runtimes)
- Not build-tested in Docker here (no daemon available) — the PR image is the real test. Driver installs in the entrypoint are best-effort with fallbacks so a changed package name can't break boot.