### PR TITLE
chore(deps): bump dependencies and refresh security overrides

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,7 +48,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4.37.5
+      uses: github/codeql-action/init@v4.37.6
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -59,7 +59,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4.37.5
+      uses: github/codeql-action/autobuild@v4.37.6
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -73,4 +73,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4.37.5
+      uses: github/codeql-action/analyze@v4.37.6

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,7 +20,7 @@
         "body-parser": "^2.3.0",
         "command-exists": "^1.2.9",
         "compression": "^1.8.1",
-        "config": "^4.4.2",
+        "config": "^5.0.0",
         "execa": "^10.0.0",
         "express": "^5.2.1",
         "express-rate-limit": "^8.6.1",
@@ -407,13 +407,13 @@
       }
     },
     "node_modules/@scalar/client-side-rendering": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@scalar/client-side-rendering/-/client-side-rendering-0.3.5.tgz",
-      "integrity": "sha512-0MX6HN4hNhMlBTqm+PJ1Rgi5yQy7NkMEPMa6QXdyKAO59pQVzWlBGT+MlAnyXCeVrqFULzZh90v81t5UQ/uYEw==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@scalar/client-side-rendering/-/client-side-rendering-0.3.6.tgz",
+      "integrity": "sha512-CshKXof+tyu0tpgMhRSoNw6Fnn1ywVveJnb5iIJ8ue/FIVn6rP+BEQcgdIiNUPBEXHaAnz+HCGGiScKRzXRB7Q==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/schemas": "0.8.0",
-        "@scalar/types": "0.17.0",
+        "@scalar/schemas": "0.8.1",
+        "@scalar/types": "0.17.1",
         "@scalar/validation": "0.6.2"
       },
       "engines": {
@@ -421,33 +421,33 @@
       }
     },
     "node_modules/@scalar/express-api-reference": {
-      "version": "0.10.12",
-      "resolved": "https://registry.npmjs.org/@scalar/express-api-reference/-/express-api-reference-0.10.12.tgz",
-      "integrity": "sha512-xQXw1KQpwybx9G8LLiuFcPvC3uRIAtfom3nFkAfaPhp6wLkPKoM1oCxKEwj+8zftFm+quiEey8GfmjISTOVZhQ==",
+      "version": "0.10.13",
+      "resolved": "https://registry.npmjs.org/@scalar/express-api-reference/-/express-api-reference-0.10.13.tgz",
+      "integrity": "sha512-4VAIiiNV7q1tmTtFcG/aZfaK9fV/+Z1hqStxmAD/MWUyVdn0BG36ZjNmEzB6cPBWZraCFv87KQaItaWVLNzezg==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/client-side-rendering": "0.3.5"
+        "@scalar/client-side-rendering": "0.3.6"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/helpers": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.9.2.tgz",
-      "integrity": "sha512-hjyMpMZjTBZQhyByZmz5oUgRKUQJO5V5AOiJxsVEGbUmgA7sJRQeTrXLB+BEwzaKS5nm2opJeNyMBYLFNK4hiQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.10.0.tgz",
+      "integrity": "sha512-IAfnpIZnXY6ni+zyFMwWHBa5b/7yr4mCSvoTGR84oS9q4Quy2wjgafnr7CyfL65ney3iilBZHigZYLYqdqCu3Q==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/schemas": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@scalar/schemas/-/schemas-0.8.0.tgz",
-      "integrity": "sha512-bwu/NCOghZI/cL6Ayti/Oeb5XEMRTncBsyQeHhkFwk4PZsR910me+kZPd5TAp6TqifMfDbAe3xyLSdlzU/KFLA==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@scalar/schemas/-/schemas-0.8.1.tgz",
+      "integrity": "sha512-SGB/Verzjf6wpULdOIQfCCPvG46GTVYawirjQ8AVSFSIMduS6zz1MpL+I90Z8/zjeSbjtwRoLtjjWb2yByEjfQ==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.9.2",
+        "@scalar/helpers": "0.10.0",
         "@scalar/validation": "0.6.2"
       },
       "engines": {
@@ -455,12 +455,12 @@
       }
     },
     "node_modules/@scalar/types": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.17.0.tgz",
-      "integrity": "sha512-mj033MX0EFOEwfpO3ch7FGGnMbye1aLlnP6LmTC9Il2AlBCDL41rYPk67jF5ICAMsAES1RQ+8N2bcC0MJnupLQ==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.17.1.tgz",
+      "integrity": "sha512-jqudbDtdvP/SiOTuj7Gg3dBY8IMb7oeJI/7K4QF2cOiWgnbYUQFeaYzktpNZwcCQkIJwlxYfd0i97KwlyD9GMQ==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.9.2",
+        "@scalar/helpers": "0.10.0",
         "nanoid": "^5.1.6",
         "type-fest": "^5.3.1",
         "zod": "^4.3.5"
@@ -703,12 +703,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "license": "MIT"
-    },
     "node_modules/append-field": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
@@ -899,9 +893,9 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.7.tgz",
-      "integrity": "sha512-o8CRCiJtib+ycO3mE4A5UChtGX4dDP2XxsWVu9P+Zc3H8tcmKwNVEDoDTXmwN+uuMhfKeT7/i7Y26xS8W7ohoA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.5.1.tgz",
+      "integrity": "sha512-cD5ciQuKlx+eumTCfqbfiL+fhQm+dHbVNB/cX4+d+I/nx4JsVop9VoFEPAs5RJ6I84QR6bZIBjpd2kjDOYeWcg==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-path": "^3.0.0"
@@ -967,9 +961,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -1494,15 +1488,15 @@
       }
     },
     "node_modules/config": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/config/-/config-4.4.2.tgz",
-      "integrity": "sha512-5HJD7TX70gOG2dAd72eDjDeSTYn6D8nOiKgysQQS8mRUo9X1wDtlzb1JlmIWkP+sM9zKRVdYJxmj+qmCsYu6DQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/config/-/config-5.0.0.tgz",
+      "integrity": "sha512-LaZ/Z113nYJ4YNrH13dWdHvgIehYACiJZPxFVK8ykqO+6CaMAiJ7NkyrxTPAimMJoIKn7qPrvTFzIBPgm4/SLA==",
       "license": "MIT",
       "dependencies": {
         "json5": "^2.2.3"
       },
       "engines": {
-        "node": ">= 20.0.0"
+        "node": ">= 20.11.0"
       }
     },
     "node_modules/connected-domain": {
@@ -1755,9 +1749,9 @@
       "license": "MIT"
     },
     "node_modules/discord-api-types": {
-      "version": "0.38.52",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.52.tgz",
-      "integrity": "sha512-uwe9EKfbjsmgWc2fdFjvDbj+dQqx3lp7wqDCmIha0jInuU+xeQjkCK9tMMn+p7RXfdVQORCInq4cD3U2ymDmyg==",
+      "version": "0.38.53",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.53.tgz",
+      "integrity": "sha512-HL1zz/UuZ+bbJjA/X8Kbxx9gk8v9rJAbTeWRNYKmIdjwJ7EovjlHgoJTxcLpATfNJ+AonOtMdy3Y5MVIJAAd/A==",
       "license": "MIT",
       "workspaces": [
         "scripts/actions/documentation"
@@ -2051,9 +2045,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.6.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
-      "integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -2806,9 +2800,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -3496,17 +3490,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/mz": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
-      }
-    },
     "node_modules/nanoid": {
       "version": "5.1.16",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
@@ -3654,15 +3637,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/object-hash": {
@@ -4354,12 +4328,12 @@
       }
     },
     "node_modules/read-last-lines": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/read-last-lines/-/read-last-lines-1.8.0.tgz",
-      "integrity": "sha512-oPL0cnZkhsO2xF7DBrdzVhXSNajPP5TzzCim/2IAjeGb17ArLLTRriI/ceV6Rook3L27mvbrOvLlf9xYYnaftQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/read-last-lines/-/read-last-lines-1.10.0.tgz",
+      "integrity": "sha512-RnfSZUzg5y2TklfEzk8K/oQChYaLiYlH4Ee7M1SsDYoygvgl9N4DPrfiXXLlbENSaeWblV173HaP3aZ1G4dyMw==",
       "license": "MIT",
-      "dependencies": {
-        "mz": "^2.7.0"
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/readable-stream": {
@@ -4582,9 +4556,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
-      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+      "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=20.0.0"
@@ -5039,27 +5013,6 @@
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
       "license": "MIT"
     },
-    "node_modules/thenify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0"
-      }
-    },
-    "node_modules/thenify-all": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "license": "MIT",
-      "dependencies": {
-        "thenify": ">= 3.1.0 < 4"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -5163,9 +5116,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -5537,9 +5490,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/backend/package.json
+++ b/backend/package.json
@@ -34,7 +34,7 @@
     "body-parser": "^2.3.0",
     "command-exists": "^1.2.9",
     "compression": "^1.8.1",
-    "config": "^4.4.2",
+    "config": "^5.0.0",
     "execa": "^10.0.0",
     "express": "^5.2.1",
     "express-rate-limit": "^8.6.1",
@@ -75,16 +75,16 @@
     "xmlbuilder2": "^4.0.3"
   },
   "overrides": {
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "braces": "3.0.3",
     "cross-spawn": "7.0.6",
     "diff": "8.0.3",
     "form-data": "4.0.6",
     "got": "11.8.6",
-    "js-yaml": "4.3.0",
-    "serialize-javascript": "7.0.5",
-    "undici": "6.27.0",
-    "ws": "8.21.0"
+    "js-yaml": "4.3.1",
+    "serialize-javascript": "7.0.7",
+    "undici": "6.28.0",
+    "ws": "8.21.3"
   },
   "devDependencies": {
     "pg-mem": "^3.0.14"

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,8 +49,8 @@
         "@types/file-saver": "^2.0.1",
         "@types/jasmine": "^6.0.0",
         "@types/node": "^26.1.2",
-        "@typescript-eslint/eslint-plugin": "^8.65.0",
-        "@typescript-eslint/parser": "^8.65.0",
+        "@typescript-eslint/eslint-plugin": "^8.66.0",
+        "@typescript-eslint/parser": "^8.66.0",
         "ajv": "^8.20.0",
         "eslint": "^10.8.0",
         "globals": "^17.8.0",
@@ -86,13 +86,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.2201.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2201.2.tgz",
-      "integrity": "sha512-RRG3JA3hPH0ypbDIyquZt9DDTP5pOMPgqQ/iLSkok1MZdKiOgpk6FGfXCa1ei72SwlX7lnJdq94d6WWdqpbyKg==",
+      "version": "0.2201.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2201.3.tgz",
+      "integrity": "sha512-5WX6rooTQZCh+yE9k3O5hc7nnQtzy1nw6fQpaTuCzIgPG8teQuVtdxegBsM3OcjJac1r+qJLo+KmTRfnqcfsyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.1.2",
+        "@angular-devkit/core": "22.1.3",
         "rxjs": "7.8.2"
       },
       "bin": {
@@ -105,9 +105,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "22.1.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.1.2.tgz",
-      "integrity": "sha512-tF1oEE7KPs8I08HJQmH5e4GkLUB3+MXXy8t6gMJULaLFxZYP9K1oXRFLappMpdm9OIbEXOChk23hrho0By9aYg==",
+      "version": "22.1.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.1.3.tgz",
+      "integrity": "sha512-ASK8oZVElt/Zpz5FrzJjLnnUbzp/fW57eFFSRgpA+n9KRnuFi6YvNdSS3HkG5049Jcukce+PiMBdfzw/jBVkEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -150,13 +150,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "22.1.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.1.2.tgz",
-      "integrity": "sha512-Lw6NvW5rfMUl/2dsuWY8l6wlfWCuYBzCYSSqqliLPDco0doGzBliHwY9uxuzuUKZgOl5TvuVyvEo0t3o4Jj4GA==",
+      "version": "22.1.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.1.3.tgz",
+      "integrity": "sha512-ebY5bwZVB0onxxyTbJch//VidVVV8jo/F13n+TV5s/3ZywsC3/XZsfMHaxlFmpvP/G17+/C9JVoEXT+uwjT+/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.1.2",
+        "@angular-devkit/core": "22.1.3",
         "jsonc-parser": "3.3.1",
         "magic-string": "1.0.0",
         "ora": "9.4.1",
@@ -185,14 +185,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "22.1.2",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.1.2.tgz",
-      "integrity": "sha512-DE/3o17JTel4EBt2BA4DqJYeBBuz5Ef/kf1jL9YZTyJu4SrLr/HI79K14jFr0VRIxzcqG92FdIzfLDxbOesQsg==",
+      "version": "22.1.3",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.1.3.tgz",
+      "integrity": "sha512-Hjen3LcVZUCNZy+epgO+/PMUpD/L8Y4vODS+Q8F0Lkva7YWQwycbJtrEr6xvFfMxp6xexxxIwB9+5b8voKSihQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2201.2",
+        "@angular-devkit/architect": "0.2201.3",
         "@babel/core": "8.0.1",
         "@babel/helper-annotate-as-pure": "8.0.0",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -234,7 +234,7 @@
         "@angular/platform-browser": "^22.0.0",
         "@angular/platform-server": "^22.0.0",
         "@angular/service-worker": "^22.0.0",
-        "@angular/ssr": "^22.1.2",
+        "@angular/ssr": "^22.1.3",
         "istanbul-lib-instrument": "^6.0.0",
         "karma": "^6.4.0",
         "less": "^4.2.0",
@@ -292,9 +292,9 @@
       }
     },
     "node_modules/@angular/cdk": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-22.1.0.tgz",
-      "integrity": "sha512-yfQug47CZ+51mHy0ZLWzi6F/YHfsAF2Z7Jxo3JLM7Aj3Er47hHB8VnrNERwK5tBLs0bE5DoEIm59ga/MI3fVGg==",
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-22.1.1.tgz",
+      "integrity": "sha512-P8YuW/r5MS8aeKF0NruktKGHQShOMctvhs3H/51BOwJrMZi5qtWJ40t1yqTrNnewSJIKI0/AroUEmEOqA9Ml9Q==",
       "license": "MIT",
       "dependencies": {
         "parse5": "^8.0.0",
@@ -308,19 +308,19 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "22.1.2",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.1.2.tgz",
-      "integrity": "sha512-gzB+iuZzB507DAkZb9s5+Jw8QRzOBolUhHEuAKH74xF6oWlEP5JdexfTgti45SjXaKKqeYpODJFnUmSQQJRhxA==",
+      "version": "22.1.3",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.1.3.tgz",
+      "integrity": "sha512-GB1Pv8CXAHXE2/hqiwSGD6JRIyT4wswadjH1j3DH2+6os1zc7CBm28/YtlKPPIHZKVOZLDqV6uW+bRQTtdOw2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2201.2",
-        "@angular-devkit/core": "22.1.2",
-        "@angular-devkit/schematics": "22.1.2",
+        "@angular-devkit/architect": "0.2201.3",
+        "@angular-devkit/core": "22.1.3",
+        "@angular-devkit/schematics": "22.1.3",
         "@inquirer/prompts": "8.5.2",
         "@listr2/prompt-adapter-inquirer": "4.2.4",
         "@modelcontextprotocol/sdk": "1.29.0",
-        "@schematics/angular": "22.1.2",
+        "@schematics/angular": "22.1.3",
         "jsonc-parser": "3.3.1",
         "listr2": "10.2.2",
         "npm-package-arg": "14.0.0",
@@ -478,15 +478,15 @@
       }
     },
     "node_modules/@angular/material": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-22.1.0.tgz",
-      "integrity": "sha512-i3Os8JZg4DejgNTtw8GCLQbbZ8+lv8h/ym6PxRwmYNpegmyGiVSKAZ2JBkEs5f1pmMaTppuG3MF6mXei4xi6Wg==",
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-22.1.1.tgz",
+      "integrity": "sha512-wXNNstkLrUJwmP/cZl+C64chL5qH0WbnHIeYbiXrPwgriAD10prbVBoSq2CWbBrAhQ691pDdFKVSLG5tC224jg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/cdk": "22.1.0",
+        "@angular/cdk": "22.1.1",
         "@angular/common": "^22.0.0 || ^23.0.0",
         "@angular/core": "^22.0.0 || ^23.0.0",
         "@angular/forms": "^22.0.0 || ^23.0.0",
@@ -4000,14 +4000,14 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "22.1.2",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.1.2.tgz",
-      "integrity": "sha512-52udja/QGSNH5geSnL4JWFOEfx8M7tqf7LNXz8byjki4VshVOkKHTawQcL4YbJfo3MfwwXm4AsoadMOk8EST2w==",
+      "version": "22.1.3",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.1.3.tgz",
+      "integrity": "sha512-5f5f0tKp3d25hjNGkvw2dtGgTN4wxPNhv1AXnhFkh+mLinQK9Qwzr2iEXDDrAuJEkvz1ACHq631IURWph0lqew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.1.2",
-        "@angular-devkit/schematics": "22.1.2",
+        "@angular-devkit/core": "22.1.3",
+        "@angular-devkit/schematics": "22.1.3",
         "jsonc-parser": "3.3.1",
         "typescript": "6.0.3"
       },
@@ -4142,17 +4142,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
-      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
+      "integrity": "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/type-utils": "8.65.0",
-        "@typescript-eslint/utils": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/type-utils": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -4165,22 +4165,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.65.0",
+        "@typescript-eslint/parser": "^8.66.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
-      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.66.0.tgz",
+      "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4196,14 +4196,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
-      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
+      "integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.65.0",
-        "@typescript-eslint/types": "^8.65.0",
+        "@typescript-eslint/tsconfig-utils": "^8.66.0",
+        "@typescript-eslint/types": "^8.66.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4218,14 +4218,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
-      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
+      "integrity": "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0"
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4236,9 +4236,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
-      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
+      "integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4253,15 +4253,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
-      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
+      "integrity": "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0",
-        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -4278,9 +4278,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
-      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
+      "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4292,16 +4292,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
-      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
+      "integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.65.0",
-        "@typescript-eslint/tsconfig-utils": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
+        "@typescript-eslint/project-service": "8.66.0",
+        "@typescript-eslint/tsconfig-utils": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -4320,16 +4320,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
-      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.66.0.tgz",
+      "integrity": "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0"
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4344,13 +4344,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
-      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
+      "integrity": "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/types": "8.66.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -4599,9 +4599,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.11",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.11.tgz",
-      "integrity": "sha512-/yImnXwyTvgMkhgekLHok/Rx5vO6E0BmStWlSqKWMVm2a2ITuZ1Tn+9bgLS+gZRdZmWtd8nxuhHpdmCUOWsTQQ==",
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -4811,9 +4811,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001806",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
-      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -5154,11 +5154,14 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
-      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.50.0.tgz",
+      "integrity": "sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -5208,6 +5211,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
       "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "deprecated": "Active development of CryptoJS has been discontinued. This library is no longer maintained.",
       "license": "MIT"
     },
     "node_modules/css-select": {
@@ -5425,9 +5429,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.399",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.399.tgz",
-      "integrity": "sha512-lEcqhErbHjXRvd41rnWLpzbyU/IXfIYo7QwaFWmxGeLiLyY2TBCdHnWY88vB+p3ubnihRypDm66panXl7TylLA==",
+      "version": "1.5.402",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.402.tgz",
+      "integrity": "sha512-/oOpMaPT6Yg+6/1XQhyIPlzgj7Ye9zf+nNM2Uh6OcE2G2oNptWazFa+qB2Pdqqbsc9KnIDzgAntoYN0dbwOXwA==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -6519,9 +6523,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.27",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
-      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7040,9 +7044,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -8196,9 +8200,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.51",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
-      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -8616,9 +8620,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -8636,7 +8640,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8795,9 +8799,9 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9783,9 +9787,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.0.tgz",
+      "integrity": "sha512-x/M6q3w4Ybp91CNaS4S69UnliqR3BzRpOT6LWbksjth0S/+jhfaPJsWjt/TewpT8j9eLIojUf5jr29WextHroA==",
       "funding": [
         {
           "type": "opencollective",
@@ -10034,9 +10038,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
     "@types/file-saver": "^2.0.1",
     "@types/jasmine": "^6.0.0",
     "@types/node": "^26.1.2",
-    "@typescript-eslint/eslint-plugin": "^8.65.0",
-    "@typescript-eslint/parser": "^8.65.0",
+    "@typescript-eslint/eslint-plugin": "^8.66.0",
+    "@typescript-eslint/parser": "^8.66.0",
     "ajv": "^8.20.0",
     "eslint": "^10.8.0",
     "globals": "^17.8.0",
@@ -116,16 +116,16 @@
       "@angular/core": "21.2.0"
     },
     "flatted": "3.4.2",
-    "hono": "4.12.27",
+    "hono": "4.13.1",
     "immutable": "5.1.8",
-    "js-yaml": "4.3.0",
-    "postcss": "8.5.18",
-    "serialize-javascript": "7.0.5",
+    "js-yaml": "4.3.1",
+    "postcss": "8.5.26",
+    "serialize-javascript": "7.0.7",
     "tar": "7.5.22",
     "tmp": "0.2.7",
     "undici": "7.28.0",
     "uuid": "14.0.0",
     "vite": "7.3.5",
-    "ws": "8.21.0"
+    "ws": "8.21.3"
   }
 }


### PR DESCRIPTION
Supersedes #351, #352 and #353.

## Why those PRs failed

All three failed the `outdated` job in the Dependencies workflow, and none of them could fix it on their own. That job fails whenever any package's installed version is behind its `wanted` version, and both lockfiles had drifted behind their declared semver ranges on `main`:

```
frontend: @angular-devkit/core  22.1.2 -> 22.1.3
          @angular/build        22.1.2 -> 22.1.3
          @angular/cdk          22.1.0 -> 22.1.1
          @angular/cli          22.1.2 -> 22.1.3
          @angular/material     22.1.0 -> 22.1.1
          core-js               3.49.0 -> 3.50.0
backend:  @scalar/express-api-reference  0.10.12 -> 0.10.13
          express-rate-limit             8.6.1   -> 8.6.2
          read-last-lines                1.8.0   -> 1.10.0
```

Since none of the three touches both lockfiles, none could go green alone. This PR combines all three bumps with the lockfile refresh so the whole set passes together.

#353 also showed a `Backend - mocha (24)` failure; that job passes here.

## The three dependabot bumps

- **`config` 4.4.2 → 5.0.0** (backend, #351). This is a major bump whose headline change is the ESM conversion of node-config, plus a `node >= 20.11.0` engine floor. Both are inert here: the npm `config` package is **not imported anywhere in the backend** (all `require('./config')` call sites resolve to the local [backend/config.js](backend/config.js) module, not the package), and `backend/package.json` already declares `node >=24 <26`. Worth noting the dependency appears to be unused entirely — removing it is out of scope for this PR but may be worth a follow-up.
- **`@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` 8.65.0 → 8.66.0** (#352).
- **`github/codeql-action` 4.37.5 → 4.37.6** (#353), across `init`, `autobuild` and `analyze`.

## Security overrides refresh

Both `overrides` blocks pinned exact versions that new advisories have since caught up with. Because an override forces a resolution, `npm audit fix` could not move them — they had to be bumped by hand. All of these stay within the range their parent declares, so no parent package changed.

**Backend**

| Package | Before | After | Advisory cleared |
| --- | --- | --- | --- |
| `brace-expansion` | 5.0.8 | 5.0.9 | GHSA-rgw5-rvv9-x895 (high) — DoS via unbounded intermediate arrays |
| `js-yaml` | 4.3.0 | 4.3.1 | GHSA-5p4m-2wfm-xmqj (high) — quadratic CPU in `!!omap` |
| `undici` | 6.27.0 | 6.28.0 | GHSA-8xcm-r25x-g524, GHSA-m8rv-5g2x-5cg5, GHSA-v3r7-h72x-cjcm (moderate) |
| `serialize-javascript` | 7.0.5 | 7.0.7 | — (kept current) |
| `ws` | 8.21.0 | 8.21.3 | — (kept current) |

**Frontend**

| Package | Before | After | Advisory cleared |
| --- | --- | --- | --- |
| `hono` | 4.12.27 | 4.13.1 | GHSA-8j4g-w8fx-2239 (moderate) — ReDoS in CORS middleware |
| `js-yaml` | 4.3.0 | 4.3.1 | GHSA-5p4m-2wfm-xmqj (high) |
| `postcss` | 8.5.18 | 8.5.26 | GHSA-fxqj-rqcc-2cmp (moderate) — arbitrary `.map` read via `sourceMappingURL` |
| `serialize-javascript` | 7.0.5 | 7.0.7 | — (kept current) |
| `ws` | 8.21.0 | 8.21.3 | — (kept current) |

`npm audit` now reports **0 vulnerabilities** in both projects, down from 10 (frontend) and 7 (backend) on `main`.

Structural pins were deliberately left alone: the nested `picomatch` 2.3.2 entries, `@angular/common`/`@angular/core` 21.2.0 under `ngx-avatars`, `got` 11.8.6, and `diff` 8.0.3 all exist to satisfy peer constraints, and moving them would mean a major bump of the parent.

## Further updates checked

- Every remaining `npm outdated` entry has `current == wanted`, so the Dependencies workflow passes. The three left over are all blocked on something outside a lockfile refresh:
  - `typescript` 6.0.3 → 7.0.2 — `@angular/compiler-cli` peers `typescript >=6.0 <6.1`, so TS 7 is not installable on Angular 22.
  - `@angular/animations` and `@angular/platform-browser-dynamic` report a `latest` (20.1.8 / 20.0.7) *below* the installed 22.1.0; these are registry dist-tag artifacts, not real updates.
- Remaining workflow actions are pinned to major tags that already resolve to their newest release (`actions/checkout@v7`, `actions/setup-node@v7`, `actions/cache@v6`, `actions/upload-artifact@v7`, `actions/download-artifact@v8`, `docker/build-push-action@v7`, `docker/login-action@v4`, `docker/metadata-action@v6`, `docker/setup-buildx-action@v4`, `docker/setup-qemu-action@v4`, `FedericoCarboni/setup-ffmpeg@v3`, `jsdaniell/create-json@v1.2.3`).

## Testing

Per CONTRIBUTING.md, all green locally:

- `npm run lint`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `CHROMIUM_BIN=... npm run test:headless` — 239/239 passing
- `npx ng build --configuration production`
- `npm test` in `backend/` — 268 passing, 25 pending (worth running here since `config` and mocha's `js-yaml` both moved)
- `npm ci --ignore-scripts --dry-run` in both projects, to confirm each lockfile still resolves the way CI installs it

No backend JavaScript changed, so `node --check` was not needed.
