### PR TITLE
chore(deps): drop the unused shortid dependency

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -53,7 +53,6 @@
         "read-last-lines": "^1.8.0",
         "redis": "^6.2.1",
         "rxjs": "^7.8.2",
-        "shortid": "^2.2.17",
         "tree-kill": "^1.2.2",
         "unzipper": "^0.12.5",
         "uuid": "^14.0.2",
@@ -4626,33 +4625,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/shortid": {
-      "version": "2.2.17",
-      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.17.tgz",
-      "integrity": "sha512-GpbM3gLF1UUXZvQw6MCyulHkWbRseNO4cyBEZresZRorwl1+SLu1ZdqgVtuwqz8mB6RpwPkm541mYSqrKyJSaA==",
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.8"
-      }
-    },
-    "node_modules/shortid/node_modules/nanoid": {
-      "version": "3.3.18",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
-      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/side-channel": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -67,7 +67,6 @@
     "read-last-lines": "^1.8.0",
     "redis": "^6.2.1",
     "rxjs": "^7.8.2",
-    "shortid": "^2.2.17",
     "tree-kill": "^1.2.2",
     "unzipper": "^0.12.5",
     "uuid": "^14.0.2",
@@ -83,9 +82,6 @@
     "got": "11.8.6",
     "js-yaml": "4.3.1",
     "serialize-javascript": "7.1.0",
-    "shortid": {
-      "nanoid": "3.3.18"
-    },
     "undici": "6.28.0",
     "ws": "8.21.3"
   },


### PR DESCRIPTION
Part of #370 — the `shortid` half.

`shortid` has **no call sites**. It appeared only in `backend/package.json` and the lockfile, with nothing else in the tree depending on it:

```
$ grep -rn "shortid" --exclude-dir=node_modules --exclude=package-lock.json .
backend/package.json:70:    "shortid": "^2.2.17",
backend/package.json:86:    "shortid": {

$ npm ls shortid
backend@1.0.10
└── shortid@2.2.17          # no other consumer
```

It is also deprecated upstream, so removing it is strictly better than carrying it.

Dropping the dependency takes the scoped `shortid > nanoid: 3.3.18` override with it, since that pin existed only to hold shortid's own nanoid down. The backend still resolves `nanoid` 5.1.16 through `@scalar/types`, which is unaffected:

```
$ npm ls nanoid
└─┬ @scalar/express-api-reference@0.10.14
  └─┬ @scalar/client-side-rendering@0.3.7
    └─┬ @scalar/types@0.18.0
      └── nanoid@5.1.16
```

The diff is a pure deletion — 32 lines removed, nothing added.

## Scope

#370 also covers replacing `fluent-ffmpeg`, which is an unrelated change to the ffmpeg execution paths. Per CONTRIBUTING ("Do not mix unrelated local changes into the same PR") that is a separate branch, so #370 stays open after this merges.

This also removes one line that #372 lists in its overrides audit, so #372 will want a trivial rebase if it lands after.

## Verification

`npm install` removes 2 packages. No frontend file changed, so frontend checks are untouched from the merged state of #368.

| Check | Result |
| --- | --- |
| backend `npm test` | 309 passing, 25 pending |
| backend `npm audit` | 0 vulnerabilities |
| `outdated` job reproduction (backend) | clean |
| `outdated` job reproduction (frontend) | clean |
