### PR TITLE
fix(auth): refuse LDAP uids that can escape the users folder

### DIFF
--- a/backend/authentication/auth.js
+++ b/backend/authentication/auth.js
@@ -21,6 +21,9 @@ let opts = null;
 let saltRounds = 10;
 
 const SAFE_UID_PATTERN = /^[A-Za-z0-9._@-]+$/;
+// Path separators and the null byte -- the characters that let a uid escape the folder
+// it is supposed to name, rather than merely look unusual.
+const PATH_UNSAFE_PATTERN = /[/\\\0]/;
 
 exports.initialize = function () {
   /*************************
@@ -174,6 +177,24 @@ exports.sanitizeUserUID = (rawUID) => {
   if (input === '.' || input === '..') return null;
   if (!SAFE_UID_PATTERN.test(input)) return null;
   return input;
+}
+
+/*************************************************
+ * The uid ends up as a path component in a dozen
+ * places (db.js, downloader.js, utils.js,
+ * twitch.js), so it must not be able to steer a
+ * path.join() out of the folder it names.
+ *
+ * Deliberately narrower than sanitizeUserUID: an
+ * LDAP directory was never held to SAFE_UID_PATTERN,
+ * and installs exist whose uids contain punctuation
+ * it refuses. Those keep working; only uids that
+ * can traverse are turned away.
+ ************************************************/
+exports.uidIsPathSafe = (rawUID) => {
+  if (typeof rawUID !== 'string' || !rawUID.trim()) return false;
+  if (rawUID === '.' || rawUID === '..') return false;
+  return !PATH_UNSAFE_PATTERN.test(rawUID);
 }
 
 function getOIDCIdentityFromClaims(claims, usernameClaim) {
@@ -343,6 +364,12 @@ exports.passport.use(new LdapStrategy(getLDAPConfiguration,
     if (!ldap_enabled) return done(null, false);
 
     const user_uid = user.uid;
+    if (!exports.uidIsPathSafe(user_uid)) {
+      logger.error(`LDAP login rejected: the directory returned an unusable uid (${JSON.stringify(user_uid)}). `
+        + `A uid must be a non-empty string, and cannot be '.', '..', or contain a path separator.`);
+      return done(null, false);
+    }
+
     let db_user = await db_api.getRecord('users', {uid: user_uid});
     if (!db_user) {
       // generate DB user

--- a/backend/test/ldap.test.js
+++ b/backend/test/ldap.test.js
@@ -74,6 +74,8 @@ describe('LDAP', function() {
         'ytdl-second',
         'ytdl.dotted_name-2@ytdl.test',
         'ytdl unsafe/uid',
+        'ytdl spaced name',
+        '..',
         'ytdl-outside'
     ];
 
@@ -224,14 +226,50 @@ describe('LDAP', function() {
     });
 
     describe('Uid handling', function() {
-        it('does not sanitize uids the way the OIDC path does', async function() {
-            // Documents current behaviour, not desired behaviour: the OIDC callback runs
-            // its login name through auth_api.sanitizeUserUID, the LDAP verify callback
-            // does not, so a directory can hand us a uid containing a path separator.
+        // The uid becomes a path component in db.js, downloader.js, utils.js and
+        // twitch.js, so a directory must not be able to hand back one that walks out of
+        // the users folder. The guard is deliberately narrower than the OIDC path's
+        // sanitizeUserUID -- see the second block.
+        it('refuses a uid containing a path separator', async function() {
             const uid = 'ytdl unsafe/uid';
-            assert.strictEqual(auth_api.sanitizeUserUID(uid), null);
 
             const result = await authenticate(uid, 'unsafe-password');
+
+            assert.strictEqual(result.outcome, 'fail');
+            const stored = await db_api.getRecord('users', {uid: uid});
+            assert(!stored, 'a rejected uid must not be written to the users table');
+        });
+
+        it('refuses a uid that is itself a relative path segment', async function() {
+            const result = await authenticate('..', 'dotdot-password');
+
+            assert.strictEqual(result.outcome, 'fail');
+            const stored = await db_api.getRecord('users', {uid: '..'});
+            assert(!stored);
+        });
+
+        it('rejects path-unsafe uids without reaching the directory', function() {
+            // Shapes worth pinning that no fixture entry can express: a uid the
+            // directory returns as an array (uid is multi-valued in the LDAP schema),
+            // a backslash on the Windows side, and a null byte.
+            assert.strictEqual(auth_api.uidIsPathSafe('..'), false);
+            assert.strictEqual(auth_api.uidIsPathSafe('.'), false);
+            assert.strictEqual(auth_api.uidIsPathSafe('a/b'), false);
+            assert.strictEqual(auth_api.uidIsPathSafe('a\\b'), false);
+            assert.strictEqual(auth_api.uidIsPathSafe('a\0b'), false);
+            assert.strictEqual(auth_api.uidIsPathSafe(''), false);
+            assert.strictEqual(auth_api.uidIsPathSafe('   '), false);
+            assert.strictEqual(auth_api.uidIsPathSafe(['a', 'b']), false);
+            assert.strictEqual(auth_api.uidIsPathSafe(undefined), false);
+        });
+
+        it('still accepts uids the stricter OIDC pattern would refuse', async function() {
+            // A directory using uids with spaces predates any of our validation and has
+            // live users. Closing the traversal must not lock them out.
+            const uid = 'ytdl spaced name';
+            assert.strictEqual(auth_api.sanitizeUserUID(uid), null, 'precondition: OIDC would refuse this');
+
+            const result = await authenticate(uid, 'spaced-password');
 
             assert.strictEqual(result.outcome, 'success');
             assert.strictEqual(result.user.uid, uid);

--- a/dev/ldap/fixtures/seed.ldif
+++ b/dev/ldap/fixtures/seed.ldif
@@ -49,15 +49,32 @@ cn: Dotted Name
 sn: Name
 userPassword: dotted-password
 
-# uid containing characters SAFE_UID_PATTERN rejects. The LDAP verify callback does
-# not sanitize uids the way the OIDC path does, so this entry exists to pin down what
-# actually happens rather than what we assume happens.
+# uid containing a path separator. The uid becomes a folder name, so this login has to
+# be refused however legitimate the bind is.
 dn: uid=ytdl unsafe/uid,ou=people,dc=ytdl,dc=test
 objectClass: inetOrgPerson
 uid: ytdl unsafe/uid
 cn: Unsafe Uid
 sn: Uid
 userPassword: unsafe-password
+
+# The other traversal shape: a uid that *is* a relative path segment.
+dn: uid=..,ou=people,dc=ytdl,dc=test
+objectClass: inetOrgPerson
+uid: ..
+cn: Dot Dot
+sn: Dot
+userPassword: dotdot-password
+
+# uid with a space -- outside SAFE_UID_PATTERN, but harmless as a folder name. A
+# directory using uids like this predates any of our validation, so it keeps working;
+# this entry is here to catch a fix that over-rejects.
+dn: uid=ytdl spaced name,ou=people,dc=ytdl,dc=test
+objectClass: inetOrgPerson
+uid: ytdl spaced name
+cn: Spaced Name
+sn: Name
+userPassword: spaced-password
 
 # Entry outside ou=people, so a searchBase of ou=people proves it scopes the search.
 dn: uid=ytdl-outside,dc=ytdl,dc=test


### PR DESCRIPTION
Closes #382.

## The hole

The LDAP verify callback wrote the directory's `uid` attribute straight into the users table. That uid becomes a path component in a dozen places — `db.js:618`, `downloader.js:1932`, `utils.js:821`, `twitch.js:72` and friends — so a directory could name a user `../..` and steer writes out of the users folder.

`deleteUser` already refuses to act on a uid that resolves outside the base folder, so the hazard was understood; the one entry point that can *introduce* such a uid just wasn't checked.

## The fix

```js
exports.uidIsPathSafe = (rawUID) => {
  if (typeof rawUID !== 'string' || !rawUID.trim()) return false;
  if (rawUID === '.' || rawUID === '..') return false;
  return !PATH_UNSAFE_PATTERN.test(rawUID);   // [/\\\0]
}
```

Called before provisioning; a failure logs what the directory sent and refuses the login.

**Deliberately narrower than `sanitizeUserUID`,** which the OIDC path uses. That was option 3 of the three in #382, and the reason is compatibility: LDAP directories were never held to `SAFE_UID_PATTERN`, so installs exist whose uids contain punctuation it refuses. A uid with a space is unusual but completely safe as a folder name. Full parity would have locked those users out on their next login *and* orphaned their media, which already lives in a folder named after the unsanitized uid. This closes the traversal and leaves everything else alone.

One extra: non-string uids are refused. `uid` is multi-valued in the LDAP schema, so a directory with two values hands back an array — which already produced a nonsense folder name. Now it produces a log line saying so.

## Coverage

The harness from #381 gained fixture entries for both traversal shapes and for a spaced uid, so the tests prove the guard closes the hole *without over-rejecting*:

- `uid=ytdl unsafe/uid` → refused, nothing written to the users table
- `uid=..` → refused
- `uid=ytdl spaced name` → **still logs in**, with an assertion that `sanitizeUserUID` would have refused it
- direct assertions on `uidIsPathSafe` for the shapes no LDIF entry can express: backslash, null byte, array, `undefined`

The test that previously pinned the old behaviour is inverted rather than deleted.

## Verified

- 16/16 against a live directory (`dev/ldap/ldap-server.sh start`)
- full backend suite: 329 passing, 25 pending, 0 failing