### PR TITLE
fix(downloads): stop pinning an uninstalled JS runtime causing 403s

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -263,7 +263,8 @@ const DEFAULT_CONFIG = {
         "download_rate_limit": "",
         "skip_join_only_videos": false,
         "use_ytdlp_impersonation": false,
-        "use_extractor_client_fallback": false
+        "use_extractor_client_fallback": false,
+        "js_runtimes": ""
       },
       "Extra": {
         "title_top": "ytdl-material",

--- a/backend/consts.js
+++ b/backend/consts.js
@@ -90,6 +90,10 @@ exports.CONFIG_ITEMS = {
         'key': 'ytdl_use_extractor_client_fallback',
         'path': 'YtdlMaterial.Downloader.use_extractor_client_fallback'
     },
+    'ytdl_js_runtimes': {
+        'key': 'ytdl_js_runtimes',
+        'path': 'YtdlMaterial.Downloader.js_runtimes'
+    },
 
     // Extra
     'ytdl_title_top': {
@@ -460,6 +464,8 @@ const YTDL_ARGS_WITH_VALUES = [
     '--max-sleep-interval',
     '-f',
     '--format',
+    '-S',
+    '--format-sort',
     '--merge-output-format',
     '--sub-format',
     '--sub-lang',

--- a/backend/downloader.js
+++ b/backend/downloader.js
@@ -1293,6 +1293,7 @@ async function getPlaylistChunkingMetadata(url, options = {}) {
     }
 
     probe_args = appendYtDlpImpersonationArgs(probe_args, downloader_fork);
+    probe_args = appendExtractorClientFallbackArgs(probe_args, downloader_fork);
 
     logger.debug(`Probing playlist metadata for automatic chunking: ${url}`);
     try {
@@ -2441,9 +2442,17 @@ exports.generateArgs = async (url, type, options, user_uid = null, simulated = f
 
         if (qualityPath) {
             if (should_preserve_selected_format_args) {
+                // An explicit per-download selection (quality, height, or audio language) wins
+                // over any format args coming from custom args.
                 downloadConfig = stripArgsWithValues(downloadConfig, ['-f', '--format', '-S', '--format-sort', '--merge-output-format']);
+                downloadConfig.push(...qualityPath);
+            } else {
+                // Nothing was selected for this download, so qualityPath is only a default.
+                // Appending it wholesale would emit a second -f that silently overrides the
+                // user's custom args, since yt-dlp honors the last one. Only fill in the
+                // format args custom args did not already set.
+                downloadConfig.push(...omitAlreadySpecifiedArgs(downloadConfig, qualityPath));
             }
-            downloadConfig.push(...qualityPath);
         }
 
         if (subtitlePath) {
@@ -2493,7 +2502,10 @@ exports.generateArgs = async (url, type, options, user_uid = null, simulated = f
     // filter out incompatible args
     downloadConfig = filterArgs(downloadConfig, is_audio);
 
-    if (!simulated) logger.verbose(`${default_downloader} args being used (${downloadConfig.length} args)`);
+    if (!simulated) {
+        logger.verbose(`${default_downloader} args being used (${downloadConfig.length} args)`);
+        logger.debug(`${default_downloader} generated args: ${utils.redactCommandArgsForLogging(downloadConfig).join(' ')}`);
+    }
     return downloadConfig;
 }
 
@@ -2634,6 +2646,35 @@ function stripArgsWithValues(args = [], args_to_strip = []) {
         cleaned_args.push(arg);
     }
     return cleaned_args;
+}
+
+// yt-dlp accepts several spellings of the same option, so a flag is "already specified"
+// if any of its aliases is present.
+const EQUIVALENT_ARG_FLAGS = [
+    ['-f', '--format'],
+    ['-S', '--format-sort']
+];
+
+function getEquivalentArgFlags(flag) {
+    return EQUIVALENT_ARG_FLAGS.find(aliases => aliases.includes(flag)) || [flag];
+}
+
+// Returns the flag/value pairs of candidate_args whose flag is not already present in
+// existing_args. Used to apply default format args without overriding user-supplied ones.
+function omitAlreadySpecifiedArgs(existing_args = [], candidate_args = []) {
+    if (!Array.isArray(existing_args) || !Array.isArray(candidate_args)) return [];
+
+    const kept_args = [];
+    for (let i = 0; i < candidate_args.length; i += 2) {
+        const flag = candidate_args[i];
+        const value = candidate_args[i + 1];
+        const already_specified = getEquivalentArgFlags(flag).some(alias => hasArg(existing_args, alias));
+        if (already_specified) continue;
+
+        kept_args.push(flag);
+        if (value !== undefined) kept_args.push(value);
+    }
+    return kept_args;
 }
 
 function stripFlagArgs(args = [], args_to_strip = []) {

--- a/backend/subscriptions.js
+++ b/backend/subscriptions.js
@@ -997,6 +997,7 @@ async function getSubscriptionInfo(sub) {
     downloadConfig = applyCustomArgs(downloadConfig, sub.custom_args);
     downloadConfig = utils.injectArgs(downloadConfig, ['--playlist-end', '1']);
     downloadConfig = downloader_api.appendYtDlpImpersonationArgs(downloadConfig, downloader_fork);
+    downloadConfig = downloader_api.appendExtractorClientFallbackArgs(downloadConfig, downloader_fork);
     let useCookies = config_api.getConfigItem('ytdl_use_cookies');
     if (useCookies) {
         if (await fs.pathExists(path.join(__dirname, 'appdata', 'cookies.txt'))) {
@@ -1492,11 +1493,15 @@ async function generateArgsForSubscription(sub, user_uid, redownload = false, de
     }
 
     downloadConfig = downloader_api.appendYtDlpImpersonationArgs(downloadConfig, default_downloader);
+    downloadConfig = downloader_api.appendExtractorClientFallbackArgs(downloadConfig, default_downloader);
 
     downloadConfig = utils.filterArgs(downloadConfig, ['--write-comments']);
 
+    logger.debug(`Subscription download args: ${utils.redactCommandArgsForLogging(downloadConfig).join(' ')}`);
+
     return downloadConfig;
 }
+exports.generateArgsForSubscription = generateArgsForSubscription;
 
 function hasSubscriptionDiscoveryDateFilter(args = []) {
     if (!Array.isArray(args)) return false;

--- a/backend/test/downloader.test.js
+++ b/backend/test/downloader.test.js
@@ -396,6 +396,49 @@ describe('Downloader', function() {
         }
     });
 
+    it('Generate args lets global custom args set the format without a duplicate -f', async function() {
+        const original_global_args = config_api.getConfigItem('ytdl_custom_args');
+        try {
+            config_api.setConfigItem('ytdl_custom_args', '-f,,bestvideo*+bestaudio/best');
+
+            const args = await downloader_api.generateArgs(url, 'video', {ui_uid: uuid()}, null, true);
+            const format_flags = args.filter(arg => arg === '-f' || arg === '--format');
+            assert.strictEqual(format_flags.length, 1);
+            assert.strictEqual(args[args.indexOf('-f') + 1], 'bestvideo*+bestaudio/best');
+        } finally {
+            config_api.setConfigItem('ytdl_custom_args', original_global_args);
+        }
+    });
+
+    it('Generate args still applies default format args custom args did not set', async function() {
+        const original_global_args = config_api.getConfigItem('ytdl_custom_args');
+        try {
+            config_api.setConfigItem('ytdl_custom_args', '-f,,bestvideo*+bestaudio/best');
+
+            const args = await downloader_api.generateArgs(url, 'video', {ui_uid: uuid()}, null, true);
+            // custom args supplied no --merge-output-format, so the default should still land
+            assert(args.includes('--merge-output-format'));
+            assert.strictEqual(args[args.indexOf('--merge-output-format') + 1], 'mp4');
+        } finally {
+            config_api.setConfigItem('ytdl_custom_args', original_global_args);
+        }
+    });
+
+    it('Generate args lets an explicit height selection override global custom args', async function() {
+        const original_global_args = config_api.getConfigItem('ytdl_custom_args');
+        try {
+            config_api.setConfigItem('ytdl_custom_args', '-f,,bestvideo*+bestaudio/best');
+
+            const args = await downloader_api.generateArgs(url, 'video', {selectedHeight: '720', ui_uid: uuid()}, null, true);
+            const format_flags = args.filter(arg => arg === '-f' || arg === '--format');
+            assert.strictEqual(format_flags.length, 1);
+            assert(!args.includes('bestvideo*+bestaudio/best'));
+            assert(args[args.indexOf('-f') + 1].includes('height=720'));
+        } finally {
+            config_api.setConfigItem('ytdl_custom_args', original_global_args);
+        }
+    });
+
     it('Download file', async function() {
         this.timeout(300000);
         await downloader_api.setupDownloads();

--- a/backend/test/subscriptions.test.js
+++ b/backend/test/subscriptions.test.js
@@ -1108,6 +1108,35 @@ describe('Subscriptions', function() {
         assert.strictEqual(success, false);
         assert.strictEqual(fs.existsSync(metadata_path), false);
     });
+    it('Applies the extractor client fallback to subscription download args', async function() {
+        const original_fallback = config_api.getConfigItem('ytdl_use_extractor_client_fallback');
+        const original_downloader = config_api.getConfigItem('ytdl_default_downloader');
+        try {
+            config_api.setConfigItem('ytdl_use_extractor_client_fallback', true);
+            config_api.setConfigItem('ytdl_default_downloader', 'yt-dlp');
+
+            const args = await subscriptions_api.generateArgsForSubscription(new_sub, null);
+            const extractor_args_index = args.indexOf('--extractor-args');
+            assert(extractor_args_index !== -1);
+            assert.strictEqual(args[extractor_args_index + 1], 'youtube:player_client=tv,web');
+        } finally {
+            config_api.setConfigItem('ytdl_use_extractor_client_fallback', original_fallback);
+            config_api.setConfigItem('ytdl_default_downloader', original_downloader);
+        }
+    });
+
+    it('Omits the extractor client fallback from subscription args when disabled', async function() {
+        const original_fallback = config_api.getConfigItem('ytdl_use_extractor_client_fallback');
+        try {
+            config_api.setConfigItem('ytdl_use_extractor_client_fallback', false);
+
+            const args = await subscriptions_api.generateArgsForSubscription(new_sub, null);
+            assert(!args.includes('--extractor-args'));
+        } finally {
+            config_api.setConfigItem('ytdl_use_extractor_client_fallback', original_fallback);
+        }
+    });
+
     it('Fresh uploads', async function() {
 
     });

--- a/backend/test/youtube-dl.test.js
+++ b/backend/test/youtube-dl.test.js
@@ -107,5 +107,57 @@ describe('youtube-dl', function() {
             config_api.setConfigItem('ytdl_default_downloader', original_fork);
         }
     });
+
+    describe('JavaScript runtime args', function() {
+        let original_runtimes = null;
+        let original_fork = null;
+
+        beforeEach(function() {
+            original_runtimes = config_api.getConfigItem('ytdl_js_runtimes');
+            original_fork = config_api.getConfigItem('ytdl_default_downloader');
+            config_api.setConfigItem('ytdl_default_downloader', 'yt-dlp');
+        });
+
+        afterEach(function() {
+            config_api.setConfigItem('ytdl_js_runtimes', original_runtimes);
+            config_api.setConfigItem('ytdl_default_downloader', original_fork);
+        });
+
+        it('Does not pin a runtime by default so yt-dlp auto-detects', function() {
+            config_api.setConfigItem('ytdl_js_runtimes', '');
+            const args = youtubedl_api.ensureJavascriptRuntimeArgs(['-f', 'best'], 'yt-dlp');
+            assert(!args.includes('--js-runtimes'));
+            assert.deepStrictEqual(args, ['-f', 'best']);
+        });
+
+        it('Pins the configured runtime when one is set', function() {
+            config_api.setConfigItem('ytdl_js_runtimes', 'deno');
+            const args = youtubedl_api.ensureJavascriptRuntimeArgs(['-f', 'best'], 'yt-dlp');
+            assert.deepStrictEqual(args, ['--js-runtimes', 'deno', '-f', 'best']);
+        });
+
+        it('Trims whitespace and ignores a blank configured runtime', function() {
+            config_api.setConfigItem('ytdl_js_runtimes', '  deno  ');
+            assert.deepStrictEqual(
+                youtubedl_api.ensureJavascriptRuntimeArgs([], 'yt-dlp'),
+                ['--js-runtimes', 'deno']
+            );
+
+            config_api.setConfigItem('ytdl_js_runtimes', '   ');
+            assert.deepStrictEqual(youtubedl_api.ensureJavascriptRuntimeArgs([], 'yt-dlp'), []);
+        });
+
+        it('Leaves an explicitly supplied --js-runtimes untouched', function() {
+            config_api.setConfigItem('ytdl_js_runtimes', 'deno');
+            const args = youtubedl_api.ensureJavascriptRuntimeArgs(['--js-runtimes', 'node'], 'yt-dlp');
+            assert.deepStrictEqual(args, ['--js-runtimes', 'node']);
+        });
+
+        it('Does not add runtime args for non yt-dlp forks', function() {
+            config_api.setConfigItem('ytdl_js_runtimes', 'deno');
+            const args = youtubedl_api.ensureJavascriptRuntimeArgs(['-f', 'best'], 'youtube-dl');
+            assert(!args.includes('--js-runtimes'));
+        });
+    });
 });
 

--- a/backend/youtube-dl.js
+++ b/backend/youtube-dl.js
@@ -35,12 +35,22 @@ function hasArg(args = [], target_arg = '') {
     return args.some(arg => typeof arg === 'string' && (arg === target_arg || arg.startsWith(`${target_arg}=`)));
 }
 
+// yt-dlp needs a JavaScript runtime to solve YouTube's JS challenge (nsig/signature
+// deciphering). Getting this wrong is not a loud failure: extraction still succeeds and
+// yt-dlp only fails later with "unable to download video data: HTTP Error 403: Forbidden".
+// Pinning a runtime that isn't installed causes exactly that, so by default we pass no
+// --js-runtimes flag at all and let yt-dlp auto-detect whatever is present.
 function ensureJavascriptRuntimeArgs(args = [], youtubedl_fork = config_api.getConfigItem('ytdl_default_downloader')) {
     if (!Array.isArray(args)) return [];
     if (youtubedl_fork !== 'yt-dlp') return args;
     if (hasArg(args, '--js-runtimes')) return args;
-    return ['--js-runtimes', 'node', ...args];
+
+    const configured_runtimes = config_api.getConfigItem('ytdl_js_runtimes');
+    if (typeof configured_runtimes !== 'string' || !configured_runtimes.trim()) return args;
+
+    return ['--js-runtimes', configured_runtimes.trim(), ...args];
 }
+exports.ensureJavascriptRuntimeArgs = ensureJavascriptRuntimeArgs;
 
 function getYoutubeDLEnv() {
     return {
@@ -169,6 +179,7 @@ exports.runYoutubeDLLineStream = async (url, args, line_handlers = {}, youtubedl
     const runtime_args = ensureJavascriptRuntimeArgs(args, selected_fork);
     const base_args = getYoutubeDLRuntimeBaseArgs(selected_fork);
     logger.debug(`Spawning ${selected_fork} process in streaming mode with ${runtime_args.length + 1} arguments`);
+    logger.debug(`${selected_fork} streaming args: ${utils.redactCommandArgsForLogging(runtime_args).join(' ')}`);
     const child_process = spawn(getYoutubeDLRuntimePath(selected_fork), [...base_args, url, ...runtime_args], {
         stdio: ['ignore', 'pipe', 'pipe'],
         env: getYoutubeDLRuntimeEnv(selected_fork)
@@ -250,6 +261,7 @@ const runYoutubeDLProcess = async (url, args, youtubedl_fork = config_api.getCon
     const runtime_args = ensureJavascriptRuntimeArgs(args, youtubedl_fork);
     const base_args = getYoutubeDLRuntimeBaseArgs(youtubedl_fork);
     logger.debug(`Spawning ${youtubedl_fork} process with ${runtime_args.length + 1} arguments`);
+    logger.debug(`${youtubedl_fork} args: ${utils.redactCommandArgsForLogging(runtime_args).join(' ')}`);
     const child_process = execa(youtubedl_path, [...base_args, url, ...runtime_args], {
         maxBuffer: Infinity,
         stdin: 'ignore',

--- a/docker-environment.md
+++ b/docker-environment.md
@@ -96,6 +96,7 @@ When using env-managed Docker setups with `write_ytdl_config='true'`, you can cl
 * `ytdl_warn_on_duplicate`: set to `'true'` to warn on duplicate downloads and reuse existing files in playlists instead of downloading them again (default `'false'`)
 * `ytdl_max_playlist_chunks`: cap automatic playlist chunk creation (default `20`, min `1`)
 * `ytdl_use_extractor_client_fallback`: set to `'true'` to add yt-dlp `--extractor-args youtube:player_client=tv,web` as a workaround for 403 download errors (default `'false'`)
+* `ytdl_js_runtimes`: pin the JavaScript runtime yt-dlp uses to solve YouTube's JS challenge, passed through as `--js-runtimes` (for example `deno` or `node`). Leave empty to let yt-dlp auto-detect an installed runtime, which is the default and is recommended. Pinning a runtime that is not installed causes downloads to fail with `unable to download video data: HTTP Error 403: Forbidden`; run `yt-dlp -v` and check the `JS Challenge Providers` line to see which runtimes are actually available (default empty)
 
 ## OIDC
 

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -202,6 +202,13 @@
               <mat-checkbox color="accent" [(ngModel)]="new_config['Downloader']['use_ytdlp_impersonation']"><ng-container i18n="Use yt-dlp browser impersonation setting">Use yt-dlp browser impersonation</ng-container></mat-checkbox>
             </div>
             }
+            <div class="col-12 mt-3 mb-2">
+              <mat-form-field class="text-field" color="accent">
+                <mat-label i18n="JavaScript runtimes">JavaScript runtimes</mat-label>
+                <input matInput [(ngModel)]="new_config['Downloader']['js_runtimes']" placeholder="deno">
+                <mat-hint><ng-container i18n="JavaScript runtimes setting input hint">Optional. Pins the runtime yt-dlp uses to solve YouTube's JS challenge (--js-runtimes). Leave empty to auto-detect, which is recommended. Pinning a runtime that is not installed causes downloads to fail with HTTP 403.</ng-container></mat-hint>
+              </mat-form-field>
+            </div>
           </div>
         </div>
       }

--- a/src/assets/default.json
+++ b/src/assets/default.json
@@ -22,7 +22,8 @@
       "download_rate_limit": "",
       "skip_join_only_videos": false,
       "use_ytdlp_impersonation": false,
-      "use_extractor_client_fallback": false
+      "use_extractor_client_fallback": false,
+      "js_runtimes": ""
     },
     "Extra": {
       "title_top": "ytdl-material",


### PR DESCRIPTION
## Problem

Downloads fail with:

```
ERROR: unable to download video data: HTTP Error 403: Forbidden
```

yt-dlp needs a JavaScript runtime to solve YouTube's JS challenge (nsig/signature deciphering). `ensureJavascriptRuntimeArgs` hardcoded `--js-runtimes node` on every invocation, but the image installs **Deno** (`Dockerfile:93`), not node.

Confirmed in a running container:

```
[debug] JS runtimes: deno-2.9.4
[debug] [youtube] [jsc] JS Challenge Providers: bun (unavailable), deno, node (unavailable), quickjs (unavailable)
```

With node unavailable, the challenge cannot be solved, signatures are wrong, and YouTube rejects the media fetch. The failure is quiet because *extraction still succeeds* — only the media download 403s, so nothing upstream looks broken. Bare `yt-dlp` in the same container auto-detects deno and downloads fine.

Because the injection lives in `runYoutubeDL`, it affected both subscription and home-page downloads.

## Fix

Pass no `--js-runtimes` flag by default and let yt-dlp auto-detect an installed runtime. Added a `js_runtimes` setting (config, env var, and Settings UI) for anyone who needs to pin one deliberately. An explicit `--js-runtimes` in custom args still wins, as before.

## Also fixed

Three issues found while tracing this:

**Args were never logged.** `downloader.js` and `youtube-dl.js` logged only arg *counts*, so there was no way to see what was actually sent to yt-dlp — this bug required a manual container run to find. Now logged at debug level through the existing `redactCommandArgsForLogging` helper, so credentials and cookie paths stay redacted.

**Global custom args containing `-f` were silently ignored.** The default `qualityPath` was appended *after* global custom args, emitting a second `-f`; yt-dlp resolves last-wins, so the app default always won. Default format args now only fill in what custom args did not already set. An explicit per-download selection (quality, height, audio language) still takes precedence, as before. Also added `-S`/`--format-sort` to `YTDL_ARGS_WITH_VALUES`, which were missing and broke dedup for sort args.

**The extractor client fallback only applied to one path.** `ytdl_use_extractor_client_fallback` was wired into the home-page download path only, so enabling it did nothing for subscription downloads, subscription info fetches, or the playlist-chunking probe.

## Testing

- Full backend suite: 236 passing, 0 failing
- New coverage for JS runtime arg resolution, format-arg precedence in both directions, and the extractor fallback on subscription args
- Production frontend build passes
- Root cause verified against a live container

## Upgrade note

No action needed. `js_runtimes` defaults to empty (auto-detect) and existing configs auto-heal the key on first read. Anyone currently working around this with `--js-runtimes,,deno` in custom args can drop it, though leaving it is harmless.
