### PR TITLE
fix(docker): restore VAAPI device access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,9 +80,10 @@ RUN npm config set strict-ssl false && \
 
 # Final image
 FROM base
-RUN npm install -g pm2 && \
+RUN command -v setpriv >/dev/null && \
+    npm install -g pm2 && \
     apt update && \
-    apt install -y --no-install-recommends gosu python3-minimal python-is-python3 python3-pip atomicparsley build-essential unzip && \
+    apt install -y --no-install-recommends python3-minimal python-is-python3 python3-pip atomicparsley build-essential unzip && \
     pip install --break-system-packages pycryptodomex && \
     apt remove -y --purge build-essential && \
     apt autoremove -y --purge && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ FROM base
 RUN command -v setpriv >/dev/null && \
     npm install -g pm2 && \
     apt update && \
-    apt install -y --no-install-recommends python3-minimal python-is-python3 python3-pip atomicparsley build-essential unzip && \
+    apt install -y --no-install-recommends gosu python3-minimal python-is-python3 python3-pip atomicparsley build-essential unzip && \
     pip install --break-system-packages pycryptodomex && \
     apt remove -y --purge build-essential && \
     apt autoremove -y --purge && \

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -80,6 +80,62 @@ install_ytdlp_impersonation_dependencies() {
     export PYTHONPATH="${target_path}${PYTHONPATH:+:${PYTHONPATH}}"
 }
 
+resolve_transcoding_mode() {
+    local env_mode
+    local env_name
+
+    for env_name in ytdl_transcoding YTDL_TRANSCODING; do
+        if printenv "$env_name" >/dev/null 2>&1; then
+            env_mode="$(printenv "$env_name")"
+            printf '%s' "$env_mode" | tr '[:upper:]' '[:lower:]' | \
+                sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+            return
+        fi
+    done
+
+    if [ ! -r appdata/default.json ]; then
+        return
+    fi
+
+    python3 -I - <<'PY'
+import json
+import sys
+try:
+    with open('appdata/default.json', encoding='utf-8') as config_file:
+        config = json.load(config_file)
+    if 'YtdlMaterial' in config:
+        root = config.get('YtdlMaterial') or {}
+    else:
+        root = config.get('YoutubeDLMaterial') or {}
+    mode = root.get('Downloader', {}).get('transcoding')
+    if mode is not None:
+        sys.stdout.write(str(mode).strip().lower())
+except (AttributeError, OSError, TypeError, ValueError):
+    # The backend will report malformed config with its normal startup diagnostics.
+    pass
+PY
+}
+
+package_is_installed() {
+    dpkg-query -W -f='${Status}' "$1" 2>/dev/null | grep -q 'ok installed'
+}
+
+transcoding_runtime_is_installed() {
+    local transcoding_mode="$1"
+
+    package_is_installed libva-drm2 || return 1
+
+    case "$transcoding_mode" in
+        qsv|intel|quicksync)
+            ls /usr/lib/*/dri/iHD_drv_video.so >/dev/null 2>&1 || return 1
+            package_is_installed libmfx-gen1.2 || return 1
+            ;;
+        *)
+            ls /usr/lib/*/dri/*_drv_video.so >/dev/null 2>&1 || return 1
+            ;;
+    esac
+}
+
 install_transcoding_drivers() {
     local transcoding_mode="$1"
 
@@ -93,10 +149,9 @@ install_transcoding_drivers() {
             ;;
     esac
 
-    # Skip if both the DRM bridge and a VA driver are already present (from a previous
-    # start or a derived image). A driver alone cannot open /dev/dri devices.
-    if dpkg-query -W -f='${Status}' libva-drm2 2>/dev/null | grep -q 'ok installed' && \
-        ls /usr/lib/*/dri/*_drv_video.so >/dev/null 2>&1; then
+    # Skip only when the complete mode-specific runtime is present from a previous
+    # start or a derived image. A VA driver alone cannot open /dev/dri devices.
+    if transcoding_runtime_is_installed "$transcoding_mode"; then
         echo "[entrypoint] VAAPI/QSV userspace drivers are already installed"
         return
     fi
@@ -140,9 +195,25 @@ resolve_runtime_home() {
     printf '/'
 }
 
+has_supplementary_groups() {
+    local primary_gid
+    local group_gid
+    local group_ids
+
+    primary_gid="$(id -g)"
+    group_ids="$(id -G 2>/dev/null || true)"
+    for group_gid in $group_ids; do
+        if [ "$group_gid" != "$primary_gid" ]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
 runtime_uid="$(resolve_runtime_env 1000 ytdl_uid uid UID)"
 runtime_gid="$(resolve_runtime_env 1000 ytdl_gid gid GID)"
-transcoding_mode="$(resolve_runtime_env "" ytdl_transcoding YTDL_TRANSCODING | tr '[:upper:]' '[:lower:]')"
+transcoding_mode="$(resolve_transcoding_mode)"
 
 install_ytdlp_impersonation_dependencies
 install_transcoding_drivers "$transcoding_mode"
@@ -154,17 +225,19 @@ if [ "$(id -u)" = "0" ]; then
     find . \! -user "$runtime_uid" -exec chown "$runtime_uid:$runtime_gid" '{}' + || echo "WARNING! Could not change directory ownership. If you manage permissions externally this is fine, otherwise you may experience issues when downloading or deleting videos."
     case "$transcoding_mode" in
         vaapi|qsv|intel|quicksync)
-            # Docker's group_add values exist in the process' supplementary group list,
-            # not necessarily in /etc/group. Preserve that kernel-level list for DRI
-            # access while matching gosu's HOME resolution behavior.
-            export HOME="$(resolve_runtime_home "$runtime_uid")"
-            exec setpriv --reuid "$runtime_uid" --regid "$runtime_gid" --keep-groups -- "$@"
-            ;;
-        *)
-            # Keep the established privilege-drop behavior for every other configuration.
-            exec gosu "$runtime_uid:$runtime_gid" "$@"
+            if has_supplementary_groups; then
+                # Docker's group_add values exist in the process' supplementary group
+                # list, not necessarily in /etc/group. Preserve that kernel-level list
+                # for DRI access while matching gosu's HOME resolution behavior.
+                HOME="$(resolve_runtime_home "$runtime_uid")"
+                export HOME
+                exec setpriv --reuid "$runtime_uid" --regid "$runtime_gid" --keep-groups -- "$@"
+            fi
             ;;
     esac
+
+    # Keep the established privilege-drop behavior outside the DRI group_add case.
+    exec gosu "$runtime_uid:$runtime_gid" "$@"
 else
     # Already running as non-root user
     echo "[entrypoint] Running as non-root user (UID=$(id -u), GID=$(id -g))"

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -94,8 +94,10 @@ install_transcoding_drivers() {
             ;;
     esac
 
-    # Skip if a VA driver is already present (from a previous start or a derived image)
-    if ls /usr/lib/*/dri/*_drv_video.so >/dev/null 2>&1; then
+    # Skip if both the DRM bridge and a VA driver are already present (from a previous
+    # start or a derived image). A driver alone cannot open /dev/dri devices.
+    if dpkg-query -W -f='${Status}' libva-drm2 2>/dev/null | grep -q 'ok installed' && \
+        ls /usr/lib/*/dri/*_drv_video.so >/dev/null 2>&1; then
         echo "[entrypoint] VAAPI/QSV userspace drivers are already installed"
         return
     fi
@@ -111,6 +113,7 @@ install_transcoding_drivers() {
         echo "[entrypoint] WARNING: apt-get update failed; hardware acceleration drivers were not installed."
         return
     fi
+    apt-get install -y --no-install-recommends libva-drm2 || echo "[entrypoint] WARNING: libva-drm2 could not be installed"
     apt-get install -y --no-install-recommends mesa-va-drivers || echo "[entrypoint] WARNING: mesa-va-drivers could not be installed"
     apt-get install -y --no-install-recommends intel-media-va-driver-non-free || \
         apt-get install -y --no-install-recommends intel-media-va-driver || \
@@ -134,7 +137,9 @@ if [ "$(id -u)" = "0" ]; then
     # Running as root - fix permissions and drop privileges
     echo "[entrypoint] Running as root, fixing permissions (this may take a while)"
     find . \! -user "$runtime_uid" -exec chown "$runtime_uid:$runtime_gid" '{}' + || echo "WARNING! Could not change directory ownership. If you manage permissions externally this is fine, otherwise you may experience issues when downloading or deleting videos."
-    exec gosu "$runtime_uid:$runtime_gid" "$@"
+    # Docker's group_add values exist in the process' supplementary group list, not
+    # necessarily in /etc/group. Preserve that kernel-level list while changing UID/GID.
+    exec setpriv --reuid "$runtime_uid" --regid "$runtime_gid" --keep-groups -- "$@"
 else
     # Already running as non-root user
     echo "[entrypoint] Running as non-root user (UID=$(id -u), GID=$(id -g))"

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -81,8 +81,7 @@ install_ytdlp_impersonation_dependencies() {
 }
 
 install_transcoding_drivers() {
-    local transcoding_mode
-    transcoding_mode="$(resolve_runtime_env "" ytdl_transcoding YTDL_TRANSCODING | tr '[:upper:]' '[:lower:]')"
+    local transcoding_mode="$1"
 
     # Only VAAPI/QSV need userspace drivers inside the container.
     # NVENC (libcuda) and AMF (libamfrt) runtimes come from the host via the container runtime.
@@ -126,20 +125,46 @@ install_transcoding_drivers() {
     rm -rf /var/lib/apt/lists/*
 }
 
+resolve_runtime_home() {
+    local passwd_name
+    local passwd_uid
+    local passwd_home
+
+    while IFS=: read -r passwd_name _ passwd_uid _ _ passwd_home _; do
+        if [ "$passwd_name" = "$1" ] || [ "$passwd_uid" = "$1" ]; then
+            printf '%s' "${passwd_home:-/}"
+            return
+        fi
+    done < /etc/passwd
+
+    printf '/'
+}
+
 runtime_uid="$(resolve_runtime_env 1000 ytdl_uid uid UID)"
 runtime_gid="$(resolve_runtime_env 1000 ytdl_gid gid GID)"
+transcoding_mode="$(resolve_runtime_env "" ytdl_transcoding YTDL_TRANSCODING | tr '[:upper:]' '[:lower:]')"
 
 install_ytdlp_impersonation_dependencies
-install_transcoding_drivers
+install_transcoding_drivers "$transcoding_mode"
 
 # Check if we're running as root
 if [ "$(id -u)" = "0" ]; then
     # Running as root - fix permissions and drop privileges
     echo "[entrypoint] Running as root, fixing permissions (this may take a while)"
     find . \! -user "$runtime_uid" -exec chown "$runtime_uid:$runtime_gid" '{}' + || echo "WARNING! Could not change directory ownership. If you manage permissions externally this is fine, otherwise you may experience issues when downloading or deleting videos."
-    # Docker's group_add values exist in the process' supplementary group list, not
-    # necessarily in /etc/group. Preserve that kernel-level list while changing UID/GID.
-    exec setpriv --reuid "$runtime_uid" --regid "$runtime_gid" --keep-groups -- "$@"
+    case "$transcoding_mode" in
+        vaapi|qsv|intel|quicksync)
+            # Docker's group_add values exist in the process' supplementary group list,
+            # not necessarily in /etc/group. Preserve that kernel-level list for DRI
+            # access while matching gosu's HOME resolution behavior.
+            export HOME="$(resolve_runtime_home "$runtime_uid")"
+            exec setpriv --reuid "$runtime_uid" --regid "$runtime_gid" --keep-groups -- "$@"
+            ;;
+        *)
+            # Keep the established privilege-drop behavior for every other configuration.
+            exec gosu "$runtime_uid:$runtime_gid" "$@"
+            ;;
+    esac
 else
     # Already running as non-root user
     echo "[entrypoint] Running as non-root user (UID=$(id -u), GID=$(id -g))"

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -407,13 +407,13 @@
       }
     },
     "node_modules/@scalar/client-side-rendering": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@scalar/client-side-rendering/-/client-side-rendering-0.3.6.tgz",
-      "integrity": "sha512-CshKXof+tyu0tpgMhRSoNw6Fnn1ywVveJnb5iIJ8ue/FIVn6rP+BEQcgdIiNUPBEXHaAnz+HCGGiScKRzXRB7Q==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@scalar/client-side-rendering/-/client-side-rendering-0.3.7.tgz",
+      "integrity": "sha512-B0ePjn0/hv1JS/dM+C2IVmU7hily4a3m8Tcd8DbfQtMMRtGH0AQB4RBZS8rTNORqVZQyXVSCv8HCwkg3f2f3eQ==",
       "license": "MIT",
       "dependencies": {
         "@scalar/schemas": "0.8.1",
-        "@scalar/types": "0.17.1",
+        "@scalar/types": "0.18.0",
         "@scalar/validation": "0.6.2"
       },
       "engines": {
@@ -421,12 +421,12 @@
       }
     },
     "node_modules/@scalar/express-api-reference": {
-      "version": "0.10.13",
-      "resolved": "https://registry.npmjs.org/@scalar/express-api-reference/-/express-api-reference-0.10.13.tgz",
-      "integrity": "sha512-4VAIiiNV7q1tmTtFcG/aZfaK9fV/+Z1hqStxmAD/MWUyVdn0BG36ZjNmEzB6cPBWZraCFv87KQaItaWVLNzezg==",
+      "version": "0.10.14",
+      "resolved": "https://registry.npmjs.org/@scalar/express-api-reference/-/express-api-reference-0.10.14.tgz",
+      "integrity": "sha512-Tx9dBfYwSHehz5A+S206Iil25j2FpLUDNWG4OoAljy8d8Q/GsJFwUe88zCwauT4LGgbdzHkrdh5viA8W55V3Cw==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/client-side-rendering": "0.3.6"
+        "@scalar/client-side-rendering": "0.3.7"
       },
       "engines": {
         "node": ">=22"
@@ -455,9 +455,9 @@
       }
     },
     "node_modules/@scalar/types": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.17.1.tgz",
-      "integrity": "sha512-jqudbDtdvP/SiOTuj7Gg3dBY8IMb7oeJI/7K4QF2cOiWgnbYUQFeaYzktpNZwcCQkIJwlxYfd0i97KwlyD9GMQ==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.18.0.tgz",
+      "integrity": "sha512-rAlZEzcNSyMohzJGrkjZQkf7RcvXYl2sVIkeTAt90Ag9M/W2D+yITDbVTAOT+GXWrvG+/XvEqEBnspjt2TfyQQ==",
       "license": "MIT",
       "dependencies": {
         "@scalar/helpers": "0.10.0",

--- a/backend/test/entrypoint.test.js
+++ b/backend/test/entrypoint.test.js
@@ -12,30 +12,46 @@ function writeStub(binDir, name, body) {
     fs.writeFileSync(stubPath, `#!/bin/sh\n${body}\n`, { mode: 0o755 });
 }
 
-function runEntrypoint(transcodingMode) {
+function runEntrypoint({
+    transcodingMode = 'false',
+    processUid = '0',
+    runtimeUid,
+    runtimeGid
+} = {}) {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ytdl-entrypoint-'));
     const binDir = path.join(tempDir, 'bin');
     const callsPath = path.join(tempDir, 'calls');
     fs.mkdirSync(binDir);
 
-    writeStub(binDir, 'id', '[ "$1" = "-u" ] && printf 0 || exit 1');
+    writeStub(binDir, 'id', 'case "$1" in -u) printf "%s" "$ENTRYPOINT_UID" ;; -g) printf 2345 ;; *) exit 1 ;; esac');
     writeStub(binDir, 'find', 'exit 0');
     writeStub(binDir, 'dpkg-query', 'exit 1');
     writeStub(binDir, 'ls', 'exit 1');
     writeStub(binDir, 'rm', 'exit 0');
     writeStub(binDir, 'apt-get', 'printf "apt-get %s\\n" "$*" >> "$ENTRYPOINT_CALLS"');
+    writeStub(binDir, 'gosu', 'printf "gosu %s\\n" "$*" >> "$ENTRYPOINT_CALLS"');
     writeStub(binDir, 'setpriv', 'printf "setpriv %s\\n" "$*" >> "$ENTRYPOINT_CALLS"');
+    writeStub(binDir, 'npm', 'printf "npm %s\\n" "$*" >> "$ENTRYPOINT_CALLS"');
+
+    const env = {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH}`,
+        ENTRYPOINT_CALLS: callsPath,
+        ENTRYPOINT_UID: processUid,
+        UID: '1000',
+        GID: '1000',
+        ytdl_transcoding: transcodingMode
+    };
+    delete env.ytdl_uid;
+    delete env.uid;
+    delete env.ytdl_gid;
+    delete env.gid;
+    if (runtimeUid !== undefined) env.ytdl_uid = runtimeUid;
+    if (runtimeGid !== undefined) env.ytdl_gid = runtimeGid;
 
     const result = spawnSync('bash', [entrypointPath, 'npm', 'start'], {
         encoding: 'utf8',
-        env: {
-            ...process.env,
-            PATH: `${binDir}:${process.env.PATH}`,
-            ENTRYPOINT_CALLS: callsPath,
-            ytdl_uid: '1234',
-            ytdl_gid: '2345',
-            ytdl_transcoding: transcodingMode
-        }
+        env
     });
 
     const calls = fs.existsSync(callsPath) ? fs.readFileSync(callsPath, 'utf8') : '';
@@ -46,21 +62,73 @@ function runEntrypoint(transcodingMode) {
 
 describe('Docker entrypoint', function() {
     it('does not install VAAPI packages when hardware transcoding is disabled', function() {
-        const calls = runEntrypoint('false');
+        const calls = runEntrypoint();
 
         assert(!calls.includes('apt-get'), calls);
     });
 
+    it('uses the image UID/GID defaults when Docker starts as root without overrides', function() {
+        const calls = runEntrypoint();
+
+        assert(calls.includes('gosu 1000:1000 npm start'), calls);
+    });
+
+    it('uses UID/GID environment overrides when Docker starts as root', function() {
+        const calls = runEntrypoint({ runtimeUid: '1234', runtimeGid: '2345' });
+
+        assert(calls.includes('gosu 1234:2345 npm start'), calls);
+    });
+
     it('installs the VAAPI DRM bridge only when VAAPI is selected', function() {
-        const calls = runEntrypoint('vaapi');
+        const calls = runEntrypoint({
+            transcodingMode: 'vaapi',
+            runtimeUid: '1234',
+            runtimeGid: '2345'
+        });
 
         assert(calls.includes('apt-get update'), calls);
         assert(calls.includes('apt-get install -y --no-install-recommends libva-drm2'), calls);
     });
 
     it('preserves Docker supplemental groups while dropping root privileges', function() {
-        const calls = runEntrypoint('false');
+        const calls = runEntrypoint({
+            transcodingMode: 'vaapi',
+            runtimeUid: '1234',
+            runtimeGid: '2345'
+        });
 
         assert(calls.includes('setpriv --reuid 1234 --regid 2345 --keep-groups -- npm start'), calls);
+    });
+
+    it('runs directly when only Docker user starts the container non-root', function() {
+        const calls = runEntrypoint({ processUid: '1234' });
+
+        assert(calls.includes('npm start'), calls);
+        assert(!calls.includes('gosu'), calls);
+        assert(!calls.includes('setpriv'), calls);
+    });
+
+    it('runs directly when Docker user and UID/GID overrides are both set', function() {
+        const calls = runEntrypoint({
+            processUid: '1234',
+            runtimeUid: '1234',
+            runtimeGid: '2345'
+        });
+
+        assert(calls.includes('npm start'), calls);
+        assert(!calls.includes('gosu'), calls);
+        assert(!calls.includes('setpriv'), calls);
+    });
+
+    it('runs VAAPI directly without installing packages when Docker starts non-root', function() {
+        const calls = runEntrypoint({
+            transcodingMode: 'vaapi',
+            processUid: '1234'
+        });
+
+        assert(!calls.includes('apt-get'), calls);
+        assert(calls.includes('npm start'), calls);
+        assert(!calls.includes('gosu'), calls);
+        assert(!calls.includes('setpriv'), calls);
     });
 });

--- a/backend/test/entrypoint.test.js
+++ b/backend/test/entrypoint.test.js
@@ -13,8 +13,15 @@ function writeStub(binDir, name, body) {
 }
 
 function runEntrypoint({
-    transcodingMode = 'false',
+    transcodingMode,
+    storedTranscodingMode = false,
+    storedConfig,
     processUid = '0',
+    processGid = processUid === '0' ? '0' : '2345',
+    supplementaryGroups = [],
+    installedPackages = [],
+    vaDriverPresent = false,
+    intelDriverPresent = false,
     runtimeUid,
     runtimeGid
 } = {}) {
@@ -22,11 +29,23 @@ function runEntrypoint({
     const binDir = path.join(tempDir, 'bin');
     const callsPath = path.join(tempDir, 'calls');
     fs.mkdirSync(binDir);
+    fs.mkdirSync(path.join(tempDir, 'appdata'));
+    const defaultStoredConfig = {
+        YtdlMaterial: {
+            Downloader: {
+                transcoding: storedTranscodingMode
+            }
+        }
+    };
+    fs.writeFileSync(
+        path.join(tempDir, 'appdata', 'default.json'),
+        JSON.stringify(storedConfig === undefined ? defaultStoredConfig : storedConfig)
+    );
 
-    writeStub(binDir, 'id', 'case "$1" in -u) printf "%s" "$ENTRYPOINT_UID" ;; -g) printf 2345 ;; *) exit 1 ;; esac');
+    writeStub(binDir, 'id', 'case "$1" in -u) printf "%s" "$ENTRYPOINT_UID" ;; -g) printf "%s" "$ENTRYPOINT_GID" ;; -G) printf "%s" "$ENTRYPOINT_GROUPS" ;; *) exit 1 ;; esac');
     writeStub(binDir, 'find', 'exit 0');
-    writeStub(binDir, 'dpkg-query', 'exit 1');
-    writeStub(binDir, 'ls', 'exit 1');
+    writeStub(binDir, 'dpkg-query', 'for package_name do :; done; case " $ENTRYPOINT_PACKAGES " in *" $package_name "*) printf "install ok installed" ;; *) exit 1 ;; esac');
+    writeStub(binDir, 'ls', 'case "$*" in *iHD_drv_video.so*) [ "$ENTRYPOINT_INTEL_DRIVER" = "true" ] ;; *) [ "$ENTRYPOINT_VA_DRIVER" = "true" ] ;; esac');
     writeStub(binDir, 'rm', 'exit 0');
     writeStub(binDir, 'apt-get', 'printf "apt-get %s\\n" "$*" >> "$ENTRYPOINT_CALLS"');
     writeStub(binDir, 'gosu', 'printf "gosu %s\\n" "$*" >> "$ENTRYPOINT_CALLS"');
@@ -38,20 +57,32 @@ function runEntrypoint({
         PATH: `${binDir}:${process.env.PATH}`,
         ENTRYPOINT_CALLS: callsPath,
         ENTRYPOINT_UID: processUid,
+        ENTRYPOINT_GID: processGid,
+        ENTRYPOINT_GROUPS: [processGid, ...supplementaryGroups].join(' '),
+        ENTRYPOINT_PACKAGES: installedPackages.join(' '),
+        ENTRYPOINT_VA_DRIVER: String(vaDriverPresent),
+        ENTRYPOINT_INTEL_DRIVER: String(intelDriverPresent),
         UID: '1000',
-        GID: '1000',
-        ytdl_transcoding: transcodingMode
+        GID: '1000'
     };
     delete env.ytdl_uid;
     delete env.uid;
     delete env.ytdl_gid;
     delete env.gid;
+    delete env.ytdl_transcoding;
+    delete env.YTDL_TRANSCODING;
+    delete env.ytdl_enable_ytdlp_impersonation_dependencies;
+    delete env.YTDL_ENABLE_YTDLP_IMPERSONATION_DEPENDENCIES;
+    delete env.ytdl_enable_curl_cffi;
+    delete env.YTDL_ENABLE_CURL_CFFI;
     if (runtimeUid !== undefined) env.ytdl_uid = runtimeUid;
     if (runtimeGid !== undefined) env.ytdl_gid = runtimeGid;
+    if (transcodingMode !== undefined) env.ytdl_transcoding = transcodingMode;
 
     const result = spawnSync('bash', [entrypointPath, 'npm', 'start'], {
         encoding: 'utf8',
-        env
+        env,
+        cwd: tempDir
     });
 
     const calls = fs.existsSync(callsPath) ? fs.readFileSync(callsPath, 'utf8') : '';
@@ -79,6 +110,18 @@ describe('Docker entrypoint', function() {
         assert(calls.includes('gosu 1234:2345 npm start'), calls);
     });
 
+    it('supports a UID environment override without a GID override', function() {
+        const calls = runEntrypoint({ runtimeUid: '1234' });
+
+        assert(calls.includes('gosu 1234:1000 npm start'), calls);
+    });
+
+    it('supports a GID environment override without a UID override', function() {
+        const calls = runEntrypoint({ runtimeGid: '2345' });
+
+        assert(calls.includes('gosu 1000:2345 npm start'), calls);
+    });
+
     it('installs the VAAPI DRM bridge only when VAAPI is selected', function() {
         const calls = runEntrypoint({
             transcodingMode: 'vaapi',
@@ -90,14 +133,136 @@ describe('Docker entrypoint', function() {
         assert(calls.includes('apt-get install -y --no-install-recommends libva-drm2'), calls);
     });
 
+    it('installs the VAAPI runtime when VAAPI was selected in persisted settings', function() {
+        const calls = runEntrypoint({ storedTranscodingMode: 'vaapi' });
+
+        assert(calls.includes('apt-get install -y --no-install-recommends libva-drm2'), calls);
+    });
+
+    it('leaves malformed persisted config diagnostics to the backend', function() {
+        const calls = runEntrypoint({ storedConfig: [] });
+
+        assert(!calls.includes('apt-get'), calls);
+        assert(calls.includes('gosu 1000:1000 npm start'), calls);
+    });
+
+    it('does not fall back to a stale legacy root when the current config root exists', function() {
+        const calls = runEntrypoint({
+            storedConfig: {
+                YtdlMaterial: {},
+                YoutubeDLMaterial: { Downloader: { transcoding: 'vaapi' } }
+            }
+        });
+
+        assert(!calls.includes('apt-get'), calls);
+    });
+
+    it('lets an explicit environment setting disable persisted VAAPI', function() {
+        const calls = runEntrypoint({
+            transcodingMode: 'false',
+            storedTranscodingMode: 'vaapi'
+        });
+
+        assert(!calls.includes('apt-get'), calls);
+    });
+
+    it('lets an explicitly empty environment setting disable persisted VAAPI', function() {
+        const calls = runEntrypoint({
+            transcodingMode: '',
+            storedTranscodingMode: 'vaapi'
+        });
+
+        assert(!calls.includes('apt-get'), calls);
+    });
+
+    it('normalizes whitespace and case in the transcoding environment setting', function() {
+        const calls = runEntrypoint({ transcodingMode: ' VAAPI ' });
+
+        assert(calls.includes('apt-get install -y --no-install-recommends libva-drm2'), calls);
+    });
+
+    it('does not reinstall an already complete VAAPI runtime', function() {
+        const calls = runEntrypoint({
+            transcodingMode: 'vaapi',
+            installedPackages: ['libva-drm2'],
+            vaDriverPresent: true
+        });
+
+        assert(!calls.includes('apt-get'), calls);
+    });
+
+    it('installs libva-drm2 when a VA driver exists without its DRM bridge', function() {
+        const calls = runEntrypoint({
+            transcodingMode: 'vaapi',
+            vaDriverPresent: true
+        });
+
+        assert(calls.includes('apt-get install -y --no-install-recommends libva-drm2'), calls);
+    });
+
+    it('retries an incomplete QSV runtime installation', function() {
+        const calls = runEntrypoint({
+            transcodingMode: 'qsv',
+            installedPackages: ['libva-drm2'],
+            vaDriverPresent: true
+        });
+
+        assert(calls.includes('apt-get install -y --no-install-recommends libmfx-gen1.2'), calls);
+    });
+
+    it('retries QSV when only a non-Intel VA driver is installed', function() {
+        const calls = runEntrypoint({
+            transcodingMode: 'qsv',
+            installedPackages: ['libva-drm2', 'libmfx-gen1.2'],
+            vaDriverPresent: true
+        });
+
+        assert(calls.includes('apt-get install -y --no-install-recommends intel-media-va-driver-non-free'), calls);
+    });
+
+    it('does not reinstall an already complete QSV runtime', function() {
+        const calls = runEntrypoint({
+            transcodingMode: 'qsv',
+            installedPackages: ['libva-drm2', 'libmfx-gen1.2'],
+            intelDriverPresent: true
+        });
+
+        assert(!calls.includes('apt-get'), calls);
+    });
+
     it('preserves Docker supplemental groups while dropping root privileges', function() {
         const calls = runEntrypoint({
             transcodingMode: 'vaapi',
+            supplementaryGroups: ['44', '106'],
             runtimeUid: '1234',
             runtimeGid: '2345'
         });
 
         assert(calls.includes('setpriv --reuid 1234 --regid 2345 --keep-groups -- npm start'), calls);
+    });
+
+    it('retains gosu for root VAAPI starts without supplemental groups', function() {
+        const calls = runEntrypoint({ transcodingMode: 'vaapi' });
+
+        assert(calls.includes('gosu 1000:1000 npm start'), calls);
+        assert(!calls.includes('setpriv'), calls);
+    });
+
+    it('preserves Docker supplemental groups for UI-configured VAAPI', function() {
+        const calls = runEntrypoint({
+            storedTranscodingMode: 'vaapi',
+            supplementaryGroups: ['44', '106']
+        });
+
+        assert(calls.includes('setpriv --reuid 1000 --regid 1000 --keep-groups -- npm start'), calls);
+        assert(!calls.includes('gosu'), calls);
+    });
+
+    it('retains gosu when supplemental groups are unrelated to transcoding', function() {
+        const calls = runEntrypoint({ supplementaryGroups: ['44', '106'] });
+
+        assert(calls.includes('gosu 1000:1000 npm start'), calls);
+        assert(!calls.includes('setpriv'), calls);
     });
 
     it('runs directly when only Docker user starts the container non-root', function() {

--- a/backend/test/entrypoint.test.js
+++ b/backend/test/entrypoint.test.js
@@ -1,0 +1,66 @@
+/* eslint-disable no-undef */
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const entrypointPath = path.resolve(__dirname, '..', 'entrypoint.sh');
+
+function writeStub(binDir, name, body) {
+    const stubPath = path.join(binDir, name);
+    fs.writeFileSync(stubPath, `#!/bin/sh\n${body}\n`, { mode: 0o755 });
+}
+
+function runEntrypoint(transcodingMode) {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ytdl-entrypoint-'));
+    const binDir = path.join(tempDir, 'bin');
+    const callsPath = path.join(tempDir, 'calls');
+    fs.mkdirSync(binDir);
+
+    writeStub(binDir, 'id', '[ "$1" = "-u" ] && printf 0 || exit 1');
+    writeStub(binDir, 'find', 'exit 0');
+    writeStub(binDir, 'dpkg-query', 'exit 1');
+    writeStub(binDir, 'ls', 'exit 1');
+    writeStub(binDir, 'rm', 'exit 0');
+    writeStub(binDir, 'apt-get', 'printf "apt-get %s\\n" "$*" >> "$ENTRYPOINT_CALLS"');
+    writeStub(binDir, 'setpriv', 'printf "setpriv %s\\n" "$*" >> "$ENTRYPOINT_CALLS"');
+
+    const result = spawnSync('bash', [entrypointPath, 'npm', 'start'], {
+        encoding: 'utf8',
+        env: {
+            ...process.env,
+            PATH: `${binDir}:${process.env.PATH}`,
+            ENTRYPOINT_CALLS: callsPath,
+            ytdl_uid: '1234',
+            ytdl_gid: '2345',
+            ytdl_transcoding: transcodingMode
+        }
+    });
+
+    const calls = fs.existsSync(callsPath) ? fs.readFileSync(callsPath, 'utf8') : '';
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    assert.strictEqual(result.status, 0, result.stderr || result.stdout);
+    return calls;
+}
+
+describe('Docker entrypoint', function() {
+    it('does not install VAAPI packages when hardware transcoding is disabled', function() {
+        const calls = runEntrypoint('false');
+
+        assert(!calls.includes('apt-get'), calls);
+    });
+
+    it('installs the VAAPI DRM bridge only when VAAPI is selected', function() {
+        const calls = runEntrypoint('vaapi');
+
+        assert(calls.includes('apt-get update'), calls);
+        assert(calls.includes('apt-get install -y --no-install-recommends libva-drm2'), calls);
+    });
+
+    it('preserves Docker supplemental groups while dropping root privileges', function() {
+        const calls = runEntrypoint('false');
+
+        assert(calls.includes('setpriv --reuid 1234 --regid 2345 --keep-groups -- npm start'), calls);
+    });
+});

--- a/docker-environment.md
+++ b/docker-environment.md
@@ -129,7 +129,7 @@ Each crop logs the encoder and whether decoding is on the GPU. At `debug` log le
 Notes:
 
 * Hardware acceleration requires the amd64 or arm64 image. The armhf/armel images ship a software-only ffmpeg build.
-* For `'vaapi'` and `'qsv'`, the entrypoint installs the userspace GPU drivers on first start (requires the container to start as root, the default, and network access). NVENC and AMF runtimes are provided by the host instead.
+* For `'vaapi'` and `'qsv'`, the entrypoint installs `libva-drm2` and the userspace GPU drivers on first start (requires the container to start as root, the default, and network access). These packages are not installed when hardware transcoding is disabled. NVENC and AMF runtimes are provided by the host instead.
 * Hardware encoding is applied to video files in h264-compatible containers (mp4, mkv, mov, ts). Other formats keep using software encoding.
 
 ### VAAPI / QSV (Intel and AMD GPUs)

--- a/docker-environment.md
+++ b/docker-environment.md
@@ -130,6 +130,7 @@ Notes:
 
 * Hardware acceleration requires the amd64 or arm64 image. The armhf/armel images ship a software-only ffmpeg build.
 * For `'vaapi'` and `'qsv'`, the entrypoint installs `libva-drm2` and the userspace GPU drivers on first start (requires the container to start as root, the default, and network access). These packages are not installed when hardware transcoding is disabled. NVENC and AMF runtimes are provided by the host instead.
+* After selecting VAAPI or QSV in the UI for the first time, restart the container once so the root entrypoint can install the required userspace packages before the next flight test.
 * Hardware encoding is applied to video files in h264-compatible containers (mp4, mkv, mov, ts). Other formats keep using software encoding.
 
 ### VAAPI / QSV (Intel and AMD GPUs)

--- a/package-lock.json
+++ b/package-lock.json
@@ -292,9 +292,9 @@
       }
     },
     "node_modules/@angular/cdk": {
-      "version": "22.1.1",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-22.1.1.tgz",
-      "integrity": "sha512-P8YuW/r5MS8aeKF0NruktKGHQShOMctvhs3H/51BOwJrMZi5qtWJ40t1yqTrNnewSJIKI0/AroUEmEOqA9Ml9Q==",
+      "version": "22.1.2",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-22.1.2.tgz",
+      "integrity": "sha512-YwTzVnTgZIQDLq3lnnPLINIB24e0SiDn7XxBxHSrOzD/+Y0zLAid5XIiMALXWOqa7rfdhfVh1kEeM93RRLnllQ==",
       "license": "MIT",
       "dependencies": {
         "parse5": "^8.0.0",
@@ -478,15 +478,15 @@
       }
     },
     "node_modules/@angular/material": {
-      "version": "22.1.1",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-22.1.1.tgz",
-      "integrity": "sha512-wXNNstkLrUJwmP/cZl+C64chL5qH0WbnHIeYbiXrPwgriAD10prbVBoSq2CWbBrAhQ691pDdFKVSLG5tC224jg==",
+      "version": "22.1.2",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-22.1.2.tgz",
+      "integrity": "sha512-KX0bVUppfwjDfUepsjpG1CAQGUGHI0l5e0QYpFcskB+1wNRCocBGsIO1br5z6neYu0rzsbhtWocjCeH05gwi7w==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/cdk": "22.1.1",
+        "@angular/cdk": "22.1.2",
         "@angular/common": "^22.0.0 || ^23.0.0",
         "@angular/core": "^22.0.0 || ^23.0.0",
         "@angular/forms": "^22.0.0 || ^23.0.0",
@@ -6407,9 +6407,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.9.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
-      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
+      "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

- install `libva-drm2` and VAAPI/QSV userspace drivers on demand only when normalized environment or persisted UI configuration selects VAAPI/QSV; transcoding-disabled containers do not run apt or receive those packages
- detect complete mode-specific runtimes and retry partial installations, including QSV installations missing the Intel iHD driver or `libmfx-gen1.2`
- preserve Docker `group_add` supplemental groups only for the VAAPI/QSV DRI privilege-drop path
- retain Gosu for ordinary root starts, including defaults, UID/GID environment overrides, VAAPI/QSV without supplemental groups, and unrelated supplemental groups
- continue executing directly when Docker `user` starts the container non-root, with or without UID/GID environment variables
- honor explicit transcoding environment settings (including an empty value) ahead of persisted settings, while supporting UI-first configuration after one container restart
- cover the full startup and installation matrix with regression tests
- refresh the in-range dependency resolutions previously reported by the dependency check

Fixes #359

## Startup compatibility

| Container start | UID/GID env | Transcoding/device groups | Execution path |
| --- | --- | --- | --- |
| Root (default) | Omitted | None | Gosu to `1000:1000` |
| Root (default) | One or both set | None | Gosu to resolved UID/GID |
| Root (default) | Either | VAAPI/QSV plus `group_add` | `setpriv --keep-groups` to resolved UID/GID |
| Root (default) | Either | VAAPI/QSV without supplemental groups | Gosu to resolved UID/GID |
| Docker `user` non-root | Omitted or set | Any | Direct execution; no privilege transition |

Automatic driver installation requires a root start and network access. A container deliberately started non-root continues to start normally but must use a derived image with the required VAAPI/QSV runtime preinstalled for hardware acceleration.

## Testing

- focused Docker entrypoint matrix: 24 passing
- backend suite: 291 passing, 25 pending
- `npm run lint`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" npm run test:headless` (239 passing)
- `npx ng build --configuration production`
- clean frontend and backend `npm ci --ignore-scripts`
- frontend and backend dependency checks (no installed package behind its wanted version)
- `bash -n backend/entrypoint.sh`
- `node --check backend/test/entrypoint.test.js`
- ShellCheck on `backend/entrypoint.sh`
- `git diff --check`
