### PR TITLE
fix: subscription Auto pagination server crashes

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1863,6 +1863,7 @@ app.post('/api/getSubscription', optionalJwt, async (req, res) => {
     }
 
     subscription = JSON.parse(JSON.stringify(subscription));
+    if (!include_videos) delete subscription['videos'];
 
     // get sub videos
     if (subscription.name) {

--- a/backend/files.js
+++ b/backend/files.js
@@ -9,6 +9,7 @@ const archive_api = require('./archive');
 const utils = require('./utils')
 const logger = require('./logger');
 const PLAYLIST_FILE_DELETE_BATCH_SIZE = 10;
+const FILE_LIST_MAX_RANGE_SIZE = 250;
 const PLAYER_SUBTITLE_SIDECAR_BASE_SUFFIX = '.player-subtitles';
 const MEDIA_EXTENSIONS_BY_TYPE = {
     audio: ['mp3'],
@@ -24,6 +25,17 @@ function shouldRestrictToUser(user_uid) {
 function escapeRegex(text = '') {
     return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
+
+function normalizeFileListRange(range = null) {
+    if (!Array.isArray(range) || range.length !== 2) return null;
+
+    const raw_start = Number(range[0]);
+    const raw_end = Number(range[1]);
+    const start = Number.isFinite(raw_start) ? Math.max(0, Math.floor(raw_start)) : 0;
+    const end = Number.isFinite(raw_end) ? Math.max(start, Math.floor(raw_end)) : start;
+    return [start, Math.min(end, start + FILE_LIST_MAX_RANGE_SIZE)];
+}
+exports.normalizeFileListRange = normalizeFileListRange;
 
 function getExpectedMediaExtension(type = 'video') {
     return type === 'audio' ? '.mp3' : '.mp4';
@@ -1548,7 +1560,8 @@ exports.getAllFiles = async (sort, range, text_search, file_type_filter, favorit
     if (file_type_filter === 'audio_only') filter_obj['isAudio'] = true;
     else if (file_type_filter === 'video_only') filter_obj['isAudio'] = false;
 
-    const files = await db_api.getRecords('files', filter_obj, false, sort, range);
+    const normalized_range = normalizeFileListRange(range);
+    const files = await db_api.getRecords('files', filter_obj, false, sort, normalized_range);
     const file_count = await db_api.getRecords('files', filter_obj, true);
 
     return {files, file_count};

--- a/backend/subscriptions.js
+++ b/backend/subscriptions.js
@@ -34,11 +34,57 @@ const SUBSCRIPTION_EXPECTED_SIZE_FORMAT_FIELDS = Object.freeze([
     'vbr',
     'abr'
 ]);
+const SUBSCRIPTION_PENDING_DOWNLOAD_BASE_PROJECTION_FIELDS = Object.freeze([
+    'uid',
+    'url',
+    'title',
+    'type',
+    'running',
+    'finished'
+]);
+const SUBSCRIPTION_PENDING_DOWNLOAD_PREFETCHED_INFO_FIELDS = Object.freeze([
+    'webpage_url',
+    'original_url',
+    'url',
+    'source_extractor',
+    'extractor',
+    'extractor_key',
+    'ie_key',
+    'source_id',
+    'id',
+    'display_id',
+    'title'
+]);
+const SUBSCRIPTION_ARCHIVE_PROJECTION_FIELDS = Object.freeze([
+    'extractor',
+    'id'
+]);
+const SUBSCRIPTION_SKIPPED_DOWNLOAD_PROJECTION_FIELDS = Object.freeze([
+    'error',
+    'error_summary',
+    'error_type',
+    'timestamp_start'
+]);
 const MATCH_FILTER_ARGS = new Set(['--match-filter', '--match-filters']);
 const BREAK_MATCH_FILTER_ARGS = new Set(['--break-match-filter', '--break-match-filters']);
 const NO_MATCH_FILTER_ARGS = new Set(['--no-match-filter', '--no-match-filters']);
 const JOIN_ONLY_AVAILABILITY_VALUES = new Set(['subscriber_only']);
 const active_subscription_refresh_trackers = new Map();
+
+function getSubscriptionPendingDownloadProjectionFields() {
+    // MongoDB find projections cannot address an array by numeric index. Projecting
+    // the selected fields across the array keeps the payload narrow and returns the
+    // normal array shape; local/PostgreSQL projections use the explicit first item.
+    const prefetched_info_path = db_api.isUsingMongoDB()
+        ? 'prefetched_info'
+        : 'prefetched_info.0';
+    return [
+        ...SUBSCRIPTION_PENDING_DOWNLOAD_BASE_PROJECTION_FIELDS,
+        ...SUBSCRIPTION_PENDING_DOWNLOAD_PREFETCHED_INFO_FIELDS.map(
+            field => `${prefetched_info_path}.${field}`
+        )
+    ];
+}
 
 function shouldRestrictToUser(user_uid) {
     return config_api.getConfigItem('ytdl_multi_user_mode') && user_uid !== null && user_uid !== undefined;
@@ -228,9 +274,14 @@ function getSubscriptionFileArchiveKey(file_obj = null, type = 'video') {
 function getSubscriptionDownloadArchiveKey(download = null, type = 'video') {
     if (!download || typeof download !== 'object') return null;
 
-    const prefetched_info_items = Array.isArray(download.prefetched_info)
-        ? download.prefetched_info.filter(info_item => !!info_item && typeof info_item === 'object')
-        : [];
+    const projected_prefetched_info = download.prefetched_info && !Array.isArray(download.prefetched_info)
+        ? download.prefetched_info['0']
+        : null;
+    const prefetched_info_items = (
+        Array.isArray(download.prefetched_info)
+            ? download.prefetched_info
+            : [projected_prefetched_info]
+    ).filter(info_item => !!info_item && typeof info_item === 'object');
     const candidates = [
         ...prefetched_info_items,
         {
@@ -745,10 +796,24 @@ async function removeArchivedPendingSubscriptionDownloads(sub, pending_downloads
 
     const effective_pending_downloads = Array.isArray(pending_downloads)
         ? pending_downloads
-        : await db_api.getRecords('download_queue', {sub_id: sub.id, finished: false});
+        : await db_api.getRecords(
+            'download_queue',
+            {sub_id: sub.id, finished: false},
+            false,
+            null,
+            null,
+            getSubscriptionPendingDownloadProjectionFields()
+        );
     if (effective_pending_downloads.length === 0) return 0;
 
-    const archive_items = await db_api.getRecords('archives', getSubscriptionArchiveFilter(sub));
+    const archive_items = await db_api.getRecords(
+        'archives',
+        getSubscriptionArchiveFilter(sub),
+        false,
+        null,
+        null,
+        SUBSCRIPTION_ARCHIVE_PROJECTION_FIELDS
+    );
     const archived_output_keys = new Set(
         archive_items
             .map(archive_item => getArchiveKey(archive_item.extractor, archive_item.id))
@@ -815,7 +880,8 @@ function countSkippedSubscriptionDownloads(downloads = [], refresh_started_at = 
     if (!Array.isArray(downloads)) return 0;
     const normalized_refresh_started_at = normalizeNullableCount(refresh_started_at);
     return downloads.filter(download => {
-        if (!downloader_api.isSkippableSubscriptionDownloadError(download && download.error, download && download.error_type)) return false;
+        const error_message = download && (download.error_summary || download.error);
+        if (!downloader_api.isSkippableSubscriptionDownloadError(error_message, download && download.error_type)) return false;
         const download_started_at = normalizeNullableCount(download && download.timestamp_start);
         return normalized_refresh_started_at === null || download_started_at === null || download_started_at >= normalized_refresh_started_at;
     }).length;
@@ -1753,7 +1819,14 @@ exports.getSubscription = async (subID, user_uid = null) => {
         db_api.getRecords('download_queue', {running: true, sub_id: subID}, true),
         db_api.getRecords('download_queue', {sub_id: subID, finished: false}, true),
         db_api.getRecords('download_queue', {sub_id: subID, running: true, finished: false}, true),
-        db_api.getRecords('download_queue', {sub_id: subID, finished: true, error: {$ne: null}})
+        db_api.getRecords(
+            'download_queue',
+            {sub_id: subID, finished: true, error: {$ne: null}},
+            false,
+            null,
+            null,
+            SUBSCRIPTION_SKIPPED_DOWNLOAD_PROJECTION_FIELDS
+        )
     ]);
     if (!sub['downloading']) sub['downloading'] = current_downloads > 0;
 

--- a/backend/test/files.test.js
+++ b/backend/test/files.test.js
@@ -586,4 +586,34 @@ describe('Files', function() {
             db_api.getRecords = original_get_records;
         }
     });
+
+    it('caps paginated file queries at the largest supported page size', async function() {
+        const original_get_records = db_api.getRecords;
+        const captured_ranges = [];
+
+        try {
+            db_api.getRecords = async (table, filter_obj, return_count, sort, range) => {
+                captured_ranges.push({return_count, range});
+                return return_count ? 400 : [];
+            };
+
+            const result = await files_api.getAllFiles(
+                {by: 'registered', order: -1},
+                [20, 1020],
+                null,
+                'both',
+                false,
+                'network-chuck',
+                null
+            );
+
+            assert.deepStrictEqual(captured_ranges, [
+                {return_count: false, range: [20, 270]},
+                {return_count: true, range: undefined}
+            ]);
+            assert.strictEqual(result.file_count, 400);
+        } finally {
+            db_api.getRecords = original_get_records;
+        }
+    });
 });

--- a/backend/test/subscriptions.test.js
+++ b/backend/test/subscriptions.test.js
@@ -416,6 +416,138 @@ describe('Subscriptions', function() {
         assert.strictEqual(stored_sub['refresh_status']['skipped_count'], 2);
         assert.strictEqual(stored_sub['refresh_status']['phase'], 'complete');
     });
+    it('Projects heavyweight queue records while retrieving subscription status', async function() {
+        const original_get_records = db_api.getRecords;
+        const sub = Object.assign({}, new_sub, {id: uuid(), name: 'projected_status_sub'});
+        const refresh_started_at = Date.now() - 1000;
+        const pending_uid = uuid();
+
+        await db_api.insertRecordIntoTable('subscriptions', {
+            ...sub,
+            refresh_status: {
+                active: false,
+                phase: 'queued',
+                discovered_count: 2,
+                total_count: 2,
+                new_items_count: 2,
+                queued_count: 2,
+                started_at: refresh_started_at
+            }
+        });
+        await archive_api.addToArchive('youtube', 'archived-pending-video', 'video', 'Archived pending video', null, sub.id);
+        await db_api.insertRecordIntoTable('download_queue', {
+            uid: pending_uid,
+            url: 'https://example.com/not-a-source-url',
+            type: 'video',
+            title: 'Archived pending video',
+            sub_id: sub.id,
+            running: false,
+            finished: false,
+            error: null,
+            prefetched_info: [{
+                extractor: 'youtube',
+                id: 'archived-pending-video',
+                title: 'Archived pending video',
+                formats: [{
+                    manifest: 'unused-heavy-format-data'
+                }]
+            }],
+            unused_heavy_payload: 'unused-heavy-queue-data'
+        });
+        await db_api.insertRecordIntoTable('download_queue', {
+            uid: uuid(),
+            url: 'https://www.youtube.com/watch?v=skipped-video',
+            type: 'video',
+            title: 'Skipped video',
+            sub_id: sub.id,
+            running: false,
+            finished: true,
+            error: 'Join this channel to get access to members-only content',
+            error_summary: 'Join this channel to get access to members-only content',
+            error_type: 'join_only',
+            timestamp_start: Date.now(),
+            prefetched_info: [{
+                formats: [{
+                    manifest: 'unused-heavy-finished-data'
+                }]
+            }],
+            unused_heavy_payload: 'unused-heavy-finished-queue-data'
+        });
+
+        const captured_calls = [];
+        try {
+            db_api.getRecords = async (...args) => {
+                captured_calls.push(args);
+                return await original_get_records(...args);
+            };
+
+            const refreshed_sub = await subscriptions_api.getSubscription(sub.id);
+
+            assert(refreshed_sub);
+            assert.strictEqual(refreshed_sub['refresh_status']['pending_download_count'], 0);
+            assert.strictEqual(refreshed_sub['refresh_status']['skipped_count'], 2);
+        } finally {
+            db_api.getRecords = original_get_records;
+        }
+
+        const pending_read = captured_calls.find(call =>
+            call[0] === 'download_queue'
+            && call[1] && call[1].finished === false
+            && call[2] === false
+        );
+        const skipped_read = captured_calls.find(call =>
+            call[0] === 'download_queue'
+            && call[1] && call[1].finished === true
+            && call[1].error
+            && call[2] === false
+        );
+        const archive_read = captured_calls.find(call => call[0] === 'archives');
+
+        assert(pending_read);
+        assert(pending_read[5].includes('prefetched_info.0.id'));
+        assert(!pending_read[5].includes('prefetched_info'));
+        assert(!pending_read[5].includes('unused_heavy_payload'));
+        assert(skipped_read);
+        assert.deepStrictEqual(skipped_read[5], [
+            'error',
+            'error_summary',
+            'error_type',
+            'timestamp_start'
+        ]);
+        assert(archive_read);
+        assert.deepStrictEqual(archive_read[5], ['extractor', 'id']);
+    });
+    it('Uses Mongo-compatible nested array projections for pending subscription downloads', async function() {
+        const original_get_records = db_api.getRecords;
+        const original_is_using_mongo_db = db_api.isUsingMongoDB;
+        const sub = Object.assign({}, new_sub, {id: uuid(), name: 'mongo_projection_sub'});
+        const captured_calls = [];
+
+        await db_api.insertRecordIntoTable('subscriptions', sub);
+
+        try {
+            db_api.isUsingMongoDB = () => true;
+            db_api.getRecords = async (...args) => {
+                captured_calls.push(args);
+                return await original_get_records(...args);
+            };
+
+            const refreshed_sub = await subscriptions_api.getSubscription(sub.id);
+            assert(refreshed_sub);
+        } finally {
+            db_api.getRecords = original_get_records;
+            db_api.isUsingMongoDB = original_is_using_mongo_db;
+        }
+
+        const pending_read = captured_calls.find(call =>
+            call[0] === 'download_queue'
+            && call[1] && call[1].finished === false
+            && call[2] === false
+        );
+        assert(pending_read);
+        assert(pending_read[5].includes('prefetched_info.id'));
+        assert(!pending_read[5].includes('prefetched_info.0.id'));
+    });
     it('Update subscription', async function () {
         await subscriptions_api.subscribe(new_sub, null, true);
         const sub_update = Object.assign({}, new_sub, {name: 'updated_name'});

--- a/src/app/components/media-library/media-library.component.spec.ts
+++ b/src/app/components/media-library/media-library.component.spec.ts
@@ -363,6 +363,62 @@ describe('MediaLibraryComponent', () => {
     expect(component.getAutoPageBatchSize()).toBe(20);
   });
 
+  it('should keep appended auto batches viewport-sized after the grid scrolls above the viewport', () => {
+    postsServiceStub.card_size = 'medium';
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 900 });
+    let grid_top = -840;
+    (component as any).videoGridContainerElement = {
+      getBoundingClientRect: () => ({ top: grid_top, width: 941 })
+    };
+    component.autoPaginationEnabled = true;
+    component.paged_data = Array.from({length: 20}, (_, index) => ({
+      uid: `file-${index + 1}`,
+      duration: 12
+    })) as any;
+
+    expect(component.getAutoPageBatchSize(true)).toBe(24);
+    expect(component.getRequestedFileRange(false, true)).toEqual([20, 44]);
+
+    grid_top = -3000;
+    component.paged_data = Array.from({length: 44}, (_, index) => ({
+      uid: `file-${index + 1}`,
+      duration: 12
+    })) as any;
+
+    expect(component.getAutoPageBatchSize(true)).toBe(24);
+    expect(component.getRequestedFileRange(false, true)).toEqual([44, 68]);
+  });
+
+  it('should keep subscription auto-pagination requests scoped and bounded', () => {
+    component.sub_id = 'network-chuck';
+    component.autoPaginationEnabled = true;
+    component.file_count = 400;
+    component.paged_data = Array.from({length: 24}, (_, index) => ({
+      uid: `file-${index + 1}`,
+      duration: 12
+    })) as any;
+    spyOn(component, 'getAutoPageBatchSize').and.returnValue(24);
+    spyOn(component, 'getAutoPageColumns').and.returnValue(4);
+    postsServiceStub.getAllFiles.calls.reset();
+    postsServiceStub.getAllFiles.and.returnValue(of({
+      files: [],
+      file_count: 400
+    }));
+
+    component.loadMoreAutoFiles();
+
+    expect(postsServiceStub.getAllFiles).toHaveBeenCalledWith(
+      { by: 'registered', order: -1 },
+      [24, 48],
+      null,
+      'both',
+      false,
+      'network-chuck',
+      false,
+      []
+    );
+  });
+
   it('should window auto-loaded video rows instead of rendering every loaded row', () => {
     component.autoPaginationEnabled = true;
     component.normal_files_received = true;

--- a/src/app/components/media-library/media-library.component.ts
+++ b/src/app/components/media-library/media-library.component.ts
@@ -1100,7 +1100,7 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
 
   getRequestedFileRange(cache_mode = false, append = false): number[] {
     if (this.autoPaginationEnabled) {
-      const auto_page_batch_size = this.getAutoPageBatchSize();
+      const auto_page_batch_size = this.getAutoPageBatchSize(append);
       const auto_page_columns = this.getAutoPageColumns();
       if (append) {
         const start = this.paged_data?.length ?? 0;
@@ -1497,13 +1497,19 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
     }
   }
 
-  getAutoPageBatchSize(): number {
+  getAutoPageBatchSize(append = false): number {
     const columns = this.getAutoPageColumns();
     const row_height = this.getAutoCardRowHeight();
     const viewport_height = this.getViewportHeight();
-    const grid_top = this.getVisibleGridTopOffset();
-    const estimated_grid_top = typeof grid_top === 'number' ? grid_top : viewport_height * 0.3;
-    const available_height = Math.max(row_height, viewport_height - estimated_grid_top);
+    const raw_grid_top = this.getVisibleGridTopOffset();
+    const grid_top = Number.isFinite(raw_grid_top)
+      ? Math.max(0, Math.min(viewport_height, raw_grid_top))
+      : viewport_height * 0.3;
+    // Once scrolling has started, the grid top becomes increasingly negative. Using that
+    // document-relative value made every append request grow with the full scroll depth.
+    const available_height = append
+      ? viewport_height
+      : Math.max(row_height, viewport_height - grid_top);
     const visible_rows = Math.max(1, Math.ceil(available_height / row_height));
     return columns * (visible_rows + this.autoPageBufferRows);
   }

--- a/src/app/posts.services.ts
+++ b/src/app/posts.services.ts
@@ -3,7 +3,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { THEMES_CONFIG } from '../themes';
 import { Router, ActivatedRouteSnapshot } from '@angular/router';
 
-import { BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { filter, take } from 'rxjs/operators';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import {
@@ -197,9 +197,9 @@ export class PostsService {
     settings_changed = new BehaviorSubject<boolean>(false);
     open_create_default_admin_dialog = new BehaviorSubject<boolean>(false);
 
-    files_changed = new BehaviorSubject<boolean>(false);
-    playlists_changed = new BehaviorSubject<boolean>(false);
-    categories_changed = new BehaviorSubject<boolean>(false);
+    files_changed = new Subject<boolean>();
+    playlists_changed = new Subject<boolean>();
+    categories_changed = new Subject<boolean>();
 
     // app status
     initialized = false;

--- a/src/app/subscription/subscription/subscription.component.spec.ts
+++ b/src/app/subscription/subscription/subscription.component.spec.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject, of } from 'rxjs';
+import { BehaviorSubject, of, Subject } from 'rxjs';
 
 import { SubscriptionComponent } from './subscription.component';
 
@@ -104,6 +104,150 @@ describe('SubscriptionComponent', () => {
 
     expect(component.subscription.file_count).toBe(2);
     expect(postsService.files_changed.next).toHaveBeenCalledWith(true);
+  });
+
+  it('should not publish a file change while initially loading subscription metadata', () => {
+    spyOn(postsService.files_changed, 'next');
+    postsService.getSubscription.and.returnValue(of({
+      subscription: {
+        id: 'sub-1',
+        name: 'Test subscription',
+        file_count: 400,
+        downloading: false
+      }
+    }));
+
+    component.getSubscription();
+
+    expect(component.subscription.file_count).toBe(400);
+    expect(postsService.files_changed.next).not.toHaveBeenCalled();
+  });
+
+  it('should not overlap lightweight subscription status requests', () => {
+    const first_response = new Subject<any>();
+    postsService.getSubscription.and.returnValues(
+      first_response.asObservable(),
+      of({
+        subscription: {
+          id: 'sub-1',
+          name: 'Test subscription',
+          file_count: 1,
+          downloading: false
+        }
+      })
+    );
+
+    component.getSubscription(true);
+    component.getSubscription(true);
+
+    expect(postsService.getSubscription).toHaveBeenCalledTimes(1);
+
+    first_response.next({
+      subscription: {
+        id: 'sub-1',
+        name: 'Test subscription',
+        file_count: 1,
+        downloading: true
+      }
+    });
+    first_response.complete();
+    component.getSubscription(true);
+
+    expect(postsService.getSubscription).toHaveBeenCalledTimes(2);
+  });
+
+  it('should discard outdated responses across rapid subscription route changes', () => {
+    const first_a_response = new Subject<any>();
+    const b_response = new Subject<any>();
+    const second_a_response = new Subject<any>();
+    postsService.getSubscription.and.returnValues(
+      first_a_response.asObservable(),
+      b_response.asObservable(),
+      second_a_response.asObservable()
+    );
+
+    component.id = 'sub-1';
+    component.getSubscription(true);
+    component.id = 'sub-2';
+    component.subscription = null;
+    component.getSubscription(true);
+    component.id = 'sub-1';
+    component.subscription = null;
+    component.getSubscription(true);
+
+    second_a_response.next({
+      subscription: {
+        id: 'sub-1',
+        name: 'Current first subscription',
+        file_count: 3,
+        downloading: false
+      }
+    });
+    second_a_response.complete();
+    first_a_response.next({
+      subscription: {
+        id: 'sub-1',
+        name: 'Outdated first subscription',
+        file_count: 1,
+        downloading: false
+      }
+    });
+    first_a_response.complete();
+    b_response.next({
+      subscription: {
+        id: 'sub-2',
+        name: 'Outdated second subscription',
+        file_count: 2,
+        downloading: false
+      }
+    });
+    b_response.complete();
+
+    expect(postsService.getSubscription).toHaveBeenCalledTimes(3);
+    expect(component.subscription.id).toBe('sub-1');
+    expect(component.subscription.name).toBe('Current first subscription');
+  });
+
+  it('should poll idle subscriptions less often while keeping active refreshes responsive', () => {
+    component.subscription = {
+      id: 'sub-1',
+      name: 'Test subscription',
+      file_count: 1,
+      downloading: false,
+      refresh_status: {
+        phase: 'complete',
+        active: false,
+        pending_download_count: 0,
+        running_download_count: 0
+      }
+    } as any;
+    const get_subscription_spy = spyOn(component, 'getSubscription');
+    (component as any).last_subscription_request_at = Date.now();
+
+    (component as any).pollSubscription();
+    expect(get_subscription_spy).not.toHaveBeenCalled();
+
+    component.subscription.refresh_status.active = true;
+    component.subscription.refresh_status.phase = 'collecting';
+    (component as any).last_subscription_request_at = Date.now() - 1001;
+    (component as any).pollSubscription();
+
+    expect(get_subscription_spy).toHaveBeenCalledWith(true);
+  });
+
+  it('should refresh subscription status immediately after starting a check', () => {
+    component.subscription = {
+      id: 'sub-1',
+      name: 'Test subscription',
+      file_count: 1,
+      downloading: false
+    } as any;
+    postsService.checkSubscription.and.returnValue(of({success: true}));
+    const get_subscription_spy = spyOn(component, 'getSubscription');
+
+    component.checkSubscription();
+
+    expect(get_subscription_spy).toHaveBeenCalledWith(true);
   });
 
   it('should describe collecting progress when totals are known', () => {

--- a/src/app/subscription/subscription/subscription.component.ts
+++ b/src/app/subscription/subscription/subscription.component.ts
@@ -5,7 +5,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { EditSubscriptionDialogComponent } from 'app/dialogs/edit-subscription-dialog/edit-subscription-dialog.component';
 import { Subscription, SubscriptionRefreshStatus } from 'api-types';
 import { saveAs } from 'file-saver';
-import { filter, take } from 'rxjs/operators';
+import { filter, finalize, take } from 'rxjs/operators';
 
 @Component({
     selector: 'app-subscription',
@@ -16,6 +16,8 @@ import { filter, take } from 'rxjs/operators';
 })
 export class SubscriptionComponent implements OnInit, OnDestroy {
 
+  private readonly active_poll_interval_ms = 1000;
+  private readonly idle_poll_interval_ms = 10000;
   id = null;
   subscription: Subscription = null;
   use_youtubedl_archive = false;
@@ -24,12 +26,20 @@ export class SubscriptionComponent implements OnInit, OnDestroy {
   sub_interval = null;
   check_clicked = false;
   cancel_clicked = false;
+  private active_subscription_request: {id: string | null; token: number} | null = null;
+  private subscription_request_sequence = 0;
+  private last_subscription_request_at = 0;
 
   constructor(private postsService: PostsService, private route: ActivatedRoute, private router: Router, private dialog: MatDialog) { }
 
   ngOnInit() {
     this.route.params.subscribe(params => {
-      this.id = params['id'];
+      const next_id = params['id'];
+      if (next_id !== this.id) {
+        this.subscription = null;
+        this.last_subscription_request_at = 0;
+      }
+      this.id = next_id;
 
       if (this.sub_interval) { clearInterval(this.sub_interval); }
 
@@ -38,7 +48,7 @@ export class SubscriptionComponent implements OnInit, OnDestroy {
         .subscribe(() => {
           this.getConfig();
           this.getSubscription();
-          this.sub_interval = setInterval(() => this.getSubscription(true), 1000);
+          this.sub_interval = setInterval(() => this.pollSubscription(), this.active_poll_interval_ms);
         });
     });
   }
@@ -55,7 +65,20 @@ export class SubscriptionComponent implements OnInit, OnDestroy {
   }
 
   getSubscription(low_cost = false) {
-    this.postsService.getSubscription(this.id, null, false).subscribe(res => {
+    const requested_id = this.id as string | null;
+    if (this.active_subscription_request?.id === requested_id) return;
+
+    const request_token = ++this.subscription_request_sequence;
+    this.active_subscription_request = {id: requested_id, token: request_token};
+    this.last_subscription_request_at = Date.now();
+    this.postsService.getSubscription(requested_id, null, false)
+      .pipe(finalize(() => {
+        if (this.active_subscription_request?.token === request_token) {
+          this.active_subscription_request = null;
+        }
+      }))
+      .subscribe(res => {
+      if (requested_id !== this.id || this.active_subscription_request?.token !== request_token) return;
       const next_subscription = res['subscription'] as Subscription;
       const current_video_count = this.getSubscriptionFileCount(this.subscription);
       const next_video_count = this.getSubscriptionFileCount(next_subscription);
@@ -67,12 +90,25 @@ export class SubscriptionComponent implements OnInit, OnDestroy {
           videos: this.subscription.videos
         };
         return;
-      } else if (next_video_count > current_video_count) {
+      } else if (this.subscription && next_video_count > current_video_count) {
         // only when files are added so we don't reload files when one is deleted
         this.postsService.files_changed.next(true);
       }
       this.subscription = next_subscription;
-    });
+    }, err => console.error(err));
+  }
+
+  private pollSubscription(): void {
+    const refresh_status = this.getRefreshStatus();
+    const poll_interval = !this.subscription
+      || this.hasActiveRefresh()
+      || (refresh_status?.pending_download_count ?? 0) > 0
+      || (refresh_status?.running_download_count ?? 0) > 0
+      ? this.active_poll_interval_ms
+      : this.idle_poll_interval_ms;
+
+    if ((Date.now() - this.last_subscription_request_at) < poll_interval) return;
+    this.getSubscription(true);
   }
 
   private getSubscriptionFileCount(subscription: Subscription | null): number {
@@ -117,6 +153,8 @@ export class SubscriptionComponent implements OnInit, OnDestroy {
         this.postsService.openSnackBar('Failed to check subscription!');
         return;
       }
+      this.last_subscription_request_at = 0;
+      this.getSubscription(true);
     }, err => {
       console.error(err);
       this.check_clicked = false;
@@ -132,6 +170,8 @@ export class SubscriptionComponent implements OnInit, OnDestroy {
         this.postsService.openSnackBar('Failed to cancel check subscription!');
         return;
       }
+      this.last_subscription_request_at = 0;
+      this.getSubscription(true);
     }, err => {
       console.error(err);
       this.cancel_clicked = false;


### PR DESCRIPTION
## Summary

- keep Auto pagination append batches viewport-sized instead of growing with scroll depth
- cap paginated file-list requests at 250 records server-side
- make subscription status reads project only required queue/archive fields across local, PostgreSQL, and MongoDB backends
- prevent replayed duplicate library refreshes and overlapping subscription polls
- reduce idle polling frequency and reject stale route responses
- ensure lightweight subscription responses do not retain embedded video arrays

## Root cause

The Auto batch calculation used the live grid top after scrolling. Once the grid moved above the viewport, its increasingly negative offset caused later requests to balloon from viewport-sized pages to roughly 40, 80, and 160 records. Subscription status polling also repeatedly loaded heavyweight queue records containing prefetched metadata. Together these amplified heap use until Node reached its approximately 512 MB V8 limit and PM2 restarted the server.

## Validation

- `npm run lint -- --quiet`
- `npm run test:headless` — 230 passing
- `cd backend && npm test` — 249 passing, 25 pending
- `npm run build`
- `git diff --check`