### PR TITLE
chore(deps): drop overrides for packages that are not installed

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -74,7 +74,6 @@
   },
   "overrides": {
     "brace-expansion": "5.0.9",
-    "braces": "3.0.3",
     "cross-spawn": "7.0.6",
     "diff": "8.0.4",
     "form-data": "4.0.6",

--- a/package.json
+++ b/package.json
@@ -86,25 +86,6 @@
     "@angular/build": {
       "picomatch": "4.0.5"
     },
-    "@angular-devkit/build-angular": {
-      "picomatch": "4.0.5",
-      "http-proxy-middleware": {
-        "micromatch": {
-          "picomatch": "2.3.2"
-        }
-      },
-      "webpack-dev-server": {
-        ".": "5.2.6",
-        "chokidar": {
-          "anymatch": {
-            "picomatch": "2.3.2"
-          },
-          "readdirp": {
-            "picomatch": "2.3.2"
-          }
-        }
-      }
-    },
     "@angular-devkit/core": {
       "ajv": "8.20.0",
       "picomatch": "4.0.5"
@@ -121,11 +102,7 @@
     "js-yaml": "4.3.1",
     "nanoid": "3.3.18",
     "postcss": "8.5.26",
-    "serialize-javascript": "7.1.0",
-    "tar": "7.5.22",
     "tmp": "0.2.7",
-    "undici": "7.29.0",
-    "uuid": "14.0.2",
     "vite": "7.3.6",
     "ws": "8.21.3"
   }


### PR DESCRIPTION
Part of #372 — the dead-config half. The stale-pin half (`@babel/core`, `vite`) is a separate branch, since it needs real verification rather than a proof that nothing moved.

Six overrides pin packages that are **absent from the tree**, so they constrain nothing:

| | Entries |
| --- | --- |
| **frontend** | `@angular-devkit/build-angular` (and its whole nested block), `serialize-javascript`, `tar`, `undici`, `uuid` |
| **backend** | `braces` |

```
$ npm ls undici webpack-dev-server uuid @angular-devkit/build-angular
ytdl-material@1.0.10
└── (empty)          # all four
```

`serialize-javascript` stays in the **backend**, where mocha pulls it in — it is removed from the frontend only.

## The oldest one

The `@angular-devkit/build-angular` block traces through 96de27f9 (*"patch picomatch for alerts 18 and 19"*) back to 1470340a, **"Migrated to angular 8"**. The project builds with `@angular/build` now, so that builder — along with the `webpack-dev-server` nested inside it and the `picomatch` pins beneath that — has had nothing to apply to for some time.

## Proof that nothing moved

This is the part worth checking rather than taking on faith. Regenerating both lockfiles from the reduced overrides produces **byte-identical files** — `git diff` on `package-lock.json` and `backend/package-lock.json` is empty. Comparing every resolved `package@version` before and after:

```
=== FRONTEND resolved-version diff ===
IDENTICAL - no resolved version changed      (699 entries)
=== BACKEND resolved-version diff ===
IDENTICAL - no resolved version changed      (477 entries)
```

So the diff is 24 deleted lines that provably alter no dependency, and only stop the manifest claiming to pin things it does not.

## Why CI never flagged it

The `outdated` job compares `current` against `wanted`, and an exact pin always satisfies itself. Config for an uninstalled package is invisible to it, which is how an Angular-8-era block stayed green for years.

## Verification

| Check | Result |
| --- | --- |
| `npm run lint` | pass |
| `tsc -p src/tsconfig.app.json` / `.spec.json` | pass |
| `npm run test:headless` | 251/251 |
| backend `npm test` | 313 passing, 25 pending |
| `ng build --configuration production` | pass |
| `npm audit` (both) | 0 vulnerabilities |
| `outdated` job reproduction (both) | clean |

## Not in scope

Two live `picomatch` pins remain under `@angular/build` and `@angular-devkit/core`. Those parents **are** installed, and npm currently reports the karma-side `picomatch@2.3.2` as `invalid` against them — but that resolves for free when karma goes away, so it is tracked in #373 and #369 rather than untangled here.
