### PR TITLE
fix(downloads): prevent heap exhaustion loading history

### DIFF
--- a/Public API v1.yaml
+++ b/Public API v1.yaml
@@ -833,7 +833,7 @@ paths:
         - Auth query parameter: []
   /api/downloads:
     post:
-      summary: Get info for all downloads
+      summary: Get a bounded page of download summaries
       tags:
         - downloader
       responses:
@@ -849,7 +849,7 @@ paths:
             schema:
               $ref: '#/components/schemas/GetAllDownloadsRequest'
       operationId: post-api-downloads
-      description: Retrieves all downloads recorded by the server and their status.
+      description: Retrieves a newest-first, server-paginated page of download summaries and their status.
       security:
         - Auth query parameter: []
   /api/download:
@@ -1829,6 +1829,15 @@ components:
         only_unfinished:
           type: boolean
           description: Filters downloads to unfinished queue items
+        page:
+          type: integer
+          minimum: 0
+          description: Zero-based history page. Ignored when filtering by UID or requesting only unfinished downloads.
+        page_size:
+          type: integer
+          minimum: 1
+          maximum: 100
+          description: Number of history items to return. The server clamps this value to its hard maximum.
     GetAllDownloadsResponse:
       type: object
       properties:
@@ -1836,6 +1845,18 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Download'
+        total_count:
+          type: integer
+          minimum: 0
+          description: Total number of scoped downloads matching the request.
+        page:
+          type: integer
+          minimum: 0
+          description: Zero-based page actually returned by the server.
+        page_size:
+          type: integer
+          minimum: 0
+          description: Page size actually applied by the server.
     ClearDownloadsRequest:
       type: object
       properties:
@@ -2828,8 +2849,15 @@ components:
           type: number
         error:
           type: string
-          description: Error text, set if download fails.
+          description: Bounded error summary, set if the download fails. Legacy entries may return a generic placeholder.
           nullable: true
+        error_summary:
+          type: string
+          description: Bounded persisted diagnostic for newly recorded failures.
+          nullable: true
+        error_details_omitted:
+          type: boolean
+          description: Whether heavyweight legacy error output was omitted from the response.
         error_type:
           type: string
           description: Error type, may or may not be set in case of an error

--- a/backend/app.js
+++ b/backend/app.js
@@ -2698,31 +2698,232 @@ app.get('/api/thumbnail/:path', optionalJwt, async (req, res) => {
 
 // Downloads management
 
+const DOWNLOADS_DEFAULT_PAGE_SIZE = 20;
+const DOWNLOADS_MAX_PAGE_SIZE = 100;
+const DOWNLOADS_MAX_UID_FILTER_SIZE = 100;
+const DOWNLOADS_MAX_ACTIVE_RESULTS = 100;
+const DOWNLOAD_LIST_PROJECTION_FIELDS = Object.freeze([
+    'uid',
+    'ui_uid',
+    'running',
+    'finished',
+    'paused',
+    'cancelled',
+    'finished_step',
+    'url',
+    'type',
+    'title',
+    'step_index',
+    'percent_complete',
+    'timestamp_start',
+    'error_type',
+    'error_summary',
+    'sub_id',
+    'sub_name',
+    'playlist_item_progress',
+    'file_uids',
+    'container.id',
+    'container.uid',
+    'duplicate_skip_only',
+    'duplicate_skip_count',
+    'options.playlistBatchId',
+    'options.playlistChunkRange',
+    'options.playlistChunkIndex',
+    'options.playlistChunkCount',
+    'options.playlistChunkTitle'
+]);
+
+function clampDownloadsInteger(value, fallback, minimum, maximum) {
+    if (value === null || value === undefined || value === '') return fallback;
+    const parsed_value = Number(value);
+    if (!Number.isFinite(parsed_value)) return fallback;
+    return Math.min(maximum, Math.max(minimum, Math.floor(parsed_value)));
+}
+
+function normalizeDownloadContainerForList(container = null) {
+    if (!container || typeof container !== 'object') return null;
+    if (container.uid) return {uid: container.uid};
+    if (container.id) return {id: container.id, uids: []};
+    return null;
+}
+
+function getDownloadErrorPlaceholder(error_type = null) {
+    const normalized_error_type = typeof error_type === 'string'
+        ? error_type.trim().slice(0, 100)
+        : '';
+    return normalized_error_type
+        ? `Download failed (${normalized_error_type}). Detailed output is unavailable for this legacy queue entry.`
+        : 'Download failed. Detailed output is unavailable for this legacy queue entry.';
+}
+
+async function attachDownloadListErrorState(downloads = [], scoped_filter = {}) {
+    if (!Array.isArray(downloads) || downloads.length === 0) return downloads;
+
+    const download_uids = downloads.map(download => download && download.uid).filter(Boolean);
+    if (download_uids.length === 0) {
+        return downloads.map(download => ({
+            ...download,
+            container: normalizeDownloadContainerForList(download.container),
+            error: null,
+            error_details_omitted: false
+        }));
+    }
+    const errored_downloads = await db_api.getRecords(
+        'download_queue',
+        {...scoped_filter, uid: {$in: download_uids}, error: {$ne: null}},
+        false,
+        null,
+        [0, download_uids.length],
+        ['uid']
+    );
+    const errored_uids = new Set(errored_downloads.map(download => download.uid));
+
+    return downloads.map(download => {
+        const normalized_download = {
+            ...download,
+            container: normalizeDownloadContainerForList(download.container)
+        };
+        const has_error_summary = typeof download.error_summary === 'string' && download.error_summary.trim() !== '';
+        if (errored_uids.has(download.uid) || has_error_summary) {
+            normalized_download.error = has_error_summary
+                ? download.error_summary
+                : getDownloadErrorPlaceholder(download.error_type);
+            normalized_download.error_details_omitted = true;
+        } else {
+            normalized_download.error = null;
+            normalized_download.error_details_omitted = false;
+        }
+        return normalized_download;
+    });
+}
+
+async function hasScopedDownload(download_uid, user_uid) {
+    if (typeof download_uid !== 'string' || download_uid.trim() === '') return false;
+    const downloads = await db_api.getRecords(
+        'download_queue',
+        {uid: download_uid, ...getScopedFilterByUser(user_uid)},
+        false,
+        null,
+        [0, 1],
+        ['uid']
+    );
+    return downloads.length > 0;
+}
+
 app.post('/api/downloads', optionalJwt, async (req, res) => {
     const user_uid = req.isAuthenticated() ? req.user.uid : null;
     const uids = req.body.uids;
     const only_unfinished = req.body.only_unfinished === true;
     const filter_obj = getScopedFilterByUser(user_uid);
+
+    if (uids !== null && uids !== undefined && !Array.isArray(uids)) {
+        res.status(400).send({error: 'Download UIDs must be provided as an array.'});
+        return;
+    }
+
     if (Array.isArray(uids)) {
         if (uids.length === 0) {
-            res.send({downloads: []});
+            res.send({downloads: [], total_count: 0, page: 0, page_size: 0});
             return;
         }
-        filter_obj['uid'] = {$in: uids};
-    } else if (only_unfinished) {
-        filter_obj['finished'] = false;
-    }
-    const downloads = await db_api.getRecords('download_queue', filter_obj);
+        const normalized_uids = [...new Set(
+            uids
+                .filter(uid => typeof uid === 'string')
+                .map(uid => uid.trim())
+                .filter(uid => uid !== '')
+        )];
+        if (normalized_uids.length > DOWNLOADS_MAX_UID_FILTER_SIZE) {
+            res.status(400).send({
+                error: `A maximum of ${DOWNLOADS_MAX_UID_FILTER_SIZE} download UIDs may be requested at once.`
+            });
+            return;
+        }
 
-    res.send({downloads: downloads});
+        if (normalized_uids.length === 0) {
+            res.send({downloads: [], total_count: 0, page: 0, page_size: 0});
+            return;
+        }
+        filter_obj['uid'] = {$in: normalized_uids};
+        const downloads = await db_api.getRecords(
+            'download_queue',
+            filter_obj,
+            false,
+            {by: 'timestamp_start', order: -1},
+            [0, normalized_uids.length],
+            DOWNLOAD_LIST_PROJECTION_FIELDS
+        );
+        const projected_downloads = await attachDownloadListErrorState(downloads, getScopedFilterByUser(user_uid));
+        res.send({
+            downloads: projected_downloads,
+            total_count: projected_downloads.length,
+            page: 0,
+            page_size: normalized_uids.length
+        });
+        return;
+    }
+
+    if (only_unfinished) {
+        filter_obj['finished'] = false;
+        const [downloads, total_count] = await Promise.all([
+            db_api.getRecords(
+                'download_queue',
+                filter_obj,
+                false,
+                {by: 'timestamp_start', order: -1},
+                [0, DOWNLOADS_MAX_ACTIVE_RESULTS],
+                DOWNLOAD_LIST_PROJECTION_FIELDS
+            ),
+            db_api.getRecords('download_queue', filter_obj, true)
+        ]);
+        const projected_downloads = await attachDownloadListErrorState(downloads, getScopedFilterByUser(user_uid));
+        res.send({
+            downloads: projected_downloads,
+            total_count: total_count,
+            page: 0,
+            page_size: DOWNLOADS_MAX_ACTIVE_RESULTS
+        });
+        return;
+    }
+
+    const page_size = clampDownloadsInteger(req.body.page_size, DOWNLOADS_DEFAULT_PAGE_SIZE, 1, DOWNLOADS_MAX_PAGE_SIZE);
+    const requested_page = clampDownloadsInteger(req.body.page, 0, 0, Number.MAX_SAFE_INTEGER);
+    const total_count = await db_api.getRecords('download_queue', filter_obj, true);
+    const last_page = total_count > 0 ? Math.floor((total_count - 1) / page_size) : 0;
+    const page = Math.min(requested_page, last_page);
+    const range_start = page * page_size;
+    const downloads = await db_api.getRecords(
+        'download_queue',
+        filter_obj,
+        false,
+        {by: 'timestamp_start', order: -1},
+        [range_start, range_start + page_size],
+        DOWNLOAD_LIST_PROJECTION_FIELDS
+    );
+    const projected_downloads = await attachDownloadListErrorState(downloads, getScopedFilterByUser(user_uid));
+
+    res.send({
+        downloads: projected_downloads,
+        total_count: total_count,
+        page: page,
+        page_size: page_size
+    });
 });
 
 app.post('/api/download', optionalJwt, async (req, res) => {
     const download_uid = req.body.download_uid;
     const user_uid = req.isAuthenticated() ? req.user.uid : null;
-    const filter_obj = {uid: download_uid, ...getScopedFilterByUser(user_uid)};
-
-    const download = await db_api.getRecord('download_queue', filter_obj);
+    const scoped_filter = getScopedFilterByUser(user_uid);
+    const filter_obj = {uid: download_uid, ...scoped_filter};
+    const downloads = await db_api.getRecords(
+        'download_queue',
+        filter_obj,
+        false,
+        null,
+        [0, 1],
+        DOWNLOAD_LIST_PROJECTION_FIELDS
+    );
+    const projected_downloads = await attachDownloadListErrorState(downloads, scoped_filter);
+    const download = projected_downloads.length > 0 ? projected_downloads[0] : null;
 
     if (download) {
         res.send({download: download});
@@ -2740,13 +2941,27 @@ app.post('/api/clearDownloads', optionalJwt, async (req, res) => {
     let success = true;
     if (clear_finished) success &= await db_api.removeAllRecords('download_queue', {finished: true, ...scoped_filter, error: null});
     if (clear_paused) {
-        const paused_downloads = await db_api.getRecords('download_queue', {paused: true, ...scoped_filter});
+        const paused_downloads = await db_api.getRecords(
+            'download_queue',
+            {paused: true, ...scoped_filter},
+            false,
+            null,
+            null,
+            ['uid']
+        );
         for (const paused_download of paused_downloads) {
             success &= await downloader_api.clearDownload(paused_download['uid']);
         }
     }
     if (clear_errors) {
-        const errored_downloads = await db_api.getRecords('download_queue', {error: {$ne: null}, ...scoped_filter});
+        const errored_downloads = await db_api.getRecords(
+            'download_queue',
+            {error: {$ne: null}, ...scoped_filter},
+            false,
+            null,
+            null,
+            ['uid']
+        );
         for (const errored_download of errored_downloads) {
             success &= await downloader_api.clearDownload(errored_download['uid']);
         }
@@ -2757,8 +2972,7 @@ app.post('/api/clearDownloads', optionalJwt, async (req, res) => {
 app.post('/api/clearDownload', optionalJwt, async (req, res) => {
     const download_uid = req.body.download_uid;
     const user_uid = req.isAuthenticated() ? req.user.uid : null;
-    const owned_download = await db_api.getRecord('download_queue', {uid: download_uid, ...getScopedFilterByUser(user_uid)});
-    if (!owned_download) {
+    if (!(await hasScopedDownload(download_uid, user_uid))) {
         res.send({success: false});
         return;
     }
@@ -2769,8 +2983,7 @@ app.post('/api/clearDownload', optionalJwt, async (req, res) => {
 app.post('/api/pauseDownload', optionalJwt, async (req, res) => {
     const download_uid = req.body.download_uid;
     const user_uid = req.isAuthenticated() ? req.user.uid : null;
-    const owned_download = await db_api.getRecord('download_queue', {uid: download_uid, ...getScopedFilterByUser(user_uid)});
-    if (!owned_download) {
+    if (!(await hasScopedDownload(download_uid, user_uid))) {
         res.send({success: false});
         return;
     }
@@ -2781,7 +2994,14 @@ app.post('/api/pauseDownload', optionalJwt, async (req, res) => {
 app.post('/api/pauseAllDownloads', optionalJwt, async (req, res) => {
     const user_uid = req.isAuthenticated() ? req.user.uid : null;
     let success = true;
-    const all_running_downloads = await db_api.getRecords('download_queue', {paused: false, finished: false, ...getScopedFilterByUser(user_uid)});
+    const all_running_downloads = await db_api.getRecords(
+        'download_queue',
+        {paused: false, finished: false, ...getScopedFilterByUser(user_uid)},
+        false,
+        null,
+        null,
+        ['uid']
+    );
     for (let i = 0; i < all_running_downloads.length; i++) {
         success &= await downloader_api.pauseDownload(all_running_downloads[i]['uid']);
     }
@@ -2791,8 +3011,7 @@ app.post('/api/pauseAllDownloads', optionalJwt, async (req, res) => {
 app.post('/api/resumeDownload', optionalJwt, async (req, res) => {
     const download_uid = req.body.download_uid;
     const user_uid = req.isAuthenticated() ? req.user.uid : null;
-    const owned_download = await db_api.getRecord('download_queue', {uid: download_uid, ...getScopedFilterByUser(user_uid)});
-    if (!owned_download) {
+    if (!(await hasScopedDownload(download_uid, user_uid))) {
         res.send({success: false});
         return;
     }
@@ -2803,7 +3022,14 @@ app.post('/api/resumeDownload', optionalJwt, async (req, res) => {
 app.post('/api/resumeAllDownloads', optionalJwt, async (req, res) => {
     const user_uid = req.isAuthenticated() ? req.user.uid : null;
     let success = true;
-    const all_paused_downloads = await db_api.getRecords('download_queue', {paused: true, ...getScopedFilterByUser(user_uid), error: null});
+    const all_paused_downloads = await db_api.getRecords(
+        'download_queue',
+        {paused: true, ...getScopedFilterByUser(user_uid), error: null},
+        false,
+        null,
+        null,
+        ['uid']
+    );
     for (let i = 0; i < all_paused_downloads.length; i++) {
         success &= await downloader_api.resumeDownload(all_paused_downloads[i]['uid']);
     }
@@ -2813,8 +3039,7 @@ app.post('/api/resumeAllDownloads', optionalJwt, async (req, res) => {
 app.post('/api/restartDownload', optionalJwt, async (req, res) => {
     const download_uid = req.body.download_uid;
     const user_uid = req.isAuthenticated() ? req.user.uid : null;
-    const owned_download = await db_api.getRecord('download_queue', {uid: download_uid, ...getScopedFilterByUser(user_uid)});
-    if (!owned_download) {
+    if (!(await hasScopedDownload(download_uid, user_uid))) {
         res.send({success: false, new_download_uid: null});
         return;
     }
@@ -2825,8 +3050,7 @@ app.post('/api/restartDownload', optionalJwt, async (req, res) => {
 app.post('/api/cancelDownload', optionalJwt, async (req, res) => {
     const download_uid = req.body.download_uid;
     const user_uid = req.isAuthenticated() ? req.user.uid : null;
-    const owned_download = await db_api.getRecord('download_queue', {uid: download_uid, ...getScopedFilterByUser(user_uid)});
-    if (!owned_download) {
+    if (!(await hasScopedDownload(download_uid, user_uid))) {
         res.send({success: false});
         return;
     }

--- a/backend/db.js
+++ b/backend/db.js
@@ -142,6 +142,9 @@ const tables = {
             url: 'text'
         },
         indexes: [
+            { keys: { timestamp_start: -1 } },
+            { keys: { user_uid: 1, timestamp_start: -1 } },
+            { keys: { user_uid: 1, finished: 1, timestamp_start: -1 } },
             { keys: { finished: 1, paused: 1, finished_step: 1, timestamp_start: 1 } },
             { keys: { user_uid: 1, finished: 1, paused: 1 } },
             { keys: { sub_id: 1, error: 1, finished: 1 } },
@@ -823,34 +826,112 @@ function compareLocalSortValues(sort, record_a, record_b) {
     return 0;
 }
 
-exports.getRecords = async (table, filter_obj = null, return_count = false, sort = null, range = null) => {
+function normalizeProjectionFields(projection_fields = null) {
+    if (projection_fields === null || projection_fields === undefined) return null;
+    if (!Array.isArray(projection_fields) || projection_fields.length === 0) {
+        throw new Error('Projection fields must be a non-empty array.');
+    }
+
+    const normalized_fields = [];
+    const seen_fields = new Set();
+    for (const field_path of projection_fields) {
+        validateMongoFieldPath(field_path);
+        if (field_path === '_id') {
+            throw new Error("The internal MongoDB '_id' field cannot be projected.");
+        }
+        if (seen_fields.has(field_path)) continue;
+        seen_fields.add(field_path);
+        normalized_fields.push(field_path);
+    }
+    return normalized_fields;
+}
+
+function getOwnValueByPath(record, path_parts = []) {
+    let current_value = record;
+    for (const path_part of path_parts) {
+        if (current_value === null || current_value === undefined || typeof current_value !== 'object') {
+            return {found: false, value: undefined};
+        }
+        if (!Object.prototype.hasOwnProperty.call(current_value, path_part)) {
+            return {found: false, value: undefined};
+        }
+        current_value = current_value[path_part];
+    }
+    return {found: true, value: current_value};
+}
+
+function setProjectedValue(target, path_parts = [], value) {
+    let current_target = target;
+    for (let index = 0; index < path_parts.length - 1; index++) {
+        const path_part = path_parts[index];
+        if (!Object.prototype.hasOwnProperty.call(current_target, path_part)) {
+            current_target[path_part] = {};
+        }
+        current_target = current_target[path_part];
+    }
+    current_target[path_parts[path_parts.length - 1]] = value;
+}
+
+function projectLocalRecord(record, projection_fields = null) {
+    if (!projection_fields) return record;
+
+    const projected_record = {};
+    for (const field_path of projection_fields) {
+        const path_parts = field_path.split('.');
+        const projected_value = getOwnValueByPath(record, path_parts);
+        if (!projected_value.found) continue;
+        setProjectedValue(projected_record, path_parts, projected_value.value);
+    }
+    return projected_record;
+}
+
+exports.getRecords = async (table, filter_obj = null, return_count = false, sort = null, range = null, projection_fields = null) => {
+    const normalized_projection_fields = return_count ? null : normalizeProjectionFields(projection_fields);
+    const normalized_range = Array.isArray(range) && range.length === 2
+        ? [
+            Math.max(0, Number(range[0]) || 0),
+            Math.max(0, Number(range[1]) || 0)
+        ]
+        : null;
+
     // local db override
     if (using_local_db) {
         let cursor = filter_obj ? exports.applyFilterLocalDB(local_db.get(table), filter_obj, 'filter').value() : local_db.get(table).value();
         if (sort) {
             cursor = cursor.sort((a, b) => compareLocalSortValues(sort, a, b));
         }
-        if (range) {
-            cursor = cursor.slice(range[0], range[1]);
+        if (normalized_range) {
+            cursor = cursor.slice(normalized_range[0], normalized_range[1]);
         }
-        return !return_count ? cursor : cursor.length;
+        if (return_count) return cursor.length;
+        return normalized_projection_fields
+            ? cursor.map(record => projectLocalRecord(record, normalized_projection_fields))
+            : cursor;
     }
 
     if (getActiveDBType() === DB_TYPES.postgres) {
-        return await postgres_store.getRecords(postgres_pool, tables, table, filter_obj, return_count, sort, range);
+        return await postgres_store.getRecords(postgres_pool, tables, table, filter_obj, return_count, sort, normalized_range, normalized_projection_fields);
     }
 
     const collection = mongo_database.collection(table);
     if (return_count) {
         return await collection.countDocuments(filter_obj || {});
     }
+    if (normalized_range && normalized_range[1] <= normalized_range[0]) return [];
 
     const cursor = filter_obj ? collection.find(filter_obj) : collection.find();
     if (sort) {
         cursor.sort({[sort['by']]: sort['order']});
     }
-    if (range) {
-        cursor.skip(range[0]).limit(range[1] - range[0]);
+    if (normalized_range) {
+        cursor.skip(normalized_range[0]).limit(normalized_range[1] - normalized_range[0]);
+    }
+    if (normalized_projection_fields) {
+        const mongo_projection = {_id: 0};
+        for (const field_path of normalized_projection_fields) {
+            mongo_projection[field_path] = 1;
+        }
+        cursor.project(mongo_projection);
     }
 
     return await cursor.toArray();

--- a/backend/downloader.js
+++ b/backend/downloader.js
@@ -31,7 +31,31 @@ const YOUTUBE_CHANNEL_TAB_SEGMENTS = new Set(['featured', 'videos', 'shorts', 's
 const DEFAULT_PROGRESS_CHECK_INTERVAL_MS = 1000;
 const FAST_PROGRESS_CHECK_INTERVAL_MS = 250;
 const FAST_PROGRESS_SIZE_THRESHOLD_BYTES = 100 * 1024 * 1024;
+const DOWNLOAD_QUEUE_CHECK_PROJECTION_FIELDS = Object.freeze([
+    'uid',
+    'timestamp_start',
+    'paused',
+    'finished',
+    'running',
+    'finished_step',
+    'step_index',
+    'sub_id',
+    'url',
+    'type',
+    'user_uid',
+    'options.playlistExclusive',
+    'options.playlistChunkRange',
+    'options.playlistBatchId',
+    'options.ui_uid',
+    'options.additionalArgs',
+    'options.customArgs',
+    'options.channelSearchPlaylist',
+    'options.concurrentQueueGroupKey',
+    'options.concurrentQueueGroupLimit'
+]);
 const ANSI_ESCAPE_SEQUENCE_REGEX = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
+const MAX_PERSISTED_DOWNLOAD_ERROR_LENGTH = 8 * 1024;
+const DOWNLOAD_ERROR_TRUNCATION_MARKER = '\n...[download error truncated]...\n';
 const DEFAULT_INVALID_FILENAME_CHARS = '\\/:*?"<>|';
 const METADATA_FIELDS_FOR_FILENAME_SANITIZATION = 'title,fulltitle,playlist_title,uploader,channel,series,chapter,album,artist';
 const DEFAULT_YTDLP_IMPERSONATION_ARG = '--impersonate=';
@@ -57,6 +81,76 @@ const SUBSCRIPTION_REFRESH_QUEUED_PHASE = 'queued';
 const SUBSCRIPTION_REFRESH_COMPLETE_PHASE = 'complete';
 let filename_sanitization_non_ytdlp_warned = false;
 let last_download_queue_start_at = 0;
+let check_downloads_in_progress = false;
+
+function truncateDownloadError(error_message = '') {
+    let normalized_message = error_message === null || error_message === undefined
+        ? ''
+        : String(error_message);
+
+    if (normalized_message.length > MAX_PERSISTED_DOWNLOAD_ERROR_LENGTH) {
+        const available_length = MAX_PERSISTED_DOWNLOAD_ERROR_LENGTH - DOWNLOAD_ERROR_TRUNCATION_MARKER.length;
+        const leading_length = Math.floor(available_length / 4);
+        const trailing_length = available_length - leading_length;
+        normalized_message = normalized_message.slice(0, leading_length)
+            + DOWNLOAD_ERROR_TRUNCATION_MARKER
+            + normalized_message.slice(-trailing_length);
+    }
+
+    normalized_message = normalized_message.replace(ANSI_ESCAPE_SEQUENCE_REGEX, '').trim();
+    if (normalized_message.length <= MAX_PERSISTED_DOWNLOAD_ERROR_LENGTH) return normalized_message;
+
+    return normalized_message.slice(0, MAX_PERSISTED_DOWNLOAD_ERROR_LENGTH);
+}
+exports.truncateDownloadError = truncateDownloadError;
+exports.MAX_PERSISTED_DOWNLOAD_ERROR_LENGTH = MAX_PERSISTED_DOWNLOAD_ERROR_LENGTH;
+exports.DOWNLOAD_ERROR_TRUNCATION_MARKER = DOWNLOAD_ERROR_TRUNCATION_MARKER.trim();
+
+function getCapturedOutputLength(output = null) {
+    if (output === null || output === undefined) return 0;
+    if (typeof output === 'string' || Buffer.isBuffer(output)) return output.length;
+    return String(output).length;
+}
+
+function formatDownloaderError(err, fallback_message = 'Downloader failed without an error message.') {
+    if (typeof err === 'string' || Buffer.isBuffer(err)) {
+        return truncateDownloadError(err) || fallback_message;
+    }
+
+    if (err && typeof err === 'object') {
+        // Execa's Error.message contains the command, stdout, and stderr. Persisting it
+        // duplicates captured media metadata and can make one queue record enormous.
+        // stderr contains yt-dlp's actionable diagnostic, so use it by itself when set.
+        const stderr = truncateDownloadError(err.stderr);
+        if (stderr) return stderr;
+
+        const short_message = truncateDownloadError(err.shortMessage);
+        if (short_message) return short_message;
+
+        const captured_stdout_length = getCapturedOutputLength(err.stdout);
+        if (err.message) {
+            let message = String(err.message);
+            if (captured_stdout_length > 0) {
+                const first_line_end = message.search(/\r?\n/);
+                if (first_line_end >= 0) message = message.slice(0, first_line_end);
+                message = `${message}\nCaptured stdout (${captured_stdout_length} characters) was omitted from this stored error.`;
+            }
+            return truncateDownloadError(message) || fallback_message;
+        }
+
+        if (captured_stdout_length > 0) {
+            return truncateDownloadError(
+                `The downloader produced no JSON error details. Captured stdout (${captured_stdout_length} characters) was omitted from this stored error.`
+            );
+        }
+    }
+
+    const primitive_message = truncateDownloadError(err);
+    return primitive_message && primitive_message !== '[object Object]'
+        ? primitive_message
+        : fallback_message;
+}
+exports.formatDownloaderError = formatDownloaderError;
 
 function asFiniteNumber(value, defaultValue = 0) {
     const numeric_value = Number(value);
@@ -1342,6 +1436,7 @@ exports.createDownload = async (url, type, options, user_uid = null, sub_id = nu
             running: false,
             finished_step: true,
             error: null,
+            error_summary: null,
             percent_complete: null,
             playlist_item_progress: null,
             finished: false,
@@ -1445,7 +1540,16 @@ exports.resumeDownload = async (download_uid) => {
 }
 
 exports.restartDownload = async (download_uid) => {
-    const download = await db_api.getRecord('download_queue', {uid: download_uid});
+    const downloads = await db_api.getRecords(
+        'download_queue',
+        {uid: download_uid},
+        false,
+        null,
+        [0, 1],
+        ['url', 'type', 'options', 'user_uid', 'sub_id', 'sub_name', 'prefetched_info', 'title']
+    );
+    const download = downloads.length > 0 ? downloads[0] : null;
+    if (!download) return false;
     await exports.clearDownload(download_uid);
     const new_download = await exports.createDownload(
         download['url'],
@@ -1481,15 +1585,53 @@ exports.cancelDownload = async (download_uid) => {
 }
 
 exports.clearDownload = async (download_uid) => {
-    const download = await db_api.getRecord('download_queue', {uid: download_uid});
+    const downloads = await db_api.getRecords(
+        'download_queue',
+        {uid: download_uid},
+        false,
+        null,
+        [0, 1],
+        [
+            'uid',
+            'sub_id',
+            'paused',
+            'finished',
+            'error_type',
+            'error_summary',
+            'type',
+            'user_uid',
+            'url',
+            'title',
+            'prefetched_info.0.webpage_url',
+            'prefetched_info.0.original_url',
+            'prefetched_info.0.url',
+            'prefetched_info.0.source_extractor',
+            'prefetched_info.0.extractor',
+            'prefetched_info.0.extractor_key',
+            'prefetched_info.0.ie_key',
+            'prefetched_info.0.source_id',
+            'prefetched_info.0.id',
+            'prefetched_info.0.display_id',
+            'prefetched_info.0.title'
+        ]
+    );
+    const download = downloads.length > 0 ? downloads[0] : null;
+    if (download && download['prefetched_info'] && !Array.isArray(download['prefetched_info'])) {
+        const first_prefetched_info = download['prefetched_info']['0'];
+        download['prefetched_info'] = first_prefetched_info ? [first_prefetched_info] : null;
+    }
     const should_archive_paused_subscription_skip = download && download['sub_id'] && download['paused'] && !download['finished'];
-    const should_archive_errored_subscription_skip = download && download['sub_id'] && download['error']
-        && isSkippableSubscriptionDownloadError(download['error'], download['error_type'])
-        && !isTransientSubscriptionDownloadError(download['error']);
+    const persisted_error_summary = download && typeof download['error_summary'] === 'string'
+        ? download['error_summary']
+        : '';
+    const should_archive_errored_subscription_skip = download && download['sub_id']
+        && (persisted_error_summary || download['error_type'])
+        && isSkippableSubscriptionDownloadError(persisted_error_summary, download['error_type'])
+        && !isTransientSubscriptionDownloadError(persisted_error_summary);
     if (should_archive_paused_subscription_skip) {
         await archiveSubscriptionDownloadBySource(download, 'after being cleared from the download queue');
     } else if (should_archive_errored_subscription_skip) {
-        await archiveSkippedSubscriptionDownload(download, download['error'], download['error_type']);
+        await archiveSkippedSubscriptionDownload(download, persisted_error_summary, download['error_type']);
     }
     return await db_api.removeRecord('download_queue', {uid: download_uid});
 }
@@ -1498,14 +1640,21 @@ async function handleDownloadError(download_uid, error_message, error_type = nul
     if (!download_uid) return;
     const download = await db_api.getRecord('download_queue', {uid: download_uid});
     if (!download || download['error']) return;
-    const is_skippable_subscription_error = download['sub_id'] && isSkippableSubscriptionDownloadError(error_message, error_type);
-    const is_transient_subscription_error = download['sub_id'] && isTransientSubscriptionDownloadError(error_message);
-    await archiveSkippedSubscriptionDownload(download, error_message, error_type);
+    const persisted_error_message = truncateDownloadError(error_message) || 'Unknown download error.';
+    const is_skippable_subscription_error = download['sub_id'] && isSkippableSubscriptionDownloadError(persisted_error_message, error_type);
+    const is_transient_subscription_error = download['sub_id'] && isTransientSubscriptionDownloadError(persisted_error_message);
+    await archiveSkippedSubscriptionDownload(download, persisted_error_message, error_type);
     if (!is_skippable_subscription_error) {
-        notifications_api.sendDownloadErrorNotification(download, download['user_uid'], error_message, error_type);
+        notifications_api.sendDownloadErrorNotification(download, download['user_uid'], persisted_error_message, error_type);
     }
-    await db_api.updateRecord('download_queue', {uid: download['uid']}, {error: error_message, finished: true, running: false, error_type: error_type});
-    await updateSubscriptionRefreshStatusForSkippedDownload(download, error_message, error_type);
+    await db_api.updateRecord('download_queue', {uid: download['uid']}, {
+        error: persisted_error_message,
+        error_summary: persisted_error_message,
+        finished: true,
+        running: false,
+        error_type: error_type
+    });
+    await updateSubscriptionRefreshStatusForSkippedDownload(download, persisted_error_message, error_type);
     if (is_transient_subscription_error) await db_api.removeRecord('download_queue', {uid: download['uid']});
 }
 
@@ -1577,16 +1726,11 @@ async function archiveSubscriptionDownloadBySource(download = null, reason = 'af
     }
 }
 
-function describeDownloadStepError(err = null) {
-    if (!err) return 'Unknown error';
-    if (typeof err === 'string') return err;
-    if (err.message) return err.message;
-    return String(err);
-}
-
 function runDownloadQueueStep(download_uid, step_description, step_runner, error_type) {
     Promise.resolve().then(() => step_runner(download_uid)).catch(async err => {
-        const error_message = `Unexpected error while ${step_description}: ${describeDownloadStepError(err)}`;
+        const error_message = truncateDownloadError(
+            `Unexpected error while ${step_description}: ${formatDownloaderError(err, 'Unknown error')}`
+        );
         logger.error(error_message);
         if (err && err.stack) logger.debug(err.stack);
         await handleDownloadError(download_uid, error_message, error_type);
@@ -1599,9 +1743,14 @@ exports.setupDownloads = async () => {
 }
 
 async function fixDownloadState() {
-    const downloads = await db_api.getRecords('download_queue');
-    downloads.sort((download1, download2) => download1.timestamp_start - download2.timestamp_start);
-    const running_downloads = downloads.filter(download => download['running'] && !download['finished'] && !download['error']);
+    const running_downloads = await db_api.getRecords(
+        'download_queue',
+        {running: true, finished: false, error: null},
+        false,
+        {by: 'timestamp_start', order: 1},
+        null,
+        ['uid', 'running', 'finished_step', 'step_index']
+    );
     for (let i = 0; i < running_downloads.length; i++) {
         await db_api.updateRecord('download_queue', {uid: running_downloads[i]['uid']}, getPausedDownloadUpdate(running_downloads[i]));
     }
@@ -1633,125 +1782,136 @@ function getResumedDownloadUpdate(download) {
 }
 
 async function checkDownloads() {
-    if (!should_check_downloads) return;
+    if (!should_check_downloads || check_downloads_in_progress) return;
+    check_downloads_in_progress = true;
 
-    const downloads = await db_api.getRecords('download_queue', {finished: false});
-    downloads.sort((download1, download2) => download1.timestamp_start - download2.timestamp_start);
+    try {
+        const downloads = await db_api.getRecords(
+            'download_queue',
+            {finished: false},
+            false,
+            {by: 'timestamp_start', order: 1},
+            null,
+            DOWNLOAD_QUEUE_CHECK_PROJECTION_FIELDS
+        );
 
-    await mutex.runExclusive(async () => {
-        // avoid checking downloads unnecessarily, but double check that should_check_downloads is still true
-        const running_downloads = downloads.filter(download => !download['paused'] && !download['finished']);
-        if (running_downloads.length === 0) {
-            should_check_downloads = false;
-            logger.verbose('Disabling checking downloads as none are available.');
-        }
-        return;
-    });
-
-    let running_downloads_count = downloads.filter(download => download['running']).length;
-    const waiting_downloads = downloads.filter(download => !download['paused'] && download['finished_step'] && !download['finished']);
-    const running_downloads = downloads.filter(download => download['running']);
-    const running_capped_queue_group_counts = new Map();
-
-    for (const running_download of running_downloads) {
-        const capped_queue_group = getCappedQueueGroup(running_download);
-        if (!capped_queue_group) continue;
-
-        const existing_group_count = running_capped_queue_group_counts.get(capped_queue_group.key) || 0;
-        running_capped_queue_group_counts.set(capped_queue_group.key, existing_group_count + 1);
-    }
-
-    const running_exclusive_downloads = running_downloads
-        .filter(download => isExclusivePlaylistDownload(download))
-        .sort((download1, download2) => download1.timestamp_start - download2.timestamp_start);
-    const waiting_exclusive_downloads = waiting_downloads
-        .filter(download => isExclusivePlaylistDownload(download))
-        .sort((download1, download2) => download1.timestamp_start - download2.timestamp_start);
-
-    let exclusive_playlist_group_key = null;
-    if (running_exclusive_downloads.length > 0) {
-        exclusive_playlist_group_key = getExclusivePlaylistGroupKey(running_exclusive_downloads[0]);
-    } else if (waiting_exclusive_downloads.length > 0) {
-        exclusive_playlist_group_key = getExclusivePlaylistGroupKey(waiting_exclusive_downloads[0]);
-    }
-    let running_exclusive_group_count = exclusive_playlist_group_key
-        ? running_exclusive_downloads.filter(download => getExclusivePlaylistGroupKey(download) === exclusive_playlist_group_key).length
-        : 0;
-    const exclusive_playlist_concurrency_limit = getExclusivePlaylistConcurrencyLimit();
-    const minimum_sleep_between_downloads_ms = getMinimumSleepBetweenDownloadsMs();
-
-    for (let i = 0; i < waiting_downloads.length; i++) {
-        const waiting_download = waiting_downloads[i];
-        const waiting_download_is_exclusive = isExclusivePlaylistDownload(waiting_download);
-        const waiting_download_group_key = waiting_download_is_exclusive ? getExclusivePlaylistGroupKey(waiting_download) : null;
-
-        if (exclusive_playlist_group_key) {
-            if (!waiting_download_is_exclusive || waiting_download_group_key !== exclusive_playlist_group_key) {
-                continue;
+        await mutex.runExclusive(async () => {
+            // avoid checking downloads unnecessarily, but double check that should_check_downloads is still true
+            const running_downloads = downloads.filter(download => !download['paused'] && !download['finished']);
+            if (running_downloads.length === 0) {
+                should_check_downloads = false;
+                logger.verbose('Disabling checking downloads as none are available.');
             }
+            return;
+        });
 
-            const has_running_download_outside_group = running_downloads.some(download => {
-                if (!download['running']) return false;
-                if (!isExclusivePlaylistDownload(download)) return true;
-                return getExclusivePlaylistGroupKey(download) !== exclusive_playlist_group_key;
-            });
-            if (has_running_download_outside_group) {
-                continue;
-            }
+        let running_downloads_count = downloads.filter(download => download['running']).length;
+        const waiting_downloads = downloads.filter(download => !download['paused'] && download['finished_step'] && !download['finished']);
+        const running_downloads = downloads.filter(download => download['running']);
+        const running_capped_queue_group_counts = new Map();
 
-            if (running_exclusive_group_count >= exclusive_playlist_concurrency_limit) {
-                continue;
-            }
-        } else {
-            const max_concurrent_downloads = config_api.getConfigItem('ytdl_max_concurrent_downloads');
-            if (hasReachedConcurrentDownloadLimit(max_concurrent_downloads, running_downloads_count)) break;
+        for (const running_download of running_downloads) {
+            const capped_queue_group = getCappedQueueGroup(running_download);
+            if (!capped_queue_group) continue;
+
+            const existing_group_count = running_capped_queue_group_counts.get(capped_queue_group.key) || 0;
+            running_capped_queue_group_counts.set(capped_queue_group.key, existing_group_count + 1);
         }
 
-        const capped_queue_group = getCappedQueueGroup(waiting_download);
-        if (capped_queue_group) {
-            const running_group_count = running_capped_queue_group_counts.get(capped_queue_group.key) || 0;
-            if (running_group_count >= capped_queue_group.limit) {
-                continue;
-            }
+        const running_exclusive_downloads = running_downloads
+            .filter(download => isExclusivePlaylistDownload(download))
+            .sort((download1, download2) => download1.timestamp_start - download2.timestamp_start);
+        const waiting_exclusive_downloads = waiting_downloads
+            .filter(download => isExclusivePlaylistDownload(download))
+            .sort((download1, download2) => download1.timestamp_start - download2.timestamp_start);
+
+        let exclusive_playlist_group_key = null;
+        if (running_exclusive_downloads.length > 0) {
+            exclusive_playlist_group_key = getExclusivePlaylistGroupKey(running_exclusive_downloads[0]);
+        } else if (waiting_exclusive_downloads.length > 0) {
+            exclusive_playlist_group_key = getExclusivePlaylistGroupKey(waiting_exclusive_downloads[0]);
         }
+        let running_exclusive_group_count = exclusive_playlist_group_key
+            ? running_exclusive_downloads.filter(download => getExclusivePlaylistGroupKey(download) === exclusive_playlist_group_key).length
+            : 0;
+        const exclusive_playlist_concurrency_limit = getExclusivePlaylistConcurrencyLimit();
+        const minimum_sleep_between_downloads_ms = getMinimumSleepBetweenDownloadsMs();
 
-        if (waiting_download['finished_step'] && !waiting_download['finished']) {
-            if (getRemainingSleepBeforeNextDownloadStartMs(minimum_sleep_between_downloads_ms) > 0) {
-                break;
+        for (let i = 0; i < waiting_downloads.length; i++) {
+            const waiting_download = waiting_downloads[i];
+            const waiting_download_is_exclusive = isExclusivePlaylistDownload(waiting_download);
+            const waiting_download_group_key = waiting_download_is_exclusive ? getExclusivePlaylistGroupKey(waiting_download) : null;
+
+            if (exclusive_playlist_group_key) {
+                if (!waiting_download_is_exclusive || waiting_download_group_key !== exclusive_playlist_group_key) {
+                    continue;
+                }
+
+                const has_running_download_outside_group = running_downloads.some(download => {
+                    if (!download['running']) return false;
+                    if (!isExclusivePlaylistDownload(download)) return true;
+                    return getExclusivePlaylistGroupKey(download) !== exclusive_playlist_group_key;
+                });
+                if (has_running_download_outside_group) {
+                    continue;
+                }
+
+                if (running_exclusive_group_count >= exclusive_playlist_concurrency_limit) {
+                    continue;
+                }
+            } else {
+                const max_concurrent_downloads = config_api.getConfigItem('ytdl_max_concurrent_downloads');
+                if (hasReachedConcurrentDownloadLimit(max_concurrent_downloads, running_downloads_count)) break;
             }
 
-            if (waiting_download['sub_id']) {
-                const sub_missing = !(await db_api.getRecord('subscriptions', {id: waiting_download['sub_id']}));
-                if (sub_missing) {
-                    handleDownloadError(waiting_download['uid'], `Download failed as subscription with id '${waiting_download['sub_id']}' is missing!`, 'sub_id_missing');
+            const capped_queue_group = getCappedQueueGroup(waiting_download);
+            if (capped_queue_group) {
+                const running_group_count = running_capped_queue_group_counts.get(capped_queue_group.key) || 0;
+                if (running_group_count >= capped_queue_group.limit) {
                     continue;
                 }
             }
-            // move to next step
-            running_downloads_count++;
-            markDownloadQueueStart(minimum_sleep_between_downloads_ms);
-            if (waiting_download['step_index'] === 0) {
-                runDownloadQueueStep(waiting_download['uid'], 'getting download info', exports.collectInfo, 'info_retrieve_failed');
-            } else if (waiting_download['step_index'] === 1) {
-                runDownloadQueueStep(waiting_download['uid'], 'downloading file', exports.downloadQueuedFile, 'unknown_error');
-            }
 
-            if (capped_queue_group) {
-                const updated_group_count = (running_capped_queue_group_counts.get(capped_queue_group.key) || 0) + 1;
-                running_capped_queue_group_counts.set(capped_queue_group.key, updated_group_count);
-            }
+            if (waiting_download['finished_step'] && !waiting_download['finished']) {
+                if (getRemainingSleepBeforeNextDownloadStartMs(minimum_sleep_between_downloads_ms) > 0) {
+                    break;
+                }
 
-            if (exclusive_playlist_group_key && waiting_download_group_key === exclusive_playlist_group_key) {
-                running_exclusive_group_count++;
-                if (running_exclusive_group_count >= exclusive_playlist_concurrency_limit) {
+                if (waiting_download['sub_id']) {
+                    const sub_missing = !(await db_api.getRecord('subscriptions', {id: waiting_download['sub_id']}));
+                    if (sub_missing) {
+                        handleDownloadError(waiting_download['uid'], `Download failed as subscription with id '${waiting_download['sub_id']}' is missing!`, 'sub_id_missing');
+                        continue;
+                    }
+                }
+                // move to next step
+                running_downloads_count++;
+                markDownloadQueueStart(minimum_sleep_between_downloads_ms);
+                if (waiting_download['step_index'] === 0) {
+                    runDownloadQueueStep(waiting_download['uid'], 'getting download info', exports.collectInfo, 'info_retrieve_failed');
+                } else if (waiting_download['step_index'] === 1) {
+                    runDownloadQueueStep(waiting_download['uid'], 'downloading file', exports.downloadQueuedFile, 'unknown_error');
+                }
+
+                if (capped_queue_group) {
+                    const updated_group_count = (running_capped_queue_group_counts.get(capped_queue_group.key) || 0) + 1;
+                    running_capped_queue_group_counts.set(capped_queue_group.key, updated_group_count);
+                }
+
+                if (exclusive_playlist_group_key && waiting_download_group_key === exclusive_playlist_group_key) {
+                    running_exclusive_group_count++;
+                    if (running_exclusive_group_count >= exclusive_playlist_concurrency_limit) {
+                        break;
+                    }
+                }
+
+                if (minimum_sleep_between_downloads_ms > 0) {
                     break;
                 }
             }
-
-            if (minimum_sleep_between_downloads_ms > 0) {
-                break;
-            }
         }
+    } finally {
+        check_downloads_in_progress = false;
     }
 }
 exports.checkDownloads = checkDownloads;
@@ -1964,8 +2124,9 @@ exports.downloadQueuedFile = async(download_uid, customDownloadHandler = null) =
         if (!parsed_output) {
             const errored_download = await db_api.getRecord('download_queue', {uid: download_uid});
             if (errored_download && errored_download['paused']) return;
-            logger.error(err.toString());
-            await handleDownloadError(download_uid, err.toString(), 'unknown_error');
+            const error_message = formatDownloaderError(err);
+            logger.error(error_message);
+            await handleDownloadError(download_uid, error_message, 'unknown_error');
             resolve(false);
             return;
         } else if (parsed_output) {
@@ -2392,25 +2553,10 @@ function filterInfoLookupArgs(args = []) {
 }
 
 function describeInfoLookupError(err, downloader_fork = 'downloader') {
-    const details = [];
-    const addDetail = (detail) => {
-        if (detail === null || detail === undefined) return;
-        const detail_text = String(detail).trim();
-        if (detail_text && !details.includes(detail_text)) details.push(detail_text);
-    };
-
-    if (typeof err === 'string') {
-        addDetail(err);
-    } else if (err && typeof err === 'object') {
-        addDetail(err.message);
-        addDetail(err.stderr);
-        addDetail(err.stdout ? `stdout: ${err.stdout}` : null);
-    } else {
-        addDetail(err);
-    }
-
-    if (details.length > 0) return details.join('\n\n');
-    return `${downloader_fork} returned no JSON output and did not provide stderr.`;
+    return formatDownloaderError(
+        err,
+        `${downloader_fork} returned no JSON output and did not provide stderr.`
+    );
 }
 
 exports.getVideoInfoByURL = async (url, args = [], download_uid = null, options = {}) => {

--- a/backend/postgres-store.js
+++ b/backend/postgres-store.js
@@ -306,6 +306,41 @@ function buildRangeClause(range = null, params = []) {
     return ` OFFSET ${offsetPlaceholder} LIMIT ${limitPlaceholder}`;
 }
 
+function buildProjectionTree(projectionFields = []) {
+    const root = {children: new Map(), included: false};
+    for (const fieldPath of projectionFields) {
+        const pathParts = getFieldPathParts(fieldPath);
+        let currentNode = root;
+        for (const pathPart of pathParts) {
+            if (!currentNode.children.has(pathPart)) {
+                currentNode.children.set(pathPart, {children: new Map(), included: false});
+            }
+            currentNode = currentNode.children.get(pathPart);
+        }
+        currentNode.included = true;
+    }
+    return root;
+}
+
+function buildProjectionObjectExpression(projectionNode, pathParts = [], docRef = 'doc') {
+    const objectParts = [];
+    for (const [fieldName, childNode] of projectionNode.children.entries()) {
+        const childPathParts = [...pathParts, fieldName];
+        const valueExpression = childNode.included
+            ? `${docRef} #> ${toPathLiteral(childPathParts)}`
+            : buildProjectionObjectExpression(childNode, childPathParts, docRef);
+        objectParts.push(`'${fieldName}', ${valueExpression}`);
+    }
+
+    if (objectParts.length === 0) return "'{}'::jsonb";
+    return `jsonb_strip_nulls(jsonb_build_object(${objectParts.join(', ')}))`;
+}
+
+function buildProjectionExpression(projectionFields = null, docRef = 'doc') {
+    if (!Array.isArray(projectionFields) || projectionFields.length === 0) return docRef;
+    return buildProjectionObjectExpression(buildProjectionTree(projectionFields), [], docRef);
+}
+
 function extractDocKey(tableMeta = {}, doc = {}) {
     const primaryKey = getPrimaryKey(tableMeta);
     if (!primaryKey || !doc || typeof doc !== 'object') return null;
@@ -649,7 +684,7 @@ async function getRecord(pool, tables, tableName, filterObj = null) {
     return records.length > 0 ? records[0] : null;
 }
 
-async function getRecords(pool, tables, tableName, filterObj = null, returnCount = false, sort = null, range = null) {
+async function getRecords(pool, tables, tableName, filterObj = null, returnCount = false, sort = null, range = null, projectionFields = null) {
     const tableMeta = tables[tableName];
     const tableIdentifier = quoteIdentifier(tableName);
     const params = [];
@@ -662,7 +697,10 @@ async function getRecords(pool, tables, tableName, filterObj = null, returnCount
 
     const sortClause = buildSortClause(tableMeta, sort, params);
     const rangeClause = buildRangeClause(range, params);
-    const result = await pool.query(`SELECT doc FROM ${tableIdentifier} WHERE ${whereClause}${sortClause}${rangeClause}`, params);
+    const selectExpression = Array.isArray(projectionFields) && projectionFields.length > 0
+        ? `${buildProjectionExpression(projectionFields)} AS doc`
+        : 'doc';
+    const result = await pool.query(`SELECT ${selectExpression} FROM ${tableIdentifier} WHERE ${whereClause}${sortClause}${rangeClause}`, params);
     return result.rows.map(row => row.doc);
 }
 

--- a/backend/subscriptions.js
+++ b/backend/subscriptions.js
@@ -25,6 +25,15 @@ const SUBSCRIPTION_REFRESH_PHASES = Object.freeze({
 });
 const SUBSCRIPTION_REFRESH_COUNT_WRITE_INTERVAL = 5;
 const SUBSCRIPTION_QUEUE_BATCH_SIZE = 50;
+const SUBSCRIPTION_EXPECTED_SIZE_FORMAT_FIELDS = Object.freeze([
+    'format_id',
+    'filesize',
+    'filesize_approx',
+    'duration',
+    'tbr',
+    'vbr',
+    'abr'
+]);
 const MATCH_FILTER_ARGS = new Set(['--match-filter', '--match-filters']);
 const BREAK_MATCH_FILTER_ARGS = new Set(['--break-match-filter', '--break-match-filters']);
 const NO_MATCH_FILTER_ARGS = new Set(['--no-match-filter', '--no-match-filters']);
@@ -1380,7 +1389,9 @@ async function handleOutputJSON(output_jsons, sub, user_uid, refresh_tracker = n
         const prefetched_info = getSubscriptionPrefetchedInfoForDownload(file_to_download);
         if (prefetched_info && Array.isArray(file_to_download['formats'])) {
             // Keep subscription queue payloads small when full info is available.
-            file_to_download['formats'] = utils.stripPropertiesFromObject(file_to_download['formats'], ['format_id', 'filesize', 'filesize_approx']);
+            file_to_download['formats'] = file_to_download['formats']
+                .filter(format => !!format && typeof format === 'object')
+                .map(format => utils.stripPropertiesFromObject(format, SUBSCRIPTION_EXPECTED_SIZE_FORMAT_FIELDS, true));
         }
         await downloader_api.createDownload(file_to_download['webpage_url'], sub.type || 'video', effective_queue_context.base_download_options, user_uid, sub.id, sub.name, prefetched_info);
         effective_queue_context.queued_count += 1;

--- a/backend/test/database.test.js
+++ b/backend/test/database.test.js
@@ -241,6 +241,59 @@ describe('Database', async function() {
                     ]);
                 });
 
+                it('Projects only selected fields after sorting and ranging local records', async function() {
+                    const heavyweight_error = 'large captured process output'.repeat(1000);
+                    await db_api.insertRecordsIntoTable('test', [
+                        {
+                            uid: 'projection-older',
+                            timestamp_start: 1,
+                            error: heavyweight_error,
+                            prefetched_info: [{description: heavyweight_error}],
+                            options: {
+                                playlistBatchId: 'batch-older',
+                                additionalArgs: [heavyweight_error]
+                            }
+                        },
+                        {
+                            uid: 'projection-newer',
+                            timestamp_start: 2,
+                            error: heavyweight_error,
+                            prefetched_info: [{description: heavyweight_error}],
+                            container: {
+                                id: 'playlist-1',
+                                uids: Array(1000).fill('file-uid')
+                            },
+                            options: {
+                                playlistBatchId: 'batch-newer',
+                                playlistChunkRange: '1-10',
+                                additionalArgs: [heavyweight_error]
+                            }
+                        }
+                    ]);
+
+                    const projected_records = await db_api.getRecords(
+                        'test',
+                        null,
+                        false,
+                        {by: 'timestamp_start', order: -1},
+                        [0, 1],
+                        ['uid', 'timestamp_start', 'container.id', 'options.playlistBatchId', 'options.playlistChunkRange']
+                    );
+
+                    assert.deepStrictEqual(projected_records, [{
+                        uid: 'projection-newer',
+                        timestamp_start: 2,
+                        container: {id: 'playlist-1'},
+                        options: {
+                            playlistBatchId: 'batch-newer',
+                            playlistChunkRange: '1-10'
+                        }
+                    }]);
+                    assert.strictEqual(Object.prototype.hasOwnProperty.call(projected_records[0], 'error'), false);
+                    assert.strictEqual(Object.prototype.hasOwnProperty.call(projected_records[0], 'prefetched_info'), false);
+                    assert.strictEqual(Object.prototype.hasOwnProperty.call(projected_records[0].options, 'additionalArgs'), false);
+                });
+
                 it.skip('Query speed', async function() {
                     this.timeout(120000); 
                     const NUM_RECORDS_TO_ADD = 300004; // max batch ops is 1000

--- a/backend/test/downloader.test.js
+++ b/backend/test/downloader.test.js
@@ -176,6 +176,34 @@ describe('Downloader', function() {
         assert.strictEqual(failed_download.error_type, 'info_retrieve_failed');
     });
 
+    it('Get file info persists stderr without captured stdout or duplicated Execa output', async function() {
+        const original_runYoutubeDL = youtubedl_api.runYoutubeDL;
+        const returned_download = await downloader_api.createDownload(url, 'video', options);
+        const captured_stdout = `CAPTURED_STDOUT_SHOULD_NOT_BE_STORED:${'x'.repeat(20000)}`;
+        const actionable_stderr = 'ERROR: [youtube] test-id: Video unavailable';
+        const execa_error = new Error(`Command failed with exit code 1\n${captured_stdout}\n${actionable_stderr}`);
+        execa_error.stdout = captured_stdout;
+        execa_error.stderr = actionable_stderr;
+
+        youtubedl_api.runYoutubeDL = async () => ({
+            callback: Promise.resolve({parsed_output: null, err: execa_error})
+        });
+
+        try {
+            const info = await _originalGetVideoInfoByURL(url, [], returned_download.uid);
+            assert.strictEqual(info, null);
+        } finally {
+            youtubedl_api.runYoutubeDL = original_runYoutubeDL;
+        }
+
+        const failed_download = await db_api.getRecord('download_queue', {uid: returned_download.uid});
+        assert(failed_download.error.includes(actionable_stderr));
+        assert(!failed_download.error.includes('CAPTURED_STDOUT_SHOULD_NOT_BE_STORED'));
+        assert(!failed_download.error.includes('Command failed with exit code 1'));
+        assert(failed_download.error.length <= downloader_api.MAX_PERSISTED_DOWNLOAD_ERROR_LENGTH);
+        assert.strictEqual(failed_download.error_summary, failed_download.error);
+    });
+
     it('Get file info uses yt-dlp when an audio language is requested', async function() {
         let captured_fork = null;
         const original_runYoutubeDL = youtubedl_api.runYoutubeDL;
@@ -385,6 +413,43 @@ describe('Downloader', function() {
         assert(success);
     });
 
+    it('Download failure persists a bounded stderr diagnostic', async function() {
+        const original_runYoutubeDL = youtubedl_api.runYoutubeDL;
+        const returned_download = await downloader_api.createDownload(url, 'video', options);
+        const captured_stdout = `CAPTURED_DOWNLOAD_STDOUT_SHOULD_NOT_BE_STORED:${'j'.repeat(20000)}`;
+        const oversized_stderr = `ERROR: actionable download failure\n${'detail '.repeat(3000)}\nFINAL ERROR DETAIL`;
+        const execa_error = new Error(`Command failed with exit code 1\n${captured_stdout}\n${oversized_stderr}`);
+        execa_error.stdout = captured_stdout;
+        execa_error.stderr = oversized_stderr;
+
+        await db_api.updateRecord('download_queue', {uid: returned_download.uid}, {
+            args: [],
+            finished_step: true,
+            step_index: 1
+        });
+        youtubedl_api.runYoutubeDL = async () => ({
+            child_process: null,
+            callback: Promise.resolve({parsed_output: null, err: execa_error})
+        });
+
+        try {
+            const success = await downloader_api.downloadQueuedFile(returned_download.uid);
+            assert.strictEqual(success, false);
+        } finally {
+            youtubedl_api.runYoutubeDL = original_runYoutubeDL;
+        }
+
+        const failed_download = await db_api.getRecord('download_queue', {uid: returned_download.uid});
+        assert.strictEqual(failed_download.error_type, 'unknown_error');
+        assert.strictEqual(failed_download.error.length, downloader_api.MAX_PERSISTED_DOWNLOAD_ERROR_LENGTH);
+        assert(failed_download.error.includes('ERROR: actionable download failure'));
+        assert(failed_download.error.includes('FINAL ERROR DETAIL'));
+        assert(failed_download.error.includes(downloader_api.DOWNLOAD_ERROR_TRUNCATION_MARKER));
+        assert(!failed_download.error.includes('CAPTURED_DOWNLOAD_STDOUT_SHOULD_NOT_BE_STORED'));
+        assert(!failed_download.error.includes('Command failed with exit code 1'));
+        assert.strictEqual(failed_download.error_summary, failed_download.error);
+    });
+
     it('Archives no-output subscription downloads so future refreshes skip them', async function() {
         const prefetched_info = [{
             _type: 'url',
@@ -591,11 +656,15 @@ describe('Downloader', function() {
         const original_max_concurrent_downloads = config_api.getConfigItem('ytdl_max_concurrent_downloads');
         const original_collect_info = downloader_api.collectInfo;
         const returned_download = await downloader_api.createDownload(`${url}&throwing_collect_info=1`, 'video', {ui_uid: uuid()});
+        const captured_stdout = `QUEUE_STEP_STDOUT_SHOULD_NOT_BE_STORED:${'x'.repeat(20000)}`;
 
         try {
             config_api.setConfigItem('ytdl_max_concurrent_downloads', 1);
             downloader_api.collectInfo = () => {
-                throw new Error('synthetic collectInfo failure');
+                const queue_step_error = new Error(`Command failed\n${captured_stdout}`);
+                queue_step_error.stdout = captured_stdout;
+                queue_step_error.stderr = 'synthetic collectInfo failure';
+                throw queue_step_error;
             };
 
             await downloader_api.checkDownloads();
@@ -614,11 +683,15 @@ describe('Downloader', function() {
         assert.strictEqual(updated_download.running, false);
         assert.strictEqual(updated_download.error_type, 'info_retrieve_failed');
         assert(updated_download.error.includes('synthetic collectInfo failure'));
+        assert(!updated_download.error.includes('QUEUE_STEP_STDOUT_SHOULD_NOT_BE_STORED'));
+        assert.strictEqual(updated_download.error_summary, updated_download.error);
     });
 
     it('fixDownloadState only pauses downloads that were actively running', async function() {
+        const original_get_records = db_api.getRecords;
         const running_download = await downloader_api.createDownload(`${url}&running_recovery=1`, 'video', {ui_uid: uuid()});
         const waiting_download = await downloader_api.createDownload(`${url}&waiting_recovery=1`, 'video', {ui_uid: uuid()});
+        let recovery_query_args = null;
 
         await db_api.updateRecord('download_queue', {uid: running_download['uid']}, {
             step_index: 1,
@@ -626,11 +699,28 @@ describe('Downloader', function() {
             running: true
         });
 
-        await downloader_api.fixDownloadState();
+        db_api.getRecords = async (...args) => {
+            recovery_query_args = args;
+            return await original_get_records(...args);
+        };
+
+        try {
+            await downloader_api.fixDownloadState();
+        } finally {
+            db_api.getRecords = original_get_records;
+        }
 
         const recovered_running_download = await db_api.getRecord('download_queue', {uid: running_download['uid']});
         const recovered_waiting_download = await db_api.getRecord('download_queue', {uid: waiting_download['uid']});
 
+        assert.deepStrictEqual(recovery_query_args, [
+            'download_queue',
+            {running: true, finished: false, error: null},
+            false,
+            {by: 'timestamp_start', order: 1},
+            null,
+            ['uid', 'running', 'finished_step', 'step_index']
+        ]);
         assert.strictEqual(recovered_running_download.paused, true);
         assert.strictEqual(recovered_running_download.running, false);
         assert.strictEqual(recovered_running_download.finished_step, true);
@@ -640,6 +730,101 @@ describe('Downloader', function() {
         assert.strictEqual(recovered_waiting_download.running, false);
         assert.strictEqual(recovered_waiting_download.finished_step, true);
         assert.strictEqual(recovered_waiting_download.step_index, 0);
+    });
+
+    it('Does not overlap download queue checks', async function() {
+        const original_get_records = db_api.getRecords;
+        let release_first_query;
+        let mark_first_query_started;
+        let queue_query_count = 0;
+        const first_query_started = new Promise(resolve => {
+            mark_first_query_started = resolve;
+        });
+        const first_query_release = new Promise(resolve => {
+            release_first_query = resolve;
+        });
+
+        await downloader_api.createDownload(`${url}&overlapping_queue_checks=1`, 'video', {ui_uid: uuid()}, null, null, null, null, true);
+        db_api.getRecords = async (...args) => {
+            if (args[0] === 'download_queue' && args[1] && args[1].finished === false) {
+                queue_query_count += 1;
+                if (queue_query_count === 1) {
+                    mark_first_query_started();
+                    await first_query_release;
+                }
+            }
+            return await original_get_records(...args);
+        };
+
+        try {
+            const first_check = downloader_api.checkDownloads();
+            await first_query_started;
+            await downloader_api.checkDownloads();
+            assert.strictEqual(queue_query_count, 1);
+            release_first_query();
+            await first_check;
+        } finally {
+            release_first_query();
+            db_api.getRecords = original_get_records;
+        }
+    });
+
+    it('Queries only scheduler fields while checking the download queue', async function() {
+        const original_get_records = db_api.getRecords;
+        const heavy_prefetched_info = [{
+            id: 'heavy-prefetched-info',
+            formats: [{format_id: 'heavy', url: 'x'.repeat(20000)}]
+        }];
+        const queued_download = await downloader_api.createDownload(
+            `${url}&projected_queue_check=1`,
+            'video',
+            {
+                ui_uid: uuid(),
+                concurrentQueueGroupKey: 'projection-test',
+                concurrentQueueGroupLimit: 1
+            },
+            null,
+            null,
+            null,
+            heavy_prefetched_info,
+            true
+        );
+        await db_api.updateRecord('download_queue', {uid: queued_download.uid}, {
+            args: ['--heavy-arg', 'y'.repeat(20000)],
+            error: `legacy-heavy-error:${'z'.repeat(20000)}`,
+            playlist_item_progress: [{title: 'heavy-progress', detail: 'p'.repeat(20000)}]
+        });
+
+        let queue_query_args = null;
+        let projected_download = null;
+        db_api.getRecords = async (...args) => {
+            const records = await original_get_records(...args);
+            if (args[0] === 'download_queue' && args[1] && args[1].finished === false) {
+                queue_query_args = args;
+                projected_download = records.find(download => download.uid === queued_download.uid);
+            }
+            return records;
+        };
+
+        try {
+            await downloader_api.checkDownloads();
+        } finally {
+            db_api.getRecords = original_get_records;
+        }
+
+        assert(queue_query_args);
+        assert.deepStrictEqual(queue_query_args[3], {by: 'timestamp_start', order: 1});
+        assert(Array.isArray(queue_query_args[5]));
+        assert(!queue_query_args[5].includes('prefetched_info'));
+        assert(!queue_query_args[5].includes('args'));
+        assert(!queue_query_args[5].includes('error'));
+        assert(!queue_query_args[5].includes('playlist_item_progress'));
+        assert(projected_download);
+        assert.strictEqual(projected_download.prefetched_info, undefined);
+        assert.strictEqual(projected_download.args, undefined);
+        assert.strictEqual(projected_download.error, undefined);
+        assert.strictEqual(projected_download.playlist_item_progress, undefined);
+        assert.strictEqual(projected_download.options.concurrentQueueGroupKey, 'projection-test');
     });
 
     it('Restart download preserves subscription metadata', async function() {

--- a/backend/test/postgres-db.test.js
+++ b/backend/test/postgres-db.test.js
@@ -40,6 +40,39 @@ describe('PostgreSQL backend integration points', function() {
     function createFakeMongoClientCtor(options = {}) {
         const databaseName = options.databaseName || 'ytdl_material';
         const clone = value => JSON.parse(JSON.stringify(value));
+        const getValueByPath = (record, fieldPath) => {
+            return fieldPath.split('.').reduce((value, pathPart) => {
+                return value && Object.prototype.hasOwnProperty.call(value, pathPart)
+                    ? value[pathPart]
+                    : undefined;
+            }, record);
+        };
+        const setValueByPath = (record, fieldPath, value) => {
+            const pathParts = fieldPath.split('.');
+            let currentRecord = record;
+            pathParts.forEach((pathPart, index) => {
+                if (index === pathParts.length - 1) {
+                    currentRecord[pathPart] = clone(value);
+                    return;
+                }
+                if (!currentRecord[pathPart]) currentRecord[pathPart] = {};
+                currentRecord = currentRecord[pathPart];
+            });
+        };
+        const applyProjection = (record, projection = null) => {
+            if (!projection) return clone(record);
+            const includedFields = Object.entries(projection)
+                .filter(([fieldPath, include]) => fieldPath !== '_id' && Number(include) === 1)
+                .map(([fieldPath]) => fieldPath);
+            if (includedFields.length === 0) return clone(record);
+
+            const projectedRecord = {};
+            includedFields.forEach(fieldPath => {
+                const value = getValueByPath(record, fieldPath);
+                if (value !== undefined) setValueByPath(projectedRecord, fieldPath, value);
+            });
+            return projectedRecord;
+        };
 
         class FakeMongoDatabase {
             constructor(initialCollections = {}, behavior = {}) {
@@ -108,9 +141,23 @@ describe('PostgreSQL backend integration points', function() {
                         const collection = database.collections.get(collectionName);
                         return collection && collection.docs.length > 0 ? clone(collection.docs[0]) : null;
                     },
-                    find: () => ({
-                        toArray: async () => clone((database.collections.get(collectionName) || { docs: [] }).docs)
-                    })
+                    find: () => {
+                        let projection = null;
+                        const cursor = {
+                            sort: () => cursor,
+                            skip: () => cursor,
+                            limit: () => cursor,
+                            project: nextProjection => {
+                                projection = clone(nextProjection);
+                                return cursor;
+                            },
+                            toArray: async () => {
+                                const docs = (database.collections.get(collectionName) || { docs: [] }).docs;
+                                return docs.map(doc => applyProjection(doc, projection));
+                            }
+                        };
+                        return cursor;
+                    }
                 };
             }
 
@@ -231,6 +278,56 @@ describe('PostgreSQL backend integration points', function() {
 
         assert.strictEqual(capturedQuery, 'SELECT doc FROM "download_queue" WHERE jsonb_extract_path(doc, VARIADIC $1::text[]) = $2::jsonb');
         assert.deepStrictEqual(capturedParams, [['finished'], 'false']);
+    });
+
+    it('projects selected PostgreSQL JSON fields before returning records', async function() {
+        let capturedQuery = null;
+        let capturedParams = null;
+        const fakePool = {
+            query: async (queryText, params) => {
+                capturedQuery = queryText;
+                capturedParams = params;
+                return {
+                    rows: [{
+                        doc: {
+                            uid: 'download-1',
+                            options: {playlistBatchId: 'batch-1'}
+                        }
+                    }]
+                };
+            }
+        };
+
+        const records = await postgres_store.getRecords(
+            fakePool,
+            {
+                download_queue: {
+                    primary_key: 'uid',
+                    field_types: {
+                        uid: 'text',
+                        timestamp_start: 'numeric'
+                    }
+                }
+            },
+            'download_queue',
+            null,
+            false,
+            {by: 'timestamp_start', order: -1},
+            [0, 20],
+            ['uid', 'options.playlistBatchId']
+        );
+
+        assert(capturedQuery.startsWith("SELECT jsonb_strip_nulls(jsonb_build_object('uid', doc #> '{uid}', 'options', jsonb_strip_nulls(jsonb_build_object('playlistBatchId', doc #> '{options,playlistBatchId}')))) AS doc"));
+        assert(capturedQuery.includes('ORDER BY CASE WHEN'));
+        assert(capturedQuery.includes('DESC NULLS LAST'));
+        assert(capturedQuery.endsWith(' OFFSET $2 LIMIT $3'));
+        assert(!capturedQuery.includes('prefetched_info'));
+        assert(!capturedQuery.includes("'error'"));
+        assert.deepStrictEqual(capturedParams, [['timestamp_start'], 0, 20]);
+        assert.deepStrictEqual(records, [{
+            uid: 'download-1',
+            options: {playlistBatchId: 'batch-1'}
+        }]);
     });
 
     it('serializes undefined update values as JSON null for PostgreSQL updates', async function() {
@@ -377,6 +474,46 @@ describe('PostgreSQL backend integration points', function() {
         assert(calls.some(call => call.name === 'updateRecord'));
         assert(calls.some(call => call.name === 'removeRecord'));
         assert(calls.some(call => call.name === 'getTableStats'));
+    });
+
+    it('uses an inclusion projection for MongoDB reads', async function() {
+        config_api.setConfigItem('ytdl_use_local_db', false);
+        config_api.setConfigItem('ytdl_remote_db_type', 'mongo');
+        config_api.setConfigItem('ytdl_mongodb_connection_string', 'mongodb://projection-db');
+
+        const heavyweightValue = 'captured output'.repeat(1000);
+        const { FakeMongoClient } = createFakeMongoClientCtor({
+            collectionsByConnectionString: {
+                'mongodb://projection-db': {
+                    download_queue: [{
+                        uid: 'download-1',
+                        error: heavyweightValue,
+                        prefetched_info: [{description: heavyweightValue}],
+                        options: {
+                            playlistBatchId: 'batch-1',
+                            additionalArgs: [heavyweightValue]
+                        }
+                    }]
+                }
+            }
+        });
+        db_api.setMongoClientCtor(FakeMongoClient);
+
+        const connected = await db_api.connectToDB(0, true);
+        const records = await db_api.getRecords(
+            'download_queue',
+            null,
+            false,
+            null,
+            null,
+            ['uid', 'options.playlistBatchId']
+        );
+
+        assert.strictEqual(connected, true);
+        assert.deepStrictEqual(records, [{
+            uid: 'download-1',
+            options: {playlistBatchId: 'batch-1'}
+        }]);
     });
 
     it('requires local DB mode to be disabled before DB-to-DB migration', async function() {

--- a/backend/test/subscriptions.test.js
+++ b/backend/test/subscriptions.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-const { assert, path, fs, uuid, db_api, subscriptions_api, archive_api, youtubedl_api, config_api } = require('./test-shared');
+const { assert, path, fs, uuid, db_api, utils, subscriptions_api, archive_api, youtubedl_api, config_api } = require('./test-shared');
 
 describe('Subscriptions', function() {
     const downloader_api = require('../downloader');
@@ -739,6 +739,84 @@ describe('Subscriptions', function() {
         } finally {
             youtubedl_api.runYoutubeDLLineStream = original_runYoutubeDLLineStream;
         }
+    });
+    it('Compacts prefetched subscription formats while retaining expected-size fields', async function() {
+        const original_runYoutubeDLLineStream = youtubedl_api.runYoutubeDLLineStream;
+        const sub = Object.assign({}, new_sub, {
+            id: uuid(),
+            name: 'compacted_formats_sub',
+            timerange: 'now-7days'
+        });
+        const fake_output = {
+            webpage_url: 'https://www.youtube.com/watch?v=compacted-formats',
+            _filename: 'subscriptions/channels/compacted_formats_sub/Compacted formats.mp4',
+            title: 'Compacted formats',
+            extractor: 'youtube',
+            id: 'compacted-formats',
+            format_id: '137+140',
+            duration: 10,
+            formats: [
+                {
+                    format_id: '137',
+                    filesize: null,
+                    filesize_approx: null,
+                    duration: 10,
+                    tbr: 800,
+                    vbr: 750,
+                    abr: 0,
+                    url: `https://media.example/video?payload=${'v'.repeat(20000)}`,
+                    fragments: Array.from({length: 100}, (_, index) => ({path: `fragment-${index}`}))
+                },
+                {
+                    format_id: '140',
+                    filesize: 500,
+                    filesize_approx: 600,
+                    duration: 10,
+                    tbr: 128,
+                    vbr: 0,
+                    abr: 128,
+                    url: `https://media.example/audio?payload=${'a'.repeat(20000)}`
+                }
+            ]
+        };
+
+        youtubedl_api.runYoutubeDLLineStream = async (requested_url, args, line_handlers = {}) => {
+            if (typeof line_handlers.onStdoutLine === 'function') {
+                line_handlers.onStdoutLine(JSON.stringify(fake_output));
+            }
+            return {
+                child_process: {pid: 4321},
+                callback: Promise.resolve({err: null})
+            };
+        };
+
+        try {
+            await subscriptions_api.subscribe(sub, null, true);
+            const started = await subscriptions_api.getVideosForSub(sub.id);
+            assert.strictEqual(started, true);
+
+            const completed = await waitForCondition(async () => {
+                const refreshed_sub = await subscriptions_api.getSubscription(sub.id);
+                return !!(refreshed_sub && !refreshed_sub.downloading);
+            });
+            assert.strictEqual(completed, true);
+        } finally {
+            youtubedl_api.runYoutubeDLLineStream = original_runYoutubeDLLineStream;
+        }
+
+        const queued_downloads = await db_api.getRecords('download_queue', {sub_id: sub.id});
+        assert.strictEqual(queued_downloads.length, 1);
+
+        const prefetched_info = queued_downloads[0].prefetched_info;
+        assert(Array.isArray(prefetched_info));
+        assert.strictEqual(prefetched_info.length, 1);
+        assert.deepStrictEqual(
+            Object.keys(prefetched_info[0].formats[0]).sort(),
+            ['abr', 'duration', 'filesize', 'filesize_approx', 'format_id', 'tbr', 'vbr'].sort()
+        );
+        assert.strictEqual(prefetched_info[0].formats[0].url, undefined);
+        assert.strictEqual(prefetched_info[0].formats[0].fragments, undefined);
+        assert.strictEqual(utils.getExpectedFileSize(prefetched_info), 1000500);
     });
     it('Applies global custom args when discovering subscription videos', async function() {
         const original_runYoutubeDLLineStream = youtubedl_api.runYoutubeDLLineStream;

--- a/src/api-types/models/Download.ts
+++ b/src/api-types/models/Download.ts
@@ -17,9 +17,17 @@ export type Download = {
     percent_complete: number;
     timestamp_start: number;
     /**
-     * Error text, set if download fails.
+     * Bounded error summary, set if the download fails. Legacy entries may return a generic placeholder.
      */
     error?: string | null;
+    /**
+     * Bounded persisted diagnostic for newly recorded failures.
+     */
+    error_summary?: string | null;
+    /**
+     * Whether heavyweight legacy error output was omitted from the response.
+     */
+    error_details_omitted?: boolean;
     /**
      * Error type, may or may not be set in case of an error
      */

--- a/src/api-types/models/GetAllDownloadsRequest.ts
+++ b/src/api-types/models/GetAllDownloadsRequest.ts
@@ -11,4 +11,12 @@ export type GetAllDownloadsRequest = {
      * Filters downloads to unfinished queue items
      */
     only_unfinished?: boolean;
+    /**
+     * Zero-based history page. Ignored when filtering by UID or requesting only unfinished downloads.
+     */
+    page?: number;
+    /**
+     * Number of history items to return. The server clamps this value to its hard maximum.
+     */
+    page_size?: number;
 };

--- a/src/api-types/models/GetAllDownloadsResponse.ts
+++ b/src/api-types/models/GetAllDownloadsResponse.ts
@@ -6,4 +6,16 @@ import type { Download } from './Download';
 
 export type GetAllDownloadsResponse = {
     downloads?: Array<Download>;
+    /**
+     * Total number of scoped downloads matching the request.
+     */
+    total_count?: number;
+    /**
+     * Zero-based page actually returned by the server.
+     */
+    page?: number;
+    /**
+     * Page size actually applied by the server.
+     */
+    page_size?: number;
 };

--- a/src/app/components/downloads/downloads.component.html
+++ b/src/app/components/downloads/downloads.component.html
@@ -104,23 +104,34 @@
       <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
     </mat-table>
 
-    <mat-paginator [ngClass]="uids ? 'rounded-bottom' : null" [pageSizeOptions]="pageSizeOptions" [pageSize]="pageSize" (page)="pageChangeEvent($event)"
+    <mat-paginator [ngClass]="uids ? 'rounded-bottom' : null" [length]="downloads_total_count" [pageIndex]="pageIndex"
+      [pageSizeOptions]="pageSizeOptions" [pageSize]="pageSize" (page)="pageChangeEvent($event)"
       showFirstLastButtons
       aria-label="Select page of downloads">
     </mat-paginator>
   </div>
   @if (!uids) {
     <div class="downloads-action-button-div">
-      <button class="downloads-action-button" [disabled]="!running_download_exists" mat-stroked-button (click)="pauseAllDownloads()"><ng-container i18n="Pause all downloads">Pause all downloads</ng-container></button>
-      <button class="downloads-action-button" [disabled]="!paused_download_exists" mat-stroked-button (click)="resumeAllDownloads()"><ng-container i18n="Resume all downloads">Resume all downloads</ng-container></button>
-      <button class="downloads-action-button" [disabled]="!failed_download_exists" mat-stroked-button (click)="retryFailedDownloads()"><ng-container i18n="Retry all failed downloads">Retry all failed</ng-container></button>
+      <button class="downloads-action-button" mat-stroked-button (click)="pauseAllDownloads()"><ng-container i18n="Pause all downloads">Pause all downloads</ng-container></button>
+      <button class="downloads-action-button" mat-stroked-button (click)="resumeAllDownloads()"><ng-container i18n="Resume all downloads">Resume all downloads</ng-container></button>
+      <button class="downloads-action-button" [disabled]="!failed_download_exists" mat-stroked-button
+        matTooltip="Retry failed on this page" i18n-matTooltip="Retry failed downloads on current page"
+        (click)="retryFailedDownloads()"><ng-container i18n="Retry failed downloads on current page">Retry failed on this page</ng-container></button>
       <button class="downloads-action-button" color="warn" mat-stroked-button (click)="clearDownloadsByType()"><ng-container i18n="Clear downloads">Clear downloads</ng-container></button>
     </div>
   }
 </div>
 
-@if ((!downloads || downloads.length === 0) && downloads_retrieved && !uids) {
+@if ((!downloads || downloads.length === 0) && downloads_retrieved && !uids && !downloads_load_error) {
   <div>
     <h4 style="text-align: center; margin-top: 10px;" i18n="No downloads label">No downloads available!</h4>
+  </div>
+}
+
+@if ((!downloads || downloads.length === 0) && downloads_retrieved && !uids && downloads_load_error) {
+  <div>
+    <h4 style="text-align: center; margin-top: 10px;" i18n="Downloads loading error">
+      Unable to load downloads. Retrying automatically…
+    </h4>
   </div>
 }

--- a/src/app/components/downloads/downloads.component.spec.ts
+++ b/src/app/components/downloads/downloads.component.spec.ts
@@ -1,6 +1,7 @@
 import { DownloadsComponent } from './downloads.component';
 import { Download } from 'api-types';
-import { of } from 'rxjs';
+import { fakeAsync, tick } from '@angular/core/testing';
+import { of, Subject } from 'rxjs';
 
 describe('DownloadsComponent', () => {
   let component: DownloadsComponent;
@@ -22,7 +23,10 @@ describe('DownloadsComponent', () => {
       restartDownload: jasmine.createSpy('restartDownload').and.returnValue(of({success: true})),
       openSnackBar: jasmine.createSpy('openSnackBar')
     };
-    router_mock = { navigate: () => {} };
+    router_mock = {
+      navigate: jasmine.createSpy('navigate'),
+      url: '/downloads'
+    };
     dialog_mock = { open: () => ({}), openDialogs: [] };
     clipboard_mock = { copy: () => true };
 
@@ -95,6 +99,174 @@ describe('DownloadsComponent', () => {
     component.getCurrentDownloads();
 
     expect(component.failed_download_exists).toBeTrue();
+  });
+
+  it('does not overlap recurring downloads requests', fakeAsync(() => {
+    const first_request = new Subject<any>();
+    const second_request = new Subject<any>();
+    posts_service_mock.getCurrentDownloads.and.returnValues(
+      first_request.asObservable(),
+      second_request.asObservable()
+    );
+
+    component.getCurrentDownloadsRecurring();
+    expect(posts_service_mock.getCurrentDownloads).toHaveBeenCalledOnceWith(null, false, 0, 10);
+
+    tick(component.downloads_check_interval * 3);
+    expect(posts_service_mock.getCurrentDownloads).toHaveBeenCalledTimes(1);
+
+    first_request.next({
+      downloads: [{uid: 'running-download', finished: false, paused: false, timestamp_start: 1}]
+    });
+    first_request.complete();
+    tick(component.downloads_check_interval - 1);
+    expect(posts_service_mock.getCurrentDownloads).toHaveBeenCalledTimes(1);
+
+    tick(1);
+    expect(posts_service_mock.getCurrentDownloads).toHaveBeenCalledTimes(2);
+    component.ngOnDestroy();
+  }));
+
+  it('backs off after an error and returns to the normal interval after recovery', fakeAsync(() => {
+    const failed_request = new Subject<any>();
+    const recovered_request = new Subject<any>();
+    const next_request = new Subject<any>();
+    posts_service_mock.getCurrentDownloads.and.returnValues(
+      failed_request.asObservable(),
+      recovered_request.asObservable(),
+      next_request.asObservable()
+    );
+
+    component.getCurrentDownloadsRecurring();
+    failed_request.error(new Error('Bad Gateway'));
+
+    expect(component.downloads_retrieved).toBeTrue();
+    expect(component.downloads_load_error).toBeTrue();
+    tick(component.downloads_error_retry_interval - 1);
+    expect(posts_service_mock.getCurrentDownloads).toHaveBeenCalledTimes(1);
+
+    tick(1);
+    expect(posts_service_mock.getCurrentDownloads).toHaveBeenCalledTimes(2);
+
+    recovered_request.next({
+      downloads: [{uid: 'running-download', finished: false, paused: false, timestamp_start: 1}]
+    });
+    expect(component.downloads_load_error).toBeFalse();
+    recovered_request.complete();
+    tick(component.downloads_check_interval - 1);
+    expect(posts_service_mock.getCurrentDownloads).toHaveBeenCalledTimes(2);
+
+    tick(1);
+    expect(posts_service_mock.getCurrentDownloads).toHaveBeenCalledTimes(3);
+    component.ngOnDestroy();
+  }));
+
+  it('cancels an in-flight downloads request when destroyed', fakeAsync(() => {
+    const pending_request = new Subject<any>();
+    posts_service_mock.getCurrentDownloads.and.returnValue(pending_request.asObservable());
+
+    component.getCurrentDownloadsRecurring();
+    expect(pending_request.observers.length).toBe(1);
+
+    component.ngOnDestroy();
+    expect(pending_request.observers.length).toBe(0);
+
+    tick(component.downloads_max_error_retry_interval);
+    expect(posts_service_mock.getCurrentDownloads).toHaveBeenCalledTimes(1);
+  }));
+
+  it('uses a slower poll interval when the downloads page has no active work', fakeAsync(() => {
+    const next_request = new Subject<any>();
+    posts_service_mock.getCurrentDownloads.and.returnValues(
+      of({downloads: [], total_count: 0, page: 0, page_size: 10}),
+      next_request.asObservable()
+    );
+
+    component.getCurrentDownloadsRecurring();
+    tick(component.downloads_idle_check_interval - 1);
+    expect(posts_service_mock.getCurrentDownloads).toHaveBeenCalledTimes(1);
+
+    tick(1);
+    expect(posts_service_mock.getCurrentDownloads).toHaveBeenCalledTimes(2);
+    component.ngOnDestroy();
+  }));
+
+  it('cancels a scheduled downloads poll when destroyed', fakeAsync(() => {
+    posts_service_mock.getCurrentDownloads.and.returnValue(of({downloads: []}));
+
+    component.getCurrentDownloadsRecurring();
+    expect(posts_service_mock.getCurrentDownloads).toHaveBeenCalledTimes(1);
+
+    component.ngOnDestroy();
+    tick(component.downloads_idle_check_interval);
+
+    expect(posts_service_mock.getCurrentDownloads).toHaveBeenCalledTimes(1);
+  }));
+
+  it('requests and applies the selected server downloads page', () => {
+    posts_service_mock.getCurrentDownloads.and.returnValue(of({
+      downloads: [{uid: 'page-download', timestamp_start: 1}],
+      total_count: 47,
+      page: 1,
+      page_size: 20
+    }));
+    component.pageIndex = 2;
+    component.pageSize = 20;
+
+    component.getCurrentDownloads();
+
+    expect(posts_service_mock.getCurrentDownloads).toHaveBeenCalledOnceWith(null, false, 2, 20);
+    expect(component.downloads_total_count).toBe(47);
+    expect(component.pageIndex).toBe(1);
+    expect(component.pageSize).toBe(20);
+    expect(component.dataSource.data.map(download => download.uid)).toEqual(['page-download']);
+    expect(component.dataSource.paginator).toBeNull();
+  });
+
+  it('cancels a stale page request and immediately loads a newly selected page', fakeAsync(() => {
+    const first_page_request = new Subject<any>();
+    const selected_page_request = new Subject<any>();
+    posts_service_mock.getCurrentDownloads.and.returnValues(
+      first_page_request.asObservable(),
+      selected_page_request.asObservable()
+    );
+
+    component.getCurrentDownloadsRecurring();
+    expect(first_page_request.observers.length).toBe(1);
+
+    component.pageChangeEvent({pageIndex: 3, pageSize: 20} as any);
+
+    expect(first_page_request.observers.length).toBe(0);
+    expect(posts_service_mock.getCurrentDownloads).toHaveBeenCalledTimes(2);
+    expect(posts_service_mock.getCurrentDownloads.calls.mostRecent().args).toEqual([null, false, 3, 20]);
+    component.ngOnDestroy();
+  }));
+
+  it('keeps exact-UID downloads requests unpaginated', () => {
+    component.uids = ['download-a', 'download-b'];
+    posts_service_mock.getCurrentDownloads.and.returnValue(of({
+      downloads: [],
+      total_count: 0,
+      page: 0,
+      page_size: 2
+    }));
+
+    component.getCurrentDownloads();
+
+    expect(posts_service_mock.getCurrentDownloads).toHaveBeenCalledOnceWith(component.uids);
+  });
+
+  it('navigates lean playlist summaries by container id', () => {
+    component.watchContent({
+      uid: 'playlist-download',
+      type: 'video',
+      container: {id: 'playlist-id'}
+    } as unknown as Download);
+
+    expect(router_mock.navigate).toHaveBeenCalledOnceWith([
+      '/player',
+      {playlist_id: 'playlist-id', type: 'video'}
+    ]);
   });
 
   it('retries failed downloads only', () => {

--- a/src/app/components/downloads/downloads.component.ts
+++ b/src/app/components/downloads/downloads.component.ts
@@ -8,8 +8,8 @@ import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { ConfirmDialogComponent } from 'app/dialogs/confirm-dialog/confirm-dialog.component';
 import { MatSort } from '@angular/material/sort';
 import { Clipboard } from '@angular/cdk/clipboard';
-import { Download, RestartDownloadResponse, SuccessObject } from 'api-types';
-import { forkJoin, of } from 'rxjs';
+import { Download, GetAllDownloadsResponse, RestartDownloadResponse, SuccessObject } from 'api-types';
+import { forkJoin, of, Subscription } from 'rxjs';
 import { catchError, filter, take } from 'rxjs/operators';
 import { PlaylistDownloadProgressDialogComponent } from 'app/dialogs/playlist-download-progress-dialog/playlist-download-progress-dialog.component';
 import { PLAYER_NAVIGATOR_STORAGE_KEY } from 'app/media-library-navigation-state.service';
@@ -26,10 +26,18 @@ export class DownloadsComponent implements OnInit, OnDestroy {
   @Input() uids: string[] = null;
 
   downloads_check_interval = 1000;
+  downloads_idle_check_interval = 10000;
+  downloads_error_retry_interval = 5000;
+  downloads_max_error_retry_interval = 30000;
   raw_downloads: Download[] = [];
   downloads: Download[] = [];
   finished_downloads = [];
-  interval_id = null;
+  interval_id: number = null;
+  private downloads_request_subscription: Subscription = null;
+  private service_initialized_subscription: Subscription = null;
+  private downloads_polling_active = false;
+  private downloads_poll_error_count = 0;
+  private component_destroyed = false;
 
   keys = Object.keys;
 
@@ -41,6 +49,8 @@ export class DownloadsComponent implements OnInit, OnDestroy {
   readonly pageSizeStorageKey = 'downloads_page_size';
   readonly pageSizeOptions = [5, 10, 20];
   pageSize = 10;
+  pageIndex = 0;
+  downloads_total_count = 0;
 
   STEP_INDEX_TO_LABEL = {
       0: $localize`Creating download`,
@@ -106,6 +116,7 @@ export class DownloadsComponent implements OnInit, OnDestroy {
   ]
 
   downloads_retrieved = false;
+  downloads_load_error = false;
 
   innerWidth: number;
 
@@ -138,47 +149,150 @@ export class DownloadsComponent implements OnInit, OnDestroy {
     if (this.postsService.initialized) {
       this.getCurrentDownloadsRecurring();
     } else {
-      this.postsService.service_initialized
+      this.service_initialized_subscription = this.postsService.service_initialized
         .pipe(filter(Boolean), take(1))
-        .subscribe(() => this.getCurrentDownloadsRecurring());
+        .subscribe(() => {
+          if (!this.component_destroyed) this.getCurrentDownloadsRecurring();
+        });
     }
   }
 
   getCurrentDownloadsRecurring(): void {
+    if (this.component_destroyed) return;
     if (!this.postsService.config['Extra']['enable_downloads_manager']) {
       this.router.navigate(['/home']);
       return;
     }
+
+    if (this.downloads_polling_active) return;
+    this.downloads_polling_active = true;
+    this.downloads_poll_error_count = 0;
     this.getCurrentDownloads();
-    this.interval_id = setInterval(() => {
-      this.getCurrentDownloads();
-    }, this.downloads_check_interval);
   }
 
   ngOnDestroy(): void {
-    if (this.interval_id) { clearInterval(this.interval_id) }
+    this.component_destroyed = true;
+    this.downloads_polling_active = false;
+    this.clearDownloadsPollTimer();
+    if (this.downloads_request_subscription) {
+      this.downloads_request_subscription.unsubscribe();
+      this.downloads_request_subscription = null;
+    }
+    if (this.service_initialized_subscription) {
+      this.service_initialized_subscription.unsubscribe();
+      this.service_initialized_subscription = null;
+    }
     if (this.playlist_progress_dialog_ref) {
       this.playlist_progress_dialog_ref.close();
     }
   }
 
   getCurrentDownloads(): void {
-    this.postsService.getCurrentDownloads(this.uids).subscribe(res => {
-      if (res['downloads'] !== null && res['downloads'] !== undefined) {
-        this.raw_downloads = this.combineDownloads(this.raw_downloads, res['downloads']);
-        this.raw_downloads.sort(this.sort_downloads);
-        this.downloads = this.groupDownloadsForDisplay(this.raw_downloads);
-        this.downloads.sort(this.sort_downloads);
-        this.dataSource.data = this.downloads;
-        this.dataSource.paginator = this.paginator;
-        this.dataSource.sort = this.sort;
-        this.refreshOpenPlaylistProgressDialog();
-        this.paused_download_exists = !!this.raw_downloads.find(download => download['paused'] && !download['error']);
-        this.running_download_exists = !!this.raw_downloads.find(download => !download['paused'] && !download['finished']);
-        this.failed_download_exists = this.raw_downloads.some(download => this.isFailedDownload(download));
+    if (this.component_destroyed) return;
+    this.clearDownloadsPollTimer();
+
+    // A slow downloads response must finish before another one can be requested.
+    if (this.downloads_request_subscription && !this.downloads_request_subscription.closed) return;
+
+    const request_subscription = new Subscription();
+    this.downloads_request_subscription = request_subscription;
+    const downloads_request = this.uids
+      ? this.postsService.getCurrentDownloads(this.uids)
+      : this.postsService.getCurrentDownloads(null, false, this.pageIndex, this.pageSize);
+    const current_request = downloads_request.subscribe({
+      next: res => {
+        this.downloads_load_error = false;
+        if (res['downloads'] !== null && res['downloads'] !== undefined) {
+          this.raw_downloads = this.combineDownloads(this.raw_downloads, res['downloads']);
+          this.raw_downloads.sort(this.sort_downloads);
+          this.downloads = this.groupDownloadsForDisplay(this.raw_downloads);
+          this.downloads.sort(this.sort_downloads);
+          this.dataSource.data = this.downloads;
+          // History pages are already sliced by the server. Exact-UID embeds retain
+          // their existing client-side paginator because the API returns all matches.
+          this.dataSource.paginator = this.uids ? this.paginator : null;
+          this.dataSource.sort = this.sort;
+          this.refreshOpenPlaylistProgressDialog();
+          this.paused_download_exists = !!this.raw_downloads.find(download => download['paused'] && !download['error']);
+          this.running_download_exists = !!this.raw_downloads.find(download => !download['paused'] && !download['finished']);
+          this.failed_download_exists = this.raw_downloads.some(download => this.isFailedDownload(download));
+          this.applyDownloadsPaginationResponse(res, res['downloads'].length);
+        }
+        this.downloads_retrieved = true;
+      },
+      error: () => {
+        // Keep the polling chain alive without surfacing an unhandled RxJS error.
+        this.downloads_retrieved = true;
+        this.downloads_load_error = true;
+        this.finishCurrentDownloadsRequest(request_subscription, false);
+      },
+      complete: () => {
+        this.finishCurrentDownloadsRequest(request_subscription, true);
       }
-      this.downloads_retrieved = true;
     });
+    request_subscription.add(current_request);
+  }
+
+  private finishCurrentDownloadsRequest(request_subscription: Subscription, succeeded: boolean): void {
+    if (this.downloads_request_subscription !== request_subscription) return;
+
+    this.downloads_request_subscription = null;
+    request_subscription.unsubscribe();
+    if (!this.downloads_polling_active || this.component_destroyed) return;
+
+    let next_poll_delay = this.running_download_exists
+      ? this.downloads_check_interval
+      : this.downloads_idle_check_interval;
+    if (succeeded) {
+      this.downloads_poll_error_count = 0;
+    } else {
+      this.downloads_poll_error_count += 1;
+      const backoff_multiplier = Math.pow(2, Math.min(this.downloads_poll_error_count - 1, 10));
+      next_poll_delay = Math.min(
+        this.downloads_error_retry_interval * backoff_multiplier,
+        this.downloads_max_error_retry_interval
+      );
+    }
+
+    this.interval_id = window.setTimeout(() => {
+      this.interval_id = null;
+      this.getCurrentDownloads();
+    }, next_poll_delay);
+  }
+
+  private clearDownloadsPollTimer(): void {
+    if (this.interval_id === null) return;
+    window.clearTimeout(this.interval_id);
+    this.interval_id = null;
+  }
+
+  private applyDownloadsPaginationResponse(res: GetAllDownloadsResponse, returned_download_count: number): void {
+    const total_count = Number(res && res['total_count']);
+    this.downloads_total_count = Number.isFinite(total_count) && total_count >= 0
+      ? Math.floor(total_count)
+      : returned_download_count;
+
+    if (this.uids) return;
+
+    const returned_page = Number(res && res['page']);
+    if (Number.isFinite(returned_page) && returned_page >= 0) {
+      this.pageIndex = Math.floor(returned_page);
+    }
+
+    const returned_page_size = Number(res && res['page_size']);
+    if (Number.isFinite(returned_page_size) && returned_page_size > 0) {
+      this.pageSize = Math.floor(returned_page_size);
+    }
+  }
+
+  private refreshCurrentDownloadsImmediately(): void {
+    this.clearDownloadsPollTimer();
+    if (this.downloads_request_subscription) {
+      const stale_request = this.downloads_request_subscription;
+      this.downloads_request_subscription = null;
+      stale_request.unsubscribe();
+    }
+    this.getCurrentDownloads();
   }
 
   clearDownloadsByType(): void {
@@ -301,8 +415,10 @@ export class DownloadsComponent implements OnInit, OnDestroy {
   }
 
   pageChangeEvent(event: PageEvent): void {
+    this.pageIndex = Number.isFinite(Number(event.pageIndex)) ? Math.max(0, Math.floor(Number(event.pageIndex))) : 0;
     this.pageSize = event.pageSize;
     localStorage.setItem(this.pageSizeStorageKey, `${this.pageSize}`);
+    if (!this.uids) this.refreshCurrentDownloadsImmediately();
   }
 
   cancelDownload(download: Download): void {
@@ -326,9 +442,10 @@ export class DownloadsComponent implements OnInit, OnDestroy {
   }
 
   watchContent(download: Download): void {
-    const container = download['container'];
+    const container = download && download['container'];
+    if (!container) return;
     sessionStorage.setItem(PLAYER_NAVIGATOR_STORAGE_KEY, this.router.url.split(';')[0]);
-    const is_playlist = container['uids']; // hacky, TODO: fix
+    const is_playlist = !!container['id'] && !container['uid'];
     if (is_playlist) {
       this.router.navigate(['/player', {playlist_id: container['id'], type: download['type']}]);
     } else {

--- a/src/app/posts.services.ts
+++ b/src/app/posts.services.ts
@@ -712,8 +712,10 @@ export class PostsService {
         return this.http.post<GetAllSubscriptionsResponse>(this.path + 'getSubscriptions', {}, this.httpOptions);
     }
 
-    getCurrentDownloads(uids: Array<string> = null, only_unfinished = false) {
+    getCurrentDownloads(uids: Array<string> = null, only_unfinished = false, page?: number, page_size?: number) {
         const body: GetAllDownloadsRequest = {uids: uids, only_unfinished: only_unfinished};
+        if (page !== undefined && page !== null) body.page = page;
+        if (page_size !== undefined && page_size !== null) body.page_size = page_size;
         return this.http.post<GetAllDownloadsResponse>(this.path + 'downloads', body, this.httpOptions);
     }
 


### PR DESCRIPTION
## Summary

Opening Downloads could exhaust the Node heap, restart the PM2 process, and produce repeated 502 responses. This change bounds the history payload and prevents the client from overlapping polling requests.

## Root cause

`POST /api/downloads` returned every matching queue record, including large prefetched metadata and persisted downloader output. The Downloads page issued a new request every second even when the previous request was still pending. Slow, heavyweight responses therefore accumulated until V8 reached its heap limit.

## Changes

- Add newest-first server pagination and `total_count` metadata to Downloads history.
- Project only fields required by the Downloads UI for local, MongoDB, and PostgreSQL reads.
- Exclude heavyweight legacy error output from list responses and cap newly persisted errors at 8 KiB.
- Replace fixed-interval polling with completion-driven polling, cancellation on page changes, idle throttling, and error backoff.
- Bound UID and unfinished-download queries and add supporting history indexes.
- Add regression coverage for pagination, projections, bounded errors, and non-overlapping polling.

## Testing

- [x] `npm run lint`
- [x] `npx tsc -p src/tsconfig.app.json --noEmit`
- [x] `npx tsc -p src/tsconfig.spec.json --noEmit`
- [x] `CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npm run test:headless` — 210 passing
- [x] `npx ng build --configuration production`
- [x] `node --check` for every modified backend JavaScript file
- [x] `npm test` from `backend/` — 226 passing, 25 pending