### PR TITLE
ci(deps): stop failing pull requests over upstream drift

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -37,9 +37,8 @@ updates:
         update-types:
           - "minor"
     ignore:
-      - dependency-name: "@angular-devkit/build-angular"
-        update-types:
-          - "version-update:semver-major"
+      # TypeScript majors land ahead of what Angular's compiler accepts, so let the
+      # Angular bump pull TypeScript along rather than the other way around.
       - dependency-name: "typescript"
         update-types:
           - "version-update:semver-major"

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -93,13 +93,30 @@ jobs:
           NODE
         working-directory: ./backend
 
-      - name: Fail if dependencies are outdated
+      - name: Report dependency status
         if: always()
+        env:
+          FRONTEND_OUTCOME: ${{ steps.frontend_outdated.outcome }}
+          BACKEND_OUTCOME: ${{ steps.backend_outdated.outcome }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          echo "Frontend check outcome: ${{ steps.frontend_outdated.outcome }}"
-          echo "Backend check outcome: ${{ steps.backend_outdated.outcome }}"
+          echo "Frontend check outcome: $FRONTEND_OUTCOME"
+          echo "Backend check outcome: $BACKEND_OUTCOME"
 
-          if [ "${{ steps.frontend_outdated.outcome }}" = "failure" ] || [ "${{ steps.backend_outdated.outcome }}" = "failure" ]; then
-            echo "One or more dependency checks reported outdated packages."
-            exit 1
+          if [ "$FRONTEND_OUTCOME" != "failure" ] && [ "$BACKEND_OUTCOME" != "failure" ]; then
+            echo "Every dependency is at the version its declared range wants."
+            exit 0
           fi
+
+          # The badge this workflow exists for reads ?branch=main, so a pull request run
+          # contributes nothing to it. Failing one only ever punished the PR that happened
+          # to be open when an unrelated package published -- the drift is upstream, not
+          # in the change under review, and dependabot opens a PR for it on its own daily
+          # run. Report it on the PR, block on main.
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            echo "::warning::Dependencies are behind what their declared ranges want. This does not block the pull request -- the drift is upstream, not in this change. The run on main is what drives the badge."
+            exit 0
+          fi
+
+          echo "One or more dependency checks reported outdated packages."
+          exit 1


### PR DESCRIPTION
Keeps the dependency badge exactly as it is, and stops the check behind it from blocking PRs it has nothing to say about.

## The problem

The workflow exists to drive this badge:

```
actions/workflows/dependencies.yml/badge.svg?branch=main
```

`?branch=main` — so **pull request runs contribute nothing to the badge.** They were blocking anyway, which meant any package publishing a new in-range version failed every open PR until someone hand-refreshed the lockfile.

That has left a trail in the PR history:

- #358 chore(deps): bump dependencies and refresh security overrides
- #368 chore(deps): refresh dependencies for the outdated check
- #385 chore(deps): move openid-client to 6.8.7

Three PRs whose entire purpose was quieting this check. The most recent one was today: #384, an LDAP refactor, went red because `openid-client` shipped a patch that morning. Nothing in the branch was related to it. The practical effect is that people learn to merge with `--admin`, which is worse than the check not existing.

## The change

The check now **warns on `pull_request` and fails on `push`, `schedule` and `workflow_dispatch`**.

```yaml
if [ "$EVENT_NAME" = "pull_request" ]; then
  echo "::warning::Dependencies are behind what their declared ranges want..."
  exit 0
fi
```

- The badge is untouched — it only ever read main.
- The drift is still reported on the PR, as a warning annotation rather than a red X.
- Dependabot opens a PR for the same drift on its own daily run, which is the mechanism that should be fixing it.

Step outcomes moved into `env:` rather than being interpolated straight into the shell, while the step was being rewritten anyway.

## Also

Drops the dependabot `ignore` entry for `@angular-devkit/build-angular`. That package is not installed — it is the same dead configuration #376 cleared out of the npm overrides. The `typescript` major ignore stays and gained a comment explaining why it is there.

## Not done, deliberately

`jasmine-core` was on my list to add as an `ignore` entry, since I closed #367 with a `@dependabot ignore this major version` comment and that state lives on GitHub rather than in the repo. It turns out #378 removed jasmine from the tree entirely, so an ignore entry for it would be exactly the dead config this PR is deleting.
