### PR TITLE
fix(deps): resolve brace-expansion CVE-2026-13149

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1003,15 +1003,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browser-stdout": {
@@ -3370,6 +3370,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimatch/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/minipass": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -27,7 +27,7 @@
         "express-session": "^1.19.0",
         "feed": "^6.0.0",
         "fluent-ffmpeg": "^2.1.3",
-        "fs-extra": "^11.3.6",
+        "fs-extra": "^11.4.0",
         "gotify": "^1.1.0",
         "jsonwebtoken": "^9.0.3",
         "lodash": "^4.18.1",
@@ -2396,9 +2396,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
-      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -41,7 +41,7 @@
     "express-session": "^1.19.0",
     "feed": "^6.0.0",
     "fluent-ffmpeg": "^2.1.3",
-    "fs-extra": "^11.3.6",
+    "fs-extra": "^11.4.0",
     "gotify": "^1.1.0",
     "jsonwebtoken": "^9.0.3",
     "lodash": "^4.18.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -75,7 +75,6 @@
     "xmlbuilder2": "^4.0.3"
   },
   "overrides": {
-    "brace-expansion": "5.0.6",
     "braces": "3.0.3",
     "cross-spawn": "7.0.6",
     "diff": "8.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "crypto-js": "^4.2.0",
         "file-saver": "^2.0.2",
         "filesize": "^11.0.22",
-        "fs-extra": "^11.3.6",
+        "fs-extra": "^11.4.0",
         "material-icons": "^1.10.8",
         "nan": "^2.28.0",
         "ngx-avatars": "1.10.2",
@@ -39,9 +39,9 @@
         "zone.js": "~0.16.2"
       },
       "devDependencies": {
-        "@angular-devkit/core": "^22.0.7",
-        "@angular/build": "^22.0.7",
-        "@angular/cli": "^22.0.7",
+        "@angular-devkit/core": "^22.0.8",
+        "@angular/build": "^22.0.8",
+        "@angular/cli": "^22.0.8",
         "@angular/compiler-cli": "^22.0.8",
         "@angular/language-service": "^22.0.8",
         "@eslint/js": "^10.0.1",
@@ -295,13 +295,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.2200.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2200.7.tgz",
-      "integrity": "sha512-t03YYe5amlcpsX5gpMGi96kpBNTMKY7/rJsRDNO3v98mSy7kzNXlgzy/jyfdFev7AJusuwVM5TKVsUAgQxCgCw==",
+      "version": "0.2200.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2200.8.tgz",
+      "integrity": "sha512-LFKK2v96nO0ESM9nftlCkTy+O/66AxNkwUpG+Q1er7LLNR2S8UReZnQ1/RhMkldCWxsmp2rQzdgHWnubaY/ZfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.0.7",
+        "@angular-devkit/core": "22.0.8",
         "rxjs": "7.8.2"
       },
       "bin": {
@@ -314,9 +314,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "22.0.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.0.7.tgz",
-      "integrity": "sha512-r8XiflsVYcsvWp+zVvaNv5GsDoihaZ2OwWfn++N6YqTUZLcqDzqhsxeNk60sJ5V+Jn4ck1aKF4A9flmvSY+tpQ==",
+      "version": "22.0.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.0.8.tgz",
+      "integrity": "sha512-Hnr4SCkxQM+xtq4uERC09qwTZpt97t4CwDZYzv/HbQA4pMYDfTxvIRHCyl+UHf4NbkC7ZVgyiab+KzTfuc609Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -359,13 +359,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "22.0.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.0.7.tgz",
-      "integrity": "sha512-bKgnBB0LPAj44uVXfW0UO1rQBb3HGXDZxa1bLtESr/KCK4j5iiaXlHqvJjc/z0em1Ds9WNQOfNXjV3IdJo9sSw==",
+      "version": "22.0.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.0.8.tgz",
+      "integrity": "sha512-9WjTKnW/5oIw4hNNcd0rSYtgHRrHKKAkG6+bdLqTCY68P2brO2yEJM2JjYtMYk/WSovknb0GxUP4n3dY3IxPug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.0.7",
+        "@angular-devkit/core": "22.0.8",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.21",
         "ora": "9.4.0",
@@ -394,14 +394,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "22.0.7",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.0.7.tgz",
-      "integrity": "sha512-cm/QJmrIgsjzZJeBeqeNwgdgK6BGBKk7ca21jnSsrwlae3F9u1E8cImFbLeZSjEGghx4wFUacFDG+6lFEICntw==",
+      "version": "22.0.8",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.0.8.tgz",
+      "integrity": "sha512-QJVVTROVb27Ixk+RU4FSKwwyRbLdtNH20zFm1CwOKzA0wQHrWfxHTqlwMhnTOsOt5Cb3eX+6IjDXoGmAfJ81mA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2200.7",
+        "@angular-devkit/architect": "0.2200.8",
         "@babel/core": "7.29.7",
         "@babel/helper-annotate-as-pure": "7.29.7",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -423,7 +423,7 @@
         "semver": "7.7.4",
         "source-map-support": "0.5.21",
         "tinyglobby": "0.2.16",
-        "vite": "7.3.5",
+        "vite": "7.3.6",
         "watchpack": "2.5.1"
       },
       "engines": {
@@ -442,7 +442,7 @@
         "@angular/platform-browser": "^22.0.0",
         "@angular/platform-server": "^22.0.0",
         "@angular/service-worker": "^22.0.0",
-        "@angular/ssr": "^22.0.7",
+        "@angular/ssr": "^22.0.8",
         "istanbul-lib-instrument": "^6.0.0",
         "karma": "^6.4.0",
         "less": "^4.2.0",
@@ -529,19 +529,19 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "22.0.7",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.0.7.tgz",
-      "integrity": "sha512-5r+fgP8ARnXZeylAGt5BuToVcR8Vn2QQZ6dPMe7V9o4NdvJqqOKmE7fEiRe7KaxIx5WSDhuAhgW9t+scLZQbvw==",
+      "version": "22.0.8",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.0.8.tgz",
+      "integrity": "sha512-kefbTsmf7sEmW5g3NIRvH0OrM18I1jjZHlB9KABgRQhsDfD/WgfLt6aSLJQeFDlAOs+ehDPzzOwd9l48wyBlFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2200.7",
-        "@angular-devkit/core": "22.0.7",
-        "@angular-devkit/schematics": "22.0.7",
+        "@angular-devkit/architect": "0.2200.8",
+        "@angular-devkit/core": "22.0.8",
+        "@angular-devkit/schematics": "22.0.8",
         "@inquirer/prompts": "8.4.2",
         "@listr2/prompt-adapter-inquirer": "4.2.3",
         "@modelcontextprotocol/sdk": "1.29.0",
-        "@schematics/angular": "22.0.7",
+        "@schematics/angular": "22.0.8",
         "@yarnpkg/lockfile": "1.1.0",
         "algoliasearch": "5.52.0",
         "ini": "6.0.0",
@@ -3696,14 +3696,14 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "22.0.7",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.0.7.tgz",
-      "integrity": "sha512-/GVLhB5zaxYGIaC4GFfsfk81SDq9ht0HbEHhHB+t1SqNPV8gnULDV2ZE0Cg+LGj+3YnPtSwpb7tS0vaHUcihVg==",
+      "version": "22.0.8",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.0.8.tgz",
+      "integrity": "sha512-zD2WLe15SoKYyBZH1GTLLaVABNNObHkH4soQqXb9agN6zkrpE0naeWaBSFSWD+95VKCiMZl8LkiOXvK+6b8S6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.0.7",
-        "@angular-devkit/schematics": "22.0.7",
+        "@angular-devkit/core": "22.0.8",
+        "@angular-devkit/schematics": "22.0.8",
         "jsonc-parser": "3.3.1",
         "typescript": "6.0.3"
       },
@@ -4567,16 +4567,16 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -6175,9 +6175,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
-      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -6352,9 +6352,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7282,9 +7282,9 @@
       "license": "MIT"
     },
     "node_modules/karma-coverage-istanbul-reporter/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7399,9 +7399,9 @@
       }
     },
     "node_modules/karma/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "crypto-js": "^4.2.0",
     "file-saver": "^2.0.2",
     "filesize": "^11.0.22",
-    "fs-extra": "^11.3.6",
+    "fs-extra": "^11.4.0",
     "material-icons": "^1.10.8",
     "nan": "^2.28.0",
     "ngx-avatars": "1.10.2",
@@ -52,9 +52,9 @@
     "zone.js": "~0.16.2"
   },
   "devDependencies": {
-    "@angular-devkit/core": "^22.0.7",
-    "@angular/build": "^22.0.7",
-    "@angular/cli": "^22.0.7",
+    "@angular-devkit/core": "^22.0.8",
+    "@angular/build": "^22.0.8",
+    "@angular/cli": "^22.0.8",
     "@angular/compiler-cli": "^22.0.8",
     "@angular/language-service": "^22.0.8",
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary

- remove the backend's global `brace-expansion` override that forced 5.x into every consumer
- resolve patched, API-compatible `brace-expansion` releases across both workspaces: 5.0.8, 2.1.2, and 1.1.16
- update Angular build tooling from 22.0.7 to 22.0.8
- update `fs-extra` from 11.3.6 to 11.4.0 in both workspaces
- clear the repository-wide outdated-dependency gate

## Why

`minimatch@9.0.9` declares `brace-expansion@^2.0.2` and consumes its CommonJS default export. The previous global 5.x override replaced that dependency with the incompatible named-export API, causing brace expansion to throw:

```text
TypeError: brace_expansion_1.default is not a function
```

Removing the override lets npm select the patched compatible release for each backend dependency path:

```text
archiver -> readdir-glob -> minimatch@10.2.5 -> brace-expansion@5.0.8
mocha -> minimatch@9.0.9 -> brace-expansion@2.1.2
```

The root lockfile is also refreshed so its `minimatch` 10 and 3 consumers resolve patched `brace-expansion` 5.0.8 and 1.1.16 respectively. Version 5.0.8 includes the CVE-2026-13149 remediation from 5.0.7 plus the latest upstream denial-of-service hardening.

This supersedes #334, which updates the backend's global override but preserves the incompatible dependency graph.

## Verification

Tested with Node.js 24.18.0:

- clean `npm ci` in both workspaces
- repository outdated-dependency checks report no packages behind wanted versions
- `npm audit` no longer reports `brace-expansion` in either workspace
- brace-expansion smoke tests pass through all four `minimatch` dependency paths
- frontend lint passes
- Angular production build passes
- backend tests — 218 passing, 24 pending
