### PR TITLE
chore(deps): move openid-client to 6.8.7

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -3586,9 +3586,9 @@
       }
     },
     "node_modules/openid-client": {
-      "version": "6.8.6",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.6.tgz",
-      "integrity": "sha512-lsfMRH/GCgMiGCRnBRY3e70uogkgOessPaTOhP3rw/dxqNOZHwOazWx+m6jt5EVk3ecRFULl0TwWpk9Qnw3RKQ==",
+      "version": "6.8.7",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.7.tgz",
+      "integrity": "sha512-gtKthNu7evSBvTdrrlHb4F3Fi9dcwlb5QaITlCs+9mfpvuOi0Q3qtBf5+iY4sEP8hy1qCoAdxBNPDcmZeVSDzQ==",
       "license": "MIT",
       "dependencies": {
         "jose": "^6.2.8",


### PR DESCRIPTION
Gets the `outdated` check back to green. It has been failing on every PR since this morning for a reason unrelated to any of them.

## What was wrong

The workflow compares the installed version against what the declared range *wants*:

```
Package          Current  Wanted  Latest
openid-client    6.8.6    6.8.7   6.8.7
```

`openid-client` published 6.8.7 into our existing `^6.8.6` range today. Nothing in the repo asked for the old version — the lockfile just had not been regenerated since the release.

## The change

`npm update openid-client`. Lockfile only, three lines, no declared range touched:

```diff
     "node_modules/openid-client": {
-      "version": "6.8.6",
+      "version": "6.8.7",
```

## Nothing else is outdated

The frontend reports three packages, all with `current === wanted`, which the check deliberately ignores:

| Package | Current | Wanted | Latest |
|---|---|---|---|
| `@angular/animations` | 22.1.3 | 22.1.3 | 20.1.8 |
| `@angular/platform-browser-dynamic` | 22.1.3 | 22.1.3 | 20.0.7 |
| `typescript` | 6.0.3 | 6.0.3 | 7.0.2 |

The two Angular rows are a dist-tag artifact — we are ahead of what npm labels `latest`, not behind it. `typescript` 7 is a major past what Angular 22 accepts. None of these are actionable, which is exactly why the check looks at `wanted` rather than `latest`.

## Verified

`npm outdated` in `backend/` now exits clean. Backend suite: 340 passing, 25 pending, 0 failing.
