### PR TITLE
refactor(downloads): remove the extractor client fallback setting

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -51,9 +51,42 @@ function normalizeConfigRoot(config_json) {
     return {normalized_config: config_json, migrated: true};
 }
 
+// Settings that no longer exist. They are stripped from the config on startup so they do
+// not linger as dead keys, and anyone who had one enabled gets told what replaced it
+// rather than silently losing the behavior.
+const RETIRED_CONFIG_ITEMS = [
+    {
+        path: 'YtdlMaterial.Downloader.use_extractor_client_fallback',
+        enabled_warning: 'The \'use extractor client fallback\' setting has been removed. It always applied a fixed'
+            + ' yt-dlp client list (--extractor-args youtube:player_client=tv,web) which no longer works and now'
+            + ' causes the HTTP 403 download errors it was meant to prevent. yt-dlp now selects its own clients.'
+            + ' If you still need to pin one, add it to your global custom args, for example:'
+            + ' --extractor-args,,youtube:player_client=default'
+    }
+];
+
 exports.initialize = () => {
     ensureConfigFileExists();
+    removeRetiredConfigItems();
     ensureConfigItemsExist();
+}
+
+function removeRetiredConfigItems() {
+    const config_json = exports.getConfigFile();
+    if (!config_json) return;
+
+    let removed_any = false;
+    for (const retired_item of RETIRED_CONFIG_ITEMS) {
+        const parent_object = Object.byString(config_json, getParentPath(retired_item.path));
+        const element_name = getElementNameInConfig(retired_item.path);
+        if (!parent_object || !(element_name in parent_object)) continue;
+
+        if (parent_object[element_name] && retired_item.enabled_warning) logger.warn(retired_item.enabled_warning);
+        delete parent_object[element_name];
+        removed_any = true;
+    }
+
+    if (removed_any) exports.setConfigFile(config_json);
 }
 
 function ensureConfigItemsExist() {
@@ -263,7 +296,6 @@ const DEFAULT_CONFIG = {
         "download_rate_limit": "",
         "skip_join_only_videos": false,
         "use_ytdlp_impersonation": false,
-        "use_extractor_client_fallback": false,
         "js_runtimes": ""
       },
       "Extra": {

--- a/backend/consts.js
+++ b/backend/consts.js
@@ -86,10 +86,6 @@ exports.CONFIG_ITEMS = {
         'key': 'ytdl_use_ytdlp_impersonation',
         'path': 'YtdlMaterial.Downloader.use_ytdlp_impersonation'
     },
-    'ytdl_use_extractor_client_fallback': {
-        'key': 'ytdl_use_extractor_client_fallback',
-        'path': 'YtdlMaterial.Downloader.use_extractor_client_fallback'
-    },
     'ytdl_js_runtimes': {
         'key': 'ytdl_js_runtimes',
         'path': 'YtdlMaterial.Downloader.js_runtimes'

--- a/backend/downloader.js
+++ b/backend/downloader.js
@@ -59,7 +59,6 @@ const DOWNLOAD_ERROR_TRUNCATION_MARKER = '\n...[download error truncated]...\n';
 const DEFAULT_INVALID_FILENAME_CHARS = '\\/:*?"<>|';
 const METADATA_FIELDS_FOR_FILENAME_SANITIZATION = 'title,fulltitle,playlist_title,uploader,channel,series,chapter,album,artist';
 const DEFAULT_YTDLP_IMPERSONATION_ARG = '--impersonate=';
-const EXTRACTOR_CLIENT_FALLBACK_ARG_VALUE = 'youtube:player_client=tv,web';
 const SKIPPABLE_SUBSCRIPTION_DOWNLOAD_ERROR_TYPES = new Set(['join_only', 'no_output', 'no_downloadable_items']);
 const SKIPPABLE_SUBSCRIPTION_DOWNLOAD_ERROR_TEXT = [
     'join this channel',
@@ -192,19 +191,6 @@ function appendYtDlpImpersonationArgs(download_args = [], downloader_fork = conf
     return download_args.concat([DEFAULT_YTDLP_IMPERSONATION_ARG]);
 }
 exports.appendYtDlpImpersonationArgs = appendYtDlpImpersonationArgs;
-
-// Works around extractor experiments (e.g. binding the GVS PO Token to the video ID for
-// the web_safari client) that cause yt-dlp to extract info successfully but get a 403
-// when it tries to download the actual video data.
-function appendExtractorClientFallbackArgs(download_args = [], downloader_fork = config_api.getConfigItem('ytdl_default_downloader')) {
-    if (!Array.isArray(download_args)) return [];
-    if (downloader_fork !== 'yt-dlp') return download_args;
-    if (!config_api.getConfigItem('ytdl_use_extractor_client_fallback')) return download_args;
-    if (hasArg(download_args, '--extractor-args')) return download_args;
-
-    return download_args.concat(['--extractor-args', EXTRACTOR_CLIENT_FALLBACK_ARG_VALUE]);
-}
-exports.appendExtractorClientFallbackArgs = appendExtractorClientFallbackArgs;
 
 function normalizeArchiveExtractor(value = null) {
     if (typeof value !== 'string') return null;
@@ -1293,7 +1279,6 @@ async function getPlaylistChunkingMetadata(url, options = {}) {
     }
 
     probe_args = appendYtDlpImpersonationArgs(probe_args, downloader_fork);
-    probe_args = appendExtractorClientFallbackArgs(probe_args, downloader_fork);
 
     logger.debug(`Probing playlist metadata for automatic chunking: ${url}`);
     try {
@@ -2497,7 +2482,6 @@ exports.generateArgs = async (url, type, options, user_uid = null, simulated = f
     }
 
     downloadConfig = appendYtDlpImpersonationArgs(downloadConfig, default_downloader);
-    downloadConfig = appendExtractorClientFallbackArgs(downloadConfig, default_downloader);
 
     // filter out incompatible args
     downloadConfig = filterArgs(downloadConfig, is_audio);

--- a/backend/subscriptions.js
+++ b/backend/subscriptions.js
@@ -997,7 +997,6 @@ async function getSubscriptionInfo(sub) {
     downloadConfig = applyCustomArgs(downloadConfig, sub.custom_args);
     downloadConfig = utils.injectArgs(downloadConfig, ['--playlist-end', '1']);
     downloadConfig = downloader_api.appendYtDlpImpersonationArgs(downloadConfig, downloader_fork);
-    downloadConfig = downloader_api.appendExtractorClientFallbackArgs(downloadConfig, downloader_fork);
     let useCookies = config_api.getConfigItem('ytdl_use_cookies');
     if (useCookies) {
         if (await fs.pathExists(path.join(__dirname, 'appdata', 'cookies.txt'))) {
@@ -1493,7 +1492,6 @@ async function generateArgsForSubscription(sub, user_uid, redownload = false, de
     }
 
     downloadConfig = downloader_api.appendYtDlpImpersonationArgs(downloadConfig, default_downloader);
-    downloadConfig = downloader_api.appendExtractorClientFallbackArgs(downloadConfig, default_downloader);
 
     downloadConfig = utils.filterArgs(downloadConfig, ['--write-comments']);
 

--- a/backend/test/config.test.js
+++ b/backend/test/config.test.js
@@ -59,5 +59,25 @@ describe('Config', async function() {
         assert(changes[2]['key'] === 'test_prop4' && changes[2]['old_value'] === false && changes[2]['new_value'] === true);
         assert(changes[3]['key'] === 'test_prop6' && changes[3]['old_value'] === false && changes[3]['new_value'] === true);
     });
+
+    it('Strips the retired extractor client fallback setting on initialize', async function() {
+        const config_json = config_api.getConfigFile();
+        config_json['YtdlMaterial']['Downloader']['use_extractor_client_fallback'] = true;
+        config_api.setConfigFile(config_json);
+
+        config_api.initialize();
+
+        const updated_config = config_api.getConfigFile();
+        assert(!('use_extractor_client_fallback' in updated_config['YtdlMaterial']['Downloader']));
+    });
+
+    it('Leaves the config alone when no retired settings are stored', async function() {
+        config_api.initialize();
+        const before = JSON.stringify(config_api.getConfigFile());
+
+        config_api.initialize();
+
+        assert.strictEqual(JSON.stringify(config_api.getConfigFile()), before);
+    });
 });
 

--- a/backend/test/downloader.test.js
+++ b/backend/test/downloader.test.js
@@ -350,49 +350,29 @@ describe('Downloader', function() {
         }
     });
 
-    it('Generate args appends the extractor client fallback when enabled', async function() {
-        const original_fallback = config_api.getConfigItem('ytdl_use_extractor_client_fallback');
+    it('Generate args never adds extractor args on its own', async function() {
         const original_downloader = config_api.getConfigItem('ytdl_default_downloader');
         try {
-            config_api.setConfigItem('ytdl_use_extractor_client_fallback', true);
             config_api.setConfigItem('ytdl_default_downloader', 'yt-dlp');
-
-            const args = await downloader_api.generateArgs(url, 'video', {ui_uid: uuid()}, null, true);
-            const extractor_args_index = args.indexOf('--extractor-args');
-            assert(extractor_args_index !== -1);
-            assert.strictEqual(args[extractor_args_index + 1], 'youtube:player_client=tv,web');
-        } finally {
-            config_api.setConfigItem('ytdl_use_extractor_client_fallback', original_fallback);
-            config_api.setConfigItem('ytdl_default_downloader', original_downloader);
-        }
-    });
-
-    it('Generate args omits the extractor client fallback when disabled', async function() {
-        const original_fallback = config_api.getConfigItem('ytdl_use_extractor_client_fallback');
-        try {
-            config_api.setConfigItem('ytdl_use_extractor_client_fallback', false);
 
             const args = await downloader_api.generateArgs(url, 'video', {ui_uid: uuid()}, null, true);
             assert(!args.includes('--extractor-args'));
         } finally {
-            config_api.setConfigItem('ytdl_use_extractor_client_fallback', original_fallback);
+            config_api.setConfigItem('ytdl_default_downloader', original_downloader);
         }
     });
 
-    it('Generate args does not duplicate a manually configured extractor-args override', async function() {
-        const original_fallback = config_api.getConfigItem('ytdl_use_extractor_client_fallback');
+    it('Generate args passes a user configured extractor-args through untouched', async function() {
+        const original_global_args = config_api.getConfigItem('ytdl_custom_args');
         try {
-            config_api.setConfigItem('ytdl_use_extractor_client_fallback', true);
+            config_api.setConfigItem('ytdl_custom_args', '--extractor-args,,youtube:player_client=default');
 
-            const args = await downloader_api.generateArgs(url, 'video', {
-                customArgs: '--extractor-args,,youtube:player_client=android',
-                ui_uid: uuid()
-            }, null, true);
+            const args = await downloader_api.generateArgs(url, 'video', {ui_uid: uuid()}, null, true);
             const extractor_args_matches = args.filter(arg => arg === '--extractor-args');
             assert.strictEqual(extractor_args_matches.length, 1);
-            assert.strictEqual(args[args.indexOf('--extractor-args') + 1], 'youtube:player_client=android');
+            assert.strictEqual(args[args.indexOf('--extractor-args') + 1], 'youtube:player_client=default');
         } finally {
-            config_api.setConfigItem('ytdl_use_extractor_client_fallback', original_fallback);
+            config_api.setConfigItem('ytdl_custom_args', original_global_args);
         }
     });
 

--- a/backend/test/subscriptions.test.js
+++ b/backend/test/subscriptions.test.js
@@ -1108,32 +1108,29 @@ describe('Subscriptions', function() {
         assert.strictEqual(success, false);
         assert.strictEqual(fs.existsSync(metadata_path), false);
     });
-    it('Applies the extractor client fallback to subscription download args', async function() {
-        const original_fallback = config_api.getConfigItem('ytdl_use_extractor_client_fallback');
+    it('Never adds extractor args to subscription download args on its own', async function() {
         const original_downloader = config_api.getConfigItem('ytdl_default_downloader');
         try {
-            config_api.setConfigItem('ytdl_use_extractor_client_fallback', true);
             config_api.setConfigItem('ytdl_default_downloader', 'yt-dlp');
-
-            const args = await subscriptions_api.generateArgsForSubscription(new_sub, null);
-            const extractor_args_index = args.indexOf('--extractor-args');
-            assert(extractor_args_index !== -1);
-            assert.strictEqual(args[extractor_args_index + 1], 'youtube:player_client=tv,web');
-        } finally {
-            config_api.setConfigItem('ytdl_use_extractor_client_fallback', original_fallback);
-            config_api.setConfigItem('ytdl_default_downloader', original_downloader);
-        }
-    });
-
-    it('Omits the extractor client fallback from subscription args when disabled', async function() {
-        const original_fallback = config_api.getConfigItem('ytdl_use_extractor_client_fallback');
-        try {
-            config_api.setConfigItem('ytdl_use_extractor_client_fallback', false);
 
             const args = await subscriptions_api.generateArgsForSubscription(new_sub, null);
             assert(!args.includes('--extractor-args'));
         } finally {
-            config_api.setConfigItem('ytdl_use_extractor_client_fallback', original_fallback);
+            config_api.setConfigItem('ytdl_default_downloader', original_downloader);
+        }
+    });
+
+    it('Passes a user configured extractor-args through to subscription args', async function() {
+        const original_global_args = config_api.getConfigItem('ytdl_custom_args');
+        try {
+            config_api.setConfigItem('ytdl_custom_args', '--extractor-args,,youtube:player_client=default');
+
+            const args = await subscriptions_api.generateArgsForSubscription(new_sub, null);
+            const extractor_args_matches = args.filter(arg => arg === '--extractor-args');
+            assert.strictEqual(extractor_args_matches.length, 1);
+            assert.strictEqual(args[args.indexOf('--extractor-args') + 1], 'youtube:player_client=default');
+        } finally {
+            config_api.setConfigItem('ytdl_custom_args', original_global_args);
         }
     });
 

--- a/docker-environment.md
+++ b/docker-environment.md
@@ -95,7 +95,14 @@ When using env-managed Docker setups with `write_ytdl_config='true'`, you can cl
 * `ytdl_min_sleep_between_downloads`: minimum seconds to wait before starting the next queued download step (default `0`, disabled)
 * `ytdl_warn_on_duplicate`: set to `'true'` to warn on duplicate downloads and reuse existing files in playlists instead of downloading them again (default `'false'`)
 * `ytdl_max_playlist_chunks`: cap automatic playlist chunk creation (default `20`, min `1`)
-* `ytdl_use_extractor_client_fallback`: set to `'true'` to add yt-dlp `--extractor-args youtube:player_client=tv,web` as a workaround for 403 download errors (default `'false'`)
+
+`ytdl_use_extractor_client_fallback` has been removed. It always applied a fixed yt-dlp client list (`--extractor-args youtube:player_client=tv,web`), which no longer works and eventually caused the HTTP 403 download errors it was meant to prevent. yt-dlp now picks its own clients. If you need to pin one, set it yourself in **Settings → Downloader → Global custom args** (args are delimited by `,,`):
+
+```
+--extractor-args,,youtube:player_client=default
+```
+
+Anything you set there takes precedence and is never overwritten. See the [wiki](https://github.com/voc0der/ytdl-material/wiki#environment-specific-guideshelp) for how to pick a client.
 * `ytdl_js_runtimes`: pin the JavaScript runtime yt-dlp uses to solve YouTube's JS challenge, passed through as `--js-runtimes` (for example `deno` or `node`). Leave empty to let yt-dlp auto-detect an installed runtime, which is the default and is recommended. Pinning a runtime that is not installed causes downloads to fail with `unable to download video data: HTTP Error 403: Forbidden`; run `yt-dlp -v` and check the `JS Challenge Providers` line to see which runtimes are actually available (default empty)
 
 ## OIDC

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -194,9 +194,6 @@
             <div class="col-12 mt-2 mb-2">
               <mat-checkbox color="accent" [(ngModel)]="new_config['Downloader']['skip_join_only_videos']"><ng-container i18n="Skip join-only videos setting">Skip join-only videos</ng-container></mat-checkbox>
             </div>
-            <div class="col-12 mt-2 mb-2">
-              <mat-checkbox color="accent" [(ngModel)]="new_config['Downloader']['use_extractor_client_fallback']" matTooltip="Adds --extractor-args youtube:player_client=tv,web (yt-dlp only) to work around extractor experiments that cause downloads to fail with HTTP 403 errors." i18n-matTooltip="Use extractor client fallback setting tooltip"><ng-container i18n="Use extractor client fallback setting">Use extractor client fallback</ng-container></mat-checkbox>
-            </div>
             @if (postsService.ytdlpImpersonationAvailable) {
             <div class="col-12 mt-2 mb-2">
               <mat-checkbox color="accent" [(ngModel)]="new_config['Downloader']['use_ytdlp_impersonation']"><ng-container i18n="Use yt-dlp browser impersonation setting">Use yt-dlp browser impersonation</ng-container></mat-checkbox>

--- a/src/assets/default.json
+++ b/src/assets/default.json
@@ -22,7 +22,6 @@
       "download_rate_limit": "",
       "skip_join_only_videos": false,
       "use_ytdlp_impersonation": false,
-      "use_extractor_client_fallback": false,
       "js_runtimes": ""
     },
     "Extra": {


### PR DESCRIPTION
## Why

`ytdl_use_extractor_client_fallback` only ever appended a hardcoded client list:

```js
const EXTRACTOR_CLIENT_FALLBACK_ARG_VALUE = 'youtube:player_client=tv,web';
```

That pin is now actively harmful. With it enabled, downloads select a `TVHTML5` format and get refused partway through:

```
ERROR: unable to download video data: HTTP Error 403: Forbidden
```

Observed at ~25% of a 255 MB file — several 10 MB chunk requests succeed, then one 403s. Confirmed from the arg log added in #340:

```
yt-dlp args: ... --extractor-args youtube:player_client=tv,web ...
```

With the setting off, yt-dlp picks its own client (`ANDROID_VR` in testing) and the same downloads complete. So the setting now causes the failure it was written to prevent.

Worth noting #340 made this more visible: it wired the fallback into the subscription paths, where it had silently done nothing before. That fix was correct — the setting claimed to do something and didn't — but it meant subscription downloads started honoring a bad value.

## Why removal rather than a new value

A hardcoded client list is the wrong shape for this. It is correct only until YouTube next changes, and it has already gone stale once. Testing showed no fixed pin that beats yt-dlp's own selection.

There is also already a better escape hatch. **Settings → Downloader → Global custom args** accepts `--extractor-args`, and it takes precedence over anything the app adds. A checkbox that hardcodes one value is strictly less capable than the field users already have.

## Changes

- Removed the constant, `appendExtractorClientFallbackArgs`, and all four call sites (2 in `downloader.js`, 2 in `subscriptions.js`)
- Removed the config item, the default in `config.js` / `default.json`, and the Settings checkbox
- Replaced the env var entry in `docker-environment.md` with instructions for setting it yourself
- Wiki updated with client-selection guidance

## Migration

Not a silent drop. Retired settings are now stripped from stored configs on startup, and anyone who had this enabled gets a warning naming the replacement:

```
The 'use extractor client fallback' setting has been removed. It always applied a fixed
yt-dlp client list (--extractor-args youtube:player_client=tv,web) which no longer works
and now causes the HTTP 403 download errors it was meant to prevent. yt-dlp now selects
its own clients. If you still need to pin one, add it to your global custom args, for
example: --extractor-args,,youtube:player_client=default
```

`RETIRED_CONFIG_ITEMS` in `config.js` gives future removals somewhere to go.

## Testing

- Full backend suite: 237 passing, 0 failing
- Replaced the three fallback tests with coverage that the app never adds `--extractor-args` on its own and that a user-supplied one passes through untouched, on both the download and subscription paths
- New config tests for the strip-on-startup migration and for it being a no-op when nothing is stored
- Production frontend build passes
