### PR TITLE
test(ldap): stand up a local directory and cover the LDAP auth path

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -76,3 +76,30 @@ behavior, so it would fail for reasons unrelated to any given change.
   "it works for me" does not disprove a report. Always reproduce with the reporter's URL.
 - **Running the backend test suite rewrites `backend/appdata/default.json`**, stripping
   retired keys and self-healing missing ones. Check `git diff` on it before committing.
+
+# A local LDAP server
+
+`ytdl_auth_method: ldap` was the one auth path with no way to exercise it, which is why
+`passport-ldapauth` had gone so long without anyone confirming what it actually does.
+`dev/ldap/ldap-server.sh` fixes that by building a throwaway OpenLDAP and seeding it:
+
+```bash
+dev/ldap/ldap-server.sh start     # builds on first run (~2 min), then listens on :3389
+cd backend && npm test            # backend/test/ldap.test.js now has a directory to talk to
+dev/ldap/ldap-server.sh stop
+```
+
+`start` reseeds from `dev/ldap/fixtures/seed.ldif` every time, so the directory is the same
+on every run and tests never have to clean up after each other. `status` shows the seeded
+uids, `search` runs `ldapsearch` as the admin account, and `clean --all` removes everything
+including the build.
+
+Nothing lands in the repo or in system directories: the tarball, the compiled OpenLDAP and
+the directory data all live under `~/.cache/ytdl-material/openldap`. It is built from
+source rather than installed because it needs no root that way, and pinned by SHA3-512 so a
+substituted tarball fails the build.
+
+`backend/test/ldap.test.js` skips itself when nothing is listening on the configured URL,
+so CI and anyone who has not started the server are unaffected. Point it elsewhere — a real
+directory, or a second instance — with the `YTDL_TEST_LDAP_*` variables that
+`dev/ldap/ldap-server.sh env` prints.

--- a/backend/test/ldap.test.js
+++ b/backend/test/ldap.test.js
@@ -1,0 +1,240 @@
+/* eslint-disable no-undef */
+const net = require('net');
+
+const {
+    assert,
+    auth_api,
+    config_api,
+    db_api
+} = require('./test-shared');
+
+// These run against the throwaway OpenLDAP server from dev/ldap/ldap-server.sh, and
+// skip themselves when nothing is listening -- CI has no directory to talk to, and a
+// contributor who has not started one should not see a wall of red.
+//
+//   dev/ldap/ldap-server.sh start
+//   npm test
+//
+// The values below are the defaults that script seeds and prints via `env`.
+const LDAP_URL = process.env.YTDL_TEST_LDAP_URL || 'ldap://127.0.0.1:3389';
+const BIND_DN = process.env.YTDL_TEST_LDAP_BIND_DN || 'cn=admin,dc=ytdl,dc=test';
+const BIND_PW = process.env.YTDL_TEST_LDAP_BIND_PW || 'ytdl-test-admin';
+const SEARCH_BASE = process.env.YTDL_TEST_LDAP_SEARCH_BASE || 'ou=people,dc=ytdl,dc=test';
+
+const baseLdapConfig = () => ({
+    url: LDAP_URL,
+    bindDN: BIND_DN,
+    bindCredentials: BIND_PW,
+    searchBase: SEARCH_BASE,
+    searchFilter: '(uid={{username}})'
+});
+
+function serverIsUp() {
+    const {hostname, port} = new URL(LDAP_URL);
+    return new Promise((resolve) => {
+        const socket = net.connect({host: hostname, port: Number(port)});
+        const settle = (up) => {
+            socket.destroy();
+            resolve(up);
+        };
+        socket.setTimeout(2000);
+        socket.once('connect', () => settle(true));
+        socket.once('timeout', () => settle(false));
+        socket.once('error', () => settle(false));
+    });
+}
+
+// passport's own middleware wants an express request and a framework it has been
+// initialized against. The strategy underneath needs neither, so drive it the way
+// passport does internally: shallow-copy it and swap in the outcome callbacks.
+function authenticate(username, password) {
+    const strategy = Object.create(auth_api.passport._strategies['ldapauth']);
+    return new Promise((resolve) => {
+        strategy.success = (user, info) => resolve({outcome: 'success', user, info});
+        strategy.fail = (challenge, status) => resolve({outcome: 'fail', challenge, status});
+        strategy.error = (error) => resolve({outcome: 'error', error});
+        strategy.redirect = (url) => resolve({outcome: 'redirect', url});
+        strategy.pass = () => resolve({outcome: 'pass'});
+        strategy.authenticate({body: {username, password}, query: {}, headers: {}}, {});
+    });
+}
+
+describe('LDAP', function() {
+    this.timeout(20000);
+
+    const original_getConfigItem = config_api.getConfigItem;
+    let auth_method = 'ldap';
+    let ldap_config = baseLdapConfig();
+
+    // Every uid the seed LDIF can hand back. A successful bind writes to the users
+    // table, so these are wiped between tests -- otherwise "a failed bind must not
+    // provision a user" passes or fails depending on what ran before it.
+    const FIXTURE_UIDS = [
+        'ytdl-user',
+        'ytdl-second',
+        'ytdl.dotted_name-2@ytdl.test',
+        'ytdl unsafe/uid',
+        'ytdl-outside'
+    ];
+
+    const forgetFixtureUsers = async () => {
+        for (const uid of FIXTURE_UIDS) await db_api.removeAllRecords('users', {uid: uid});
+    };
+
+    before(async function() {
+        if (!await serverIsUp()) {
+            // eslint-disable-next-line no-console
+            console.log(`      (no LDAP server on ${LDAP_URL} -- run dev/ldap/ldap-server.sh start)`);
+            this.skip();
+        }
+        config_api.getConfigItem = (key) => {
+            if (key === 'ytdl_auth_method') return auth_method;
+            if (key === 'ytdl_ldap_config') return ldap_config;
+            return original_getConfigItem(key);
+        };
+    });
+
+    after(async function() {
+        config_api.getConfigItem = original_getConfigItem;
+        await forgetFixtureUsers();
+    });
+
+    beforeEach(async function() {
+        auth_method = 'ldap';
+        ldap_config = baseLdapConfig();
+        await forgetFixtureUsers();
+    });
+
+    describe('Successful binds', function() {
+        it('provisions a user that has never logged in before', async function() {
+            const result = await authenticate('ytdl-user', 'user-password');
+
+            assert.strictEqual(result.outcome, 'success');
+            assert.strictEqual(result.user.uid, 'ytdl-user');
+            assert.strictEqual(result.user.auth_method, 'ldap');
+            const stored = await db_api.getRecord('users', {uid: 'ytdl-user'});
+            assert(stored, 'expected the LDAP user to be written to the users table');
+            assert.strictEqual(stored.auth_method, 'ldap');
+        });
+
+        it('reuses the existing record on a second login', async function() {
+            const first = await authenticate('ytdl-user', 'user-password');
+            const second = await authenticate('ytdl-user', 'user-password');
+
+            assert.strictEqual(first.outcome, 'success');
+            assert.strictEqual(second.outcome, 'success');
+            assert.strictEqual(second.user.uid, first.user.uid);
+            const all = await db_api.getRecords('users', {uid: 'ytdl-user'});
+            assert.strictEqual(all.length, 1, 'a repeat login must not create a second record');
+        });
+
+        it('keeps users distinct rather than accepting any valid bind', async function() {
+            const first = await authenticate('ytdl-user', 'user-password');
+            const second = await authenticate('ytdl-second', 'second-password');
+            const crossed = await authenticate('ytdl-user', 'second-password');
+
+            assert.strictEqual(first.user.uid, 'ytdl-user');
+            assert.strictEqual(second.user.uid, 'ytdl-second');
+            assert.strictEqual(crossed.outcome, 'fail');
+        });
+
+        it('accepts uids containing dots, dashes, underscores and @', async function() {
+            const uid = 'ytdl.dotted_name-2@ytdl.test';
+
+            const result = await authenticate(uid, 'dotted-password');
+
+            assert.strictEqual(result.outcome, 'success');
+            assert.strictEqual(result.user.uid, uid);
+        });
+    });
+
+    describe('Rejected binds', function() {
+        it('fails on a wrong password', async function() {
+            const result = await authenticate('ytdl-user', 'not-the-password');
+
+            assert.strictEqual(result.outcome, 'fail');
+            assert.strictEqual(result.status, 401);
+            const stored = await db_api.getRecord('users', {uid: 'ytdl-user'});
+            assert(!stored, 'a failed bind must not provision a user');
+        });
+
+        it('fails on an unknown user', async function() {
+            const result = await authenticate('nobody-here', 'any-password');
+
+            assert.strictEqual(result.outcome, 'fail');
+        });
+
+        it('fails on missing credentials without reaching the directory', async function() {
+            const result = await authenticate('ytdl-user', '');
+
+            assert.strictEqual(result.outcome, 'fail');
+            assert.strictEqual(result.status, 400);
+        });
+
+        it('refuses to look outside the configured search base', async function() {
+            // uid=ytdl-outside is seeded one level up from ou=people, so finding it
+            // would mean the searchBase is not being applied.
+            const result = await authenticate('ytdl-outside', 'outside-password');
+
+            assert.strictEqual(result.outcome, 'fail');
+        });
+
+        it('fails every login while the auth method is not ldap', async function() {
+            auth_method = 'internal';
+
+            const result = await authenticate('ytdl-user', 'user-password');
+
+            assert.strictEqual(result.outcome, 'fail');
+            const stored = await db_api.getRecord('users', {uid: 'ytdl-user'});
+            assert(!stored, 'ldap must not provision users when it is switched off');
+        });
+    });
+
+    describe('Broken configuration', function() {
+        it('reports a wrong service account password as a login failure', async function() {
+            // Worth knowing when reading a support thread: the service account's own
+            // bind failing surfaces as InvalidCredentialsError too, so the admin who
+            // fat-fingered bindCredentials sees the same 401 their users see, with
+            // nothing in the response distinguishing the two.
+            ldap_config = {...baseLdapConfig(), bindCredentials: 'wrong-service-password'};
+
+            const result = await authenticate('ytdl-user', 'user-password');
+
+            assert.strictEqual(result.outcome, 'fail');
+            assert.strictEqual(result.status, 401);
+        });
+
+        it('errors when the directory is unreachable', async function() {
+            // Port 1 is reserved and nothing listens on it, so this is a connection
+            // refusal rather than a hang.
+            ldap_config = {...baseLdapConfig(), url: 'ldap://127.0.0.1:1'};
+
+            const result = await authenticate('ytdl-user', 'user-password');
+
+            assert.strictEqual(result.outcome, 'error');
+        });
+
+        it('fails cleanly on a search base that does not exist', async function() {
+            ldap_config = {...baseLdapConfig(), searchBase: 'ou=missing,dc=ytdl,dc=test'};
+
+            const result = await authenticate('ytdl-user', 'user-password');
+
+            assert.notStrictEqual(result.outcome, 'success');
+        });
+    });
+
+    describe('Uid handling', function() {
+        it('does not sanitize uids the way the OIDC path does', async function() {
+            // Documents current behaviour, not desired behaviour: the OIDC callback runs
+            // its login name through auth_api.sanitizeUserUID, the LDAP verify callback
+            // does not, so a directory can hand us a uid containing a path separator.
+            const uid = 'ytdl unsafe/uid';
+            assert.strictEqual(auth_api.sanitizeUserUID(uid), null);
+
+            const result = await authenticate(uid, 'unsafe-password');
+
+            assert.strictEqual(result.outcome, 'success');
+            assert.strictEqual(result.user.uid, uid);
+        });
+    });
+});

--- a/dev/ldap/fixtures/seed.ldif
+++ b/dev/ldap/fixtures/seed.ldif
@@ -1,0 +1,79 @@
+# Seed data for the local test directory (dc=ytdl,dc=test).
+#
+# Loaded offline with slapadd on every `ldap-server.sh start`, so the directory is
+# identical for every run -- tests may bind, but must not write.
+#
+# Passwords are stored in the clear on purpose. slapd compares them fine, and a
+# readable fixture is worth more here than a {SSHA} blob nobody can map back to the
+# password a failing test was using.
+
+dn: dc=ytdl,dc=test
+objectClass: top
+objectClass: dcObject
+objectClass: organization
+o: ytdl-material test directory
+dc: ytdl
+
+dn: ou=people,dc=ytdl,dc=test
+objectClass: organizationalUnit
+ou: people
+
+dn: ou=groups,dc=ytdl,dc=test
+objectClass: organizationalUnit
+ou: groups
+
+# The ordinary case: a user that should log in and be auto-provisioned.
+dn: uid=ytdl-user,ou=people,dc=ytdl,dc=test
+objectClass: inetOrgPerson
+uid: ytdl-user
+cn: Regular Test User
+sn: User
+givenName: Regular
+mail: ytdl-user@ytdl.test
+userPassword: user-password
+
+# Second ordinary user, to prove auth is per-user and not "any valid bind wins".
+dn: uid=ytdl-second,ou=people,dc=ytdl,dc=test
+objectClass: inetOrgPerson
+uid: ytdl-second
+cn: Second Test User
+sn: User
+mail: ytdl-second@ytdl.test
+userPassword: second-password
+
+# uid with the punctuation SAFE_UID_PATTERN allows (dot, dash, underscore, @).
+dn: uid=ytdl.dotted_name-2@ytdl.test,ou=people,dc=ytdl,dc=test
+objectClass: inetOrgPerson
+uid: ytdl.dotted_name-2@ytdl.test
+cn: Dotted Name
+sn: Name
+userPassword: dotted-password
+
+# uid containing characters SAFE_UID_PATTERN rejects. The LDAP verify callback does
+# not sanitize uids the way the OIDC path does, so this entry exists to pin down what
+# actually happens rather than what we assume happens.
+dn: uid=ytdl unsafe/uid,ou=people,dc=ytdl,dc=test
+objectClass: inetOrgPerson
+uid: ytdl unsafe/uid
+cn: Unsafe Uid
+sn: Uid
+userPassword: unsafe-password
+
+# Entry outside ou=people, so a searchBase of ou=people proves it scopes the search.
+dn: uid=ytdl-outside,dc=ytdl,dc=test
+objectClass: inetOrgPerson
+uid: ytdl-outside
+cn: Outside The Search Base
+sn: Base
+userPassword: outside-password
+
+dn: cn=ytdl-users,ou=groups,dc=ytdl,dc=test
+objectClass: groupOfNames
+cn: ytdl-users
+member: uid=ytdl-user,ou=people,dc=ytdl,dc=test
+member: uid=ytdl-second,ou=people,dc=ytdl,dc=test
+
+dn: cn=ytdl-admins,ou=groups,dc=ytdl,dc=test
+objectClass: groupOfNames
+cn: ytdl-admins
+member: uid=ytdl-user,ou=people,dc=ytdl,dc=test

--- a/dev/ldap/fixtures/slapd.conf.tmpl
+++ b/dev/ldap/fixtures/slapd.conf.tmpl
@@ -1,0 +1,38 @@
+# Template for the throwaway test directory. dev/ldap/ldap-server.sh substitutes the
+# @PLACEHOLDERS@ and writes the result into the run directory -- do not edit the
+# generated copy, it is rewritten on every start.
+#
+# slapd.conf is the deprecated-but-supported config format. cn=config is what a real
+# deployment should use; here the flat file wins because it is one readable page
+# instead of a directory of LDIF that has to be bootstrapped before it can be read.
+
+include		@PREFIX@/etc/openldap/schema/core.schema
+include		@PREFIX@/etc/openldap/schema/cosine.schema
+include		@PREFIX@/etc/openldap/schema/inetorgperson.schema
+
+pidfile		@RUN_DIR@/slapd.pid
+argsfile	@RUN_DIR@/slapd.args
+
+# Anonymous binds must be allowed to reach the compare/search, because
+# passport-ldapauth binds as the service account, searches for the user, then
+# re-binds as the user it found.
+access to attrs=userPassword
+	by self write
+	by anonymous auth
+	by * none
+
+access to *
+	by self write
+	by users read
+	by anonymous read
+
+database	mdb
+maxsize		134217728
+suffix		"@SUFFIX@"
+rootdn		"@ROOT_DN@"
+rootpw		@ROOT_PW@
+directory	@DATA_DIR@
+
+index		objectClass	eq
+index		uid		eq,sub
+index		cn,sn,mail	eq,sub

--- a/dev/ldap/ldap-server.sh
+++ b/dev/ldap/ldap-server.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+#
+# Throwaway OpenLDAP server for exercising the LDAP auth path locally.
+#
+# Nothing in CI uses this, and nothing it touches lives inside the repo: the source
+# tarball, the build and the directory data all sit under the cache dir printed by
+# `ldap-server.sh env`. Deleting that directory undoes everything this script does.
+#
+# Usage: dev/ldap/ldap-server.sh <command>
+# Run with no arguments for the command list.
+
+set -euo pipefail
+
+OPENLDAP_VERSION="${OPENLDAP_VERSION:-2.6.14}"
+# Published alongside the tarball as openldap-<version>.sha3-512. Pinned here rather
+# than fetched so a swapped tarball fails the build instead of bringing its own digest.
+OPENLDAP_SHA3_512="${OPENLDAP_SHA3_512:-ac6a9de179d89ae498b74da4127699ea0963cd98e750c9cf81e11d71610c5dd07fee3b42c6b82ed23561797294b33f475189bbb86f0aa865453cc4158104b024}"
+OPENLDAP_URL="https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-${OPENLDAP_VERSION}.tgz"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURES="$HERE/fixtures"
+
+CACHE_ROOT="${YTDL_LDAP_CACHE:-${XDG_CACHE_HOME:-$HOME/.cache}/ytdl-material/openldap}"
+PREFIX="$CACHE_ROOT/$OPENLDAP_VERSION"
+BUILD_DIR="$CACHE_ROOT/build"
+TARBALL="$CACHE_ROOT/openldap-${OPENLDAP_VERSION}.tgz"
+RUN_DIR="${YTDL_LDAP_RUN_DIR:-$CACHE_ROOT/run}"
+DATA_DIR="$RUN_DIR/data"
+CONF="$RUN_DIR/slapd.conf"
+# slapd writes this itself, per the pidfile directive in slapd.conf.tmpl. Tracking the
+# shell's $! separately would just give us a second copy to keep in sync.
+PID_FILE="$RUN_DIR/slapd.pid"
+LOG_FILE="$RUN_DIR/slapd.log"
+
+HOST="${YTDL_LDAP_HOST:-127.0.0.1}"
+PORT="${YTDL_LDAP_PORT:-3389}"
+URL="ldap://$HOST:$PORT"
+
+SUFFIX="dc=ytdl,dc=test"
+ROOT_DN="cn=admin,$SUFFIX"
+ROOT_PW="ytdl-test-admin"
+SEARCH_BASE="ou=people,$SUFFIX"
+
+SLAPD="$PREFIX/libexec/slapd"
+SLAPADD="$PREFIX/sbin/slapadd"
+LDAPSEARCH="$PREFIX/bin/ldapsearch"
+
+say() { printf '\033[0;36m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[0;33m==>\033[0m %s\n' "$*" >&2; }
+die() { printf '\033[0;31m==>\033[0m %s\n' "$*" >&2; exit 1; }
+
+require_tools() {
+  local missing=()
+  for tool in curl tar make gcc openssl; do
+    command -v "$tool" >/dev/null 2>&1 || missing+=("$tool")
+  done
+  [ ${#missing[@]} -eq 0 ] || die "missing build tools: ${missing[*]}"
+}
+
+is_built() { [ -x "$SLAPD" ] && [ -x "$SLAPADD" ] && [ -x "$LDAPSEARCH" ]; }
+
+running_pid() {
+  [ -f "$PID_FILE" ] || return 1
+  local pid
+  pid="$(cat "$PID_FILE")"
+  [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null || return 1
+  printf '%s' "$pid"
+}
+
+download() {
+  mkdir -p "$CACHE_ROOT"
+  if [ ! -f "$TARBALL" ]; then
+    say "downloading openldap $OPENLDAP_VERSION"
+    curl -fL --retry 3 --connect-timeout 10 -o "$TARBALL.part" "$OPENLDAP_URL"
+    mv "$TARBALL.part" "$TARBALL"
+  fi
+  local actual
+  actual="$(openssl dgst -sha3-512 "$TARBALL" | awk '{print $NF}')"
+  if [ "$actual" != "$OPENLDAP_SHA3_512" ]; then
+    rm -f "$TARBALL"
+    die "checksum mismatch for openldap-$OPENLDAP_VERSION.tgz (got $actual); deleted the download. If you set OPENLDAP_VERSION, set OPENLDAP_SHA3_512 to match."
+  fi
+  say "checksum ok"
+}
+
+cmd_build() {
+  if is_built && [ "${1:-}" != "--force" ]; then
+    say "already built at $PREFIX (pass --force to rebuild)"
+    return 0
+  fi
+  require_tools
+  download
+  rm -rf "$BUILD_DIR"
+  mkdir -p "$BUILD_DIR"
+  say "extracting"
+  tar xzf "$TARBALL" -C "$BUILD_DIR"
+  local src="$BUILD_DIR/openldap-$OPENLDAP_VERSION"
+  say "configuring (this takes a minute)"
+  (
+    cd "$src"
+    # No SASL and no modules: a static slapd with the mdb backend is all the auth path
+    # needs, and every dependency skipped here is one less thing to install first.
+    ./configure \
+      --prefix="$PREFIX" \
+      --without-cyrus-sasl \
+      --with-tls=openssl \
+      --enable-slapd \
+      --enable-mdb \
+      --disable-relay \
+      --without-systemd \
+      > "$CACHE_ROOT/configure.log" 2>&1 || { tail -30 "$CACHE_ROOT/configure.log" >&2; die "configure failed (full log: $CACHE_ROOT/configure.log)"; }
+    say "building"
+    make depend > "$CACHE_ROOT/build.log" 2>&1
+    # OpenLDAP's makefiles are not reliably parallel-safe; retry serially before giving up.
+    make -j"$(nproc)" >> "$CACHE_ROOT/build.log" 2>&1 || make >> "$CACHE_ROOT/build.log" 2>&1 \
+      || { tail -30 "$CACHE_ROOT/build.log" >&2; die "build failed (full log: $CACHE_ROOT/build.log)"; }
+    say "installing into $PREFIX"
+    # systemdsystemunitdir defaults to /usr/lib/systemd/system, which install writes to
+    # even under --prefix -- and which is not writable (nor wanted) for a throwaway
+    # build. Blanking it makes the Makefile skip the unit file entirely.
+    make install systemdsystemunitdir= >> "$CACHE_ROOT/build.log" 2>&1
+  )
+  rm -rf "$BUILD_DIR"
+  is_built || die "build finished but slapd is missing from $PREFIX"
+  say "built openldap $OPENLDAP_VERSION"
+}
+
+write_conf() {
+  mkdir -p "$RUN_DIR" "$DATA_DIR"
+  sed \
+    -e "s|@PREFIX@|$PREFIX|g" \
+    -e "s|@RUN_DIR@|$RUN_DIR|g" \
+    -e "s|@DATA_DIR@|$DATA_DIR|g" \
+    -e "s|@SUFFIX@|$SUFFIX|g" \
+    -e "s|@ROOT_DN@|$ROOT_DN|g" \
+    -e "s|@ROOT_PW@|$ROOT_PW|g" \
+    "$FIXTURES/slapd.conf.tmpl" > "$CONF"
+}
+
+wait_until_ready() {
+  local attempt=0
+  while [ "$attempt" -lt 50 ]; do
+    if "$LDAPSEARCH" -x -H "$URL" -b "" -s base -LLL namingContexts > /dev/null 2>&1; then
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    sleep 0.2
+  done
+  warn "slapd did not answer within 10s; last log lines:"
+  tail -20 "$LOG_FILE" >&2 || true
+  return 1
+}
+
+cmd_start() {
+  is_built || cmd_build
+  if running_pid > /dev/null; then
+    say "already running on $URL (pid $(running_pid))"
+    return 0
+  fi
+  # A stale socket from a crashed run is the usual cause of a confusing bind failure.
+  if "$LDAPSEARCH" -x -H "$URL" -b "" -s base -LLL namingContexts > /dev/null 2>&1; then
+    die "something is already listening on $PORT that this script did not start"
+  fi
+  say "seeding a fresh directory"
+  rm -rf "$RUN_DIR"
+  write_conf
+  "$SLAPADD" -q -f "$CONF" -l "$FIXTURES/seed.ldif" > "$RUN_DIR/slapadd.log" 2>&1 \
+    || { cat "$RUN_DIR/slapadd.log" >&2; die "slapadd failed"; }
+  say "starting slapd on $URL"
+  # -d 256 (stats) keeps slapd in the foreground so the log lands in a file we control
+  # instead of the system journal, which a non-root dev process cannot write to anyway.
+  nohup "$SLAPD" -f "$CONF" -h "$URL/" -d 256 > "$LOG_FILE" 2>&1 &
+  wait_until_ready || { cmd_stop; die "slapd failed to start"; }
+  say "ready"
+  cmd_env
+}
+
+cmd_stop() {
+  local pid
+  if ! pid="$(running_pid)"; then
+    say "not running"
+    # Covers the case where slapd outlived its pidfile -- otherwise the next `start`
+    # dies on the port being taken with no hint as to what is holding it.
+    if "$LDAPSEARCH" -x -H "$URL" -b "" -s base -LLL namingContexts > /dev/null 2>&1; then
+      warn "but $PORT is still answering LDAP; find the stray slapd with: ss -ltnp | grep $PORT"
+    fi
+    rm -f "$PID_FILE"
+    return 0
+  fi
+  say "stopping slapd (pid $pid)"
+  kill "$pid" 2>/dev/null || true
+  local attempt=0
+  while kill -0 "$pid" 2>/dev/null && [ "$attempt" -lt 50 ]; do
+    attempt=$((attempt + 1))
+    sleep 0.1
+  done
+  kill -9 "$pid" 2>/dev/null || true
+  rm -f "$PID_FILE"
+}
+
+cmd_restart() { cmd_stop; cmd_start; }
+
+cmd_status() {
+  if running_pid > /dev/null; then
+    say "running on $URL (pid $(running_pid))"
+    "$LDAPSEARCH" -x -H "$URL" -D "$ROOT_DN" -w "$ROOT_PW" -b "$SEARCH_BASE" -LLL uid || true
+  else
+    say "not running"
+    is_built && say "built at $PREFIX" || say "not built"
+  fi
+}
+
+cmd_search() {
+  running_pid > /dev/null || die "not running; start it first"
+  "$LDAPSEARCH" -x -H "$URL" -D "$ROOT_DN" -w "$ROOT_PW" -b "$SUFFIX" "${@:-(objectClass=*)}"
+}
+
+cmd_env() {
+  cat <<ENV
+YTDL_TEST_LDAP_URL=$URL
+YTDL_TEST_LDAP_BIND_DN=$ROOT_DN
+YTDL_TEST_LDAP_BIND_PW=$ROOT_PW
+YTDL_TEST_LDAP_SEARCH_BASE=$SEARCH_BASE
+ENV
+}
+
+cmd_clean() {
+  cmd_stop
+  say "removing $RUN_DIR"
+  rm -rf "$RUN_DIR"
+  if [ "${1:-}" = "--all" ]; then
+    say "removing $CACHE_ROOT"
+    rm -rf "$CACHE_ROOT"
+  fi
+}
+
+cmd_help() {
+  cat <<'HELP'
+dev/ldap/ldap-server.sh <command>
+
+  build [--force]  download, verify and compile OpenLDAP into the cache dir
+  start            (re)seed the directory and start slapd on 127.0.0.1:3389
+  stop             stop slapd
+  restart          stop, reseed, start
+  status           show whether it is running, and list the seeded uids
+  search [filter]  run ldapsearch against it as the admin account
+  env              print the YTDL_TEST_LDAP_* vars the backend tests read
+  clean [--all]    stop and drop the directory data (--all drops the build too)
+
+The backend LDAP tests skip themselves when nothing is listening, so `start` is the
+only thing that has to happen before `npm test` in backend/ exercises them:
+
+  dev/ldap/ldap-server.sh start
+  cd backend && npm test
+HELP
+}
+
+case "${1:-help}" in
+  build)   shift; cmd_build "$@";;
+  start)   shift; cmd_start "$@";;
+  stop)    shift; cmd_stop "$@";;
+  restart) shift; cmd_restart "$@";;
+  status)  shift; cmd_status "$@";;
+  search)  shift; cmd_search "$@";;
+  env)     shift; cmd_env "$@";;
+  clean)   shift; cmd_clean "$@";;
+  help|-h|--help) cmd_help;;
+  *) warn "unknown command: $1"; cmd_help; exit 1;;
+esac


### PR DESCRIPTION
First half of #371. **No dependency changes** — this is the environment and the coverage that the `passport-ldapauth` removal needs in order to be safe. #371 stays open.

## Why this comes first

ldapjs is decommissioned in *every* published major (2.x and 3.x carry the same notice), so there is no bump that silences it — `passport-ldapauth` has to be replaced. That is a rewrite of the one auth path with zero test coverage, and it had zero coverage because there was no directory to test against.

## The harness

`dev/ldap/ldap-server.sh` builds OpenLDAP 2.6.14 from source into `~/.cache/ytdl-material/openldap` and runs it on `127.0.0.1:3389`:

```bash
dev/ldap/ldap-server.sh start     # ~2 min on first run, seconds after
cd backend && npm test
dev/ldap/ldap-server.sh stop
```

- **No root.** Built from source with `--prefix` into the cache dir, rather than installed. `systemdsystemunitdir` is blanked because `make install` otherwise writes a unit file to `/usr/lib/systemd/system` even under a prefix.
- **Nothing in the repo.** Tarball, build and directory data all live under the cache dir; `clean --all` removes the lot.
- **Pinned.** SHA3-512 is committed, not fetched alongside the tarball, so a substituted download fails the build.
- `start` reseeds from `fixtures/seed.ldif` every time, so the directory is identical on every run and tests never clean up after each other.

Also `status`, `search`, `restart`, `env`, `clean`.

## The tests

`backend/test/ldap.test.js` — 13 tests driving the real registered passport strategy, not a stub. It **skips itself when nothing is listening**, so CI and anyone who has not started a server see 13 pending and no failures.

Three things it pins down that were previously assumed rather than known:

- a successful bind provisions the user with `auth_method: 'ldap'`, and a repeat login reuses that record instead of adding a second one
- a wrong `bindCredentials` surfaces as a **401 login failure**, indistinguishable in the response from a user's own wrong password — worth knowing before reading the next support thread about it
- the LDAP verify callback **does not** run uids through `sanitizeUserUID` the way the OIDC callback does, so a directory can hand us a uid containing a path separator. The test documents current behaviour; it does not change it. Flagging rather than fixing here — see below.

Plus the ordinary ones: wrong password, unknown user, missing credentials, search base scoping, `auth_method != 'ldap'` refusing every login, unreachable directory, non-existent search base.

## Verified

- 13/13 against a freshly built and seeded server, twice, including a full clean lifecycle on an alternate port
- 13 pending / 0 failing with no server listening
- full backend suite: 326 passing, 25 pending, 0 failing

## Follow-ups, not in this PR

- The uid sanitizing gap above probably wants its own issue.
- #371 proper: replace `passport-ldapauth` with a thin strategy over `ldapts`. These tests are the regression baseline for it.