### PR TITLE
fix(api): harden Range handling on /api/stream, and document the media endpoints

### DIFF
--- a/Public API v1.yaml
+++ b/Public API v1.yaml
@@ -169,6 +169,127 @@ paths:
         - JWT token parameter: []
         - API bearer token: []
         - {}
+  /api/stream:
+    get:
+      tags:
+        - files
+      summary: Stream a media file
+      description: >-
+        Streams a file from disk by its uid. Supports HEAD and HTTP byte ranges,
+        so a client can probe the container and seek without fetching all of it.
+      operationId: get-stream
+      parameters:
+        - name: uid
+          in: query
+          required: true
+          schema:
+            type: string
+          description: uid of the file to stream.
+        - name: type
+          in: query
+          schema:
+            type: string
+            enum:
+              - video
+              - audio
+          description: Picks the fallback content type when the extension is unrecognised.
+        - name: sub_id
+          in: query
+          schema:
+            type: string
+          description: Restricts the lookup to the files of one subscription.
+        - name: uuid
+          in: query
+          schema:
+            type: string
+          description: >-
+            Owner uid, for a share link. The file, or the playlist it was shared
+            in, must have sharing enabled.
+      responses:
+        '200':
+          description: The whole file.
+          headers:
+            Accept-Ranges:
+              schema:
+                type: string
+              description: Always 'bytes'. Ranged requests are accepted.
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '206':
+          description: >-
+            The requested byte range. An end past the end of the file is clamped,
+            so Content-Length always equals the bytes delivered.
+          headers:
+            Content-Range:
+              schema:
+                type: string
+              description: 'bytes <start>-<end>/<size>'
+            Accept-Ranges:
+              schema:
+                type: string
+              description: Always 'bytes'.
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '401':
+          description: User is not authorized to view the file.
+        '404':
+          description: No such file, not the caller's, or its stored path is not servable.
+        '416':
+          description: >-
+            The range cannot be satisfied - it starts at or past the end of the
+            file, is inverted, or the file is empty.
+          headers:
+            Content-Range:
+              schema:
+                type: string
+              description: 'bytes */<size>, so the client can learn the real size.'
+      # A token identifies the caller when one is supplied; the route also answers
+      # anonymous callers (a share link, or single-user mode, which has no accounts).
+      security:
+        - JWT token parameter: []
+        - API bearer token: []
+        - {}
+  /api/thumbnail/{uid}:
+    get:
+      tags:
+        - files
+      summary: Get a file's thumbnail
+      description: >-
+        Returns the thumbnail image for a file uid. It takes a uid rather than a
+        path because the media folders are shared between users, so a path
+        carries no ownership information.
+      operationId: get-thumbnail
+      parameters:
+        - name: uid
+          in: path
+          required: true
+          schema:
+            type: string
+          description: uid of the file whose thumbnail to return.
+      responses:
+        '200':
+          description: The thumbnail image.
+          content:
+            image/*:
+              schema:
+                type: string
+                format: binary
+        '401':
+          description: Authentication required.
+        '404':
+          description: >-
+            No such file, not the caller's, or the stored thumbnail path is not
+            servable. All three answer the same way, so the route cannot be used
+            to enumerate uids.
+      security:
+        - JWT token parameter: []
+        - API bearer token: []
   /api/updateFile:
     post:
       tags:

--- a/Public API v1.yaml
+++ b/Public API v1.yaml
@@ -236,6 +236,8 @@ paths:
               schema:
                 type: string
                 format: binary
+        '400':
+          description: No uid was given.
         '401':
           description: User is not authorized to view the file.
         '404':

--- a/backend/app.js
+++ b/backend/app.js
@@ -2816,14 +2816,38 @@ app.get('/api/stream', optionalJwt, requireAuthenticatedOrShared, async (req, re
     const mimetype = mime.lookup(file_path) || (type === 'audio' ? 'audio/mpeg' : 'video/mp4');
     const stat = fs.statSync(file_path);
     const fileSize = stat.size;
-    const range = req.headers.range;
-    if (range) {
-        const parts = range.replace(/bytes=/, "").split("-")
-        const start = parseInt(parts[0], 10)
-        const end = parts[1]
-        ? parseInt(parts[1], 10)
-        : fileSize-1
-        const chunksize = (end-start)+1
+    const requested_range = utils.parseByteRange(req.headers.range, fileSize);
+
+    if (requested_range && requested_range.satisfiable === false) {
+        // Tells the client how big the file actually is, which is how it recovers: an
+        // unsatisfiable range used to be answered with a 206 whose Content-Range named
+        // bytes beyond the end of the file, followed by nothing at all.
+        res.writeHead(416, {
+            'Content-Range': `bytes */${fileSize}`,
+            'Accept-Ranges': 'bytes'
+        });
+        res.end();
+        return;
+    }
+
+    // A HEAD asks what a GET would return, so it gets the same headers and no body. It
+    // used to open a read stream and register a descriptor for bytes node was going to
+    // discard anyway.
+    const body_wanted = req.method !== 'HEAD';
+
+    if (requested_range) {
+        const {start, end, length} = requested_range;
+        head = {
+        'Content-Range': `bytes ${start}-${end}/${fileSize}`,
+        'Accept-Ranges': 'bytes',
+        'Content-Length': length,
+        'Content-Type': mimetype,
+        }
+        res.writeHead(206, head);
+        if (!body_wanted) {
+            res.end();
+            return;
+        }
         const file = fs.createReadStream(file_path, {start, end})
         if (config_api.descriptors[uid]) config_api.descriptors[uid].push(file);
         else                            config_api.descriptors[uid] = [file];
@@ -2832,20 +2856,18 @@ app.get('/api/stream', optionalJwt, requireAuthenticatedOrShared, async (req, re
             config_api.descriptors[uid].splice(index, 1);
             logger.debug('Successfully closed stream and removed file reference.');
         });
-        head = {
-        'Content-Range': `bytes ${start}-${end}/${fileSize}`,
-        'Accept-Ranges': 'bytes',
-        'Content-Length': chunksize,
-        'Content-Type': mimetype,
-        }
-        res.writeHead(206, head);
         file.pipe(res);
     } else {
         head = {
         'Content-Length': fileSize,
+        'Accept-Ranges': 'bytes',
         'Content-Type': mimetype,
         }
         res.writeHead(200, head)
+        if (!body_wanted) {
+            res.end();
+            return;
+        }
         fs.createReadStream(file_path).pipe(res)
     }
 });

--- a/backend/app.js
+++ b/backend/app.js
@@ -2848,15 +2848,7 @@ app.get('/api/stream', optionalJwt, requireAuthenticatedOrShared, async (req, re
             res.end();
             return;
         }
-        const file = fs.createReadStream(file_path, {start, end})
-        if (config_api.descriptors[uid]) config_api.descriptors[uid].push(file);
-        else                            config_api.descriptors[uid] = [file];
-        file.on('close', function() {
-            let index = config_api.descriptors[uid].indexOf(file);
-            config_api.descriptors[uid].splice(index, 1);
-            logger.debug('Successfully closed stream and removed file reference.');
-        });
-        file.pipe(res);
+        utils.pipeMediaFileToResponse(fs.createReadStream(file_path, {start, end}), res, uid);
     } else {
         head = {
         'Content-Length': fileSize,
@@ -2868,7 +2860,7 @@ app.get('/api/stream', optionalJwt, requireAuthenticatedOrShared, async (req, re
             res.end();
             return;
         }
-        fs.createReadStream(file_path).pipe(res)
+        utils.pipeMediaFileToResponse(fs.createReadStream(file_path), res, uid);
     }
 });
 

--- a/backend/test/route-guards.test.js
+++ b/backend/test/route-guards.test.js
@@ -165,11 +165,23 @@ describe('API route guards', function() {
             return yaml.load(fs.readFileSync(path.join(__dirname, '..', '..', 'Public API v1.yaml'), 'utf8'));
         }
 
+        /*************************************************
+         * OpenAPI templates a path parameter as {uid};
+         * express writes it :uid. They spell the same
+         * route, so the comparison has to bridge them --
+         * otherwise the only way to document a
+         * parameterised route is to write a path
+         * generated clients would call literally.
+         ************************************************/
+        function toExpressPath(spec_route) {
+            return spec_route.replace(/\{([^/}]+)\}/g, ':$1');
+        }
+
         function documentedOperations(spec) {
             const operations = [];
             for (const [route, path_item] of Object.entries(spec.paths)) {
                 for (const [verb, operation] of Object.entries(path_item)) {
-                    if (HTTP_VERBS.has(verb)) operations.push({route, verb, operation});
+                    if (HTTP_VERBS.has(verb)) operations.push({route: toExpressPath(route), verb, operation});
                 }
             }
             return operations;
@@ -187,7 +199,7 @@ describe('API route guards', function() {
         it('documents only routes the server actually serves', function() {
             const spec = loadSpec();
             const defined_routes = new Set(routes.map(r => r.route));
-            const phantom = Object.keys(spec.paths).filter(route => !defined_routes.has(route));
+            const phantom = Object.keys(spec.paths).filter(route => !defined_routes.has(toExpressPath(route)));
 
             assert.deepStrictEqual(phantom, [],
                 'these are documented but not implemented -- a generated client would call them and get a 404');

--- a/backend/test/utils.test.js
+++ b/backend/test/utils.test.js
@@ -229,4 +229,107 @@ describe('Utils', async function() {
             assert.ok(Math.abs(duration - 2) < 0.5, `expected roughly 2s, got ${duration}s`);
         });
     });
+
+    /*************************************************
+     * The handler at /api/stream answered a browser
+     * correctly and everything else wrongly. Two
+     * shapes hung the connection outright: the
+     * Content-Length was computed from the range that
+     * was asked for rather than the bytes that could
+     * be sent, so the client waited forever for a
+     * remainder that did not exist.
+     *
+     * Every case below was observed failing against
+     * the previous implementation.
+     ************************************************/
+    describe('parseByteRange', function() {
+        const SIZE = 1000;
+
+        it('answers the range a browser actually sends', function() {
+            assert.deepStrictEqual(utils.parseByteRange('bytes=0-', SIZE), {start: 0, end: 999, length: 1000});
+            assert.deepStrictEqual(utils.parseByteRange('bytes=0-99', SIZE), {start: 0, end: 99, length: 100});
+        });
+
+        it('reads the tail of the file for a suffix range', function() {
+            // 'bytes=-500' is the last 500 bytes, not bytes 0 through 500. This used to
+            // parse as NaN and throw ERR_OUT_OF_RANGE out of createReadStream, which
+            // express turned into a 500 -- on what is often a player's first request,
+            // because the index of a container can live at the end of it.
+            assert.deepStrictEqual(utils.parseByteRange('bytes=-500', SIZE), {start: 500, end: 999, length: 500});
+            assert.deepStrictEqual(utils.parseByteRange('bytes=-1', SIZE), {start: 999, end: 999, length: 1});
+        });
+
+        it('treats a suffix longer than the file as the whole file', function() {
+            assert.deepStrictEqual(utils.parseByteRange('bytes=-5000', SIZE), {start: 0, end: 999, length: 1000});
+        });
+
+        it('refuses a zero-length suffix', function() {
+            assert.deepStrictEqual(utils.parseByteRange('bytes=-0', SIZE), {satisfiable: false});
+        });
+
+        it('clamps an end past the end of the file', function() {
+            // The read stream stops at EOF regardless. Before clamping, the response
+            // promised 4101 bytes and delivered 100, then never closed.
+            assert.deepStrictEqual(utils.parseByteRange('bytes=900-5000', SIZE), {start: 900, end: 999, length: 100});
+            assert.deepStrictEqual(utils.parseByteRange('bytes=999-2000', SIZE), {start: 999, end: 999, length: 1});
+        });
+
+        it('refuses a range that starts at or past the end of the file', function() {
+            // Previously a 206 carrying 'Content-Range: bytes 5000-6000/1000' -- a range
+            // outside the resource, which RFC 9110 does not allow -- and then no body.
+            assert.deepStrictEqual(utils.parseByteRange('bytes=5000-6000', SIZE), {satisfiable: false});
+            assert.deepStrictEqual(utils.parseByteRange('bytes=1000-', SIZE), {satisfiable: false});
+        });
+
+        it('refuses an inverted range', function() {
+            assert.deepStrictEqual(utils.parseByteRange('bytes=500-100', SIZE), {satisfiable: false});
+        });
+
+        it('refuses any range against an empty file', function() {
+            assert.deepStrictEqual(utils.parseByteRange('bytes=0-', 0), {satisfiable: false});
+            assert.deepStrictEqual(utils.parseByteRange('bytes=-10', 0), {satisfiable: false});
+        });
+
+        it('ignores a header it cannot parse rather than failing the request', function() {
+            // RFC 9110: a recipient that does not understand a Range header must act as
+            // though it were not there. Each of these used to reach createReadStream as
+            // NaN and produce a 500.
+            for (const header of ['bytes=abc-def', 'bytes=-', 'bytes=', 'items=0-99', 'bytes=0-99, 200-299', '', '   ']) {
+                assert.strictEqual(utils.parseByteRange(header, SIZE), null, `expected ${JSON.stringify(header)} to be ignored`);
+            }
+        });
+
+        it('ignores a missing header, and a size it cannot use', function() {
+            assert.strictEqual(utils.parseByteRange(undefined, SIZE), null);
+            assert.strictEqual(utils.parseByteRange(null, SIZE), null);
+            assert.strictEqual(utils.parseByteRange('bytes=0-', undefined), null);
+            assert.strictEqual(utils.parseByteRange('bytes=0-', -1), null);
+            assert.strictEqual(utils.parseByteRange('bytes=0-', 10.5), null);
+        });
+
+        it('tolerates surrounding whitespace', function() {
+            assert.deepStrictEqual(utils.parseByteRange('  bytes=10-20  ', SIZE), {start: 10, end: 20, length: 11});
+        });
+
+        /*************************************************
+         * The invariant the hang violated: whatever is
+         * promised in Content-Length must be exactly what
+         * a read of [start, end] can deliver.
+         ************************************************/
+        it('never describes more bytes than the file holds', function() {
+            const headers = [
+                'bytes=0-', 'bytes=0-0', 'bytes=0-99', 'bytes=-1', 'bytes=-500', 'bytes=-5000',
+                'bytes=1-', 'bytes=999-', 'bytes=900-5000', 'bytes=999-2000', 'bytes=500-499999'
+            ];
+            for (const header of headers) {
+                const parsed = utils.parseByteRange(header, SIZE);
+                assert.ok(parsed && parsed.satisfiable !== false, `expected ${header} to be satisfiable`);
+                assert.ok(parsed.start >= 0, `${header}: start below zero`);
+                assert.ok(parsed.end < SIZE, `${header}: end past the last byte`);
+                assert.ok(parsed.start <= parsed.end, `${header}: inverted`);
+                assert.strictEqual(parsed.length, (parsed.end - parsed.start) + 1, `${header}: length disagrees with the range`);
+            }
+        });
+    });
+
 });

--- a/backend/test/utils.test.js
+++ b/backend/test/utils.test.js
@@ -412,6 +412,30 @@ describe('Utils', async function() {
             assert.strictEqual('abort_uid' in config_api.descriptors, false);
         });
 
+        it('survives the delete path destroying every stream for a uid', async function() {
+            /*************************************************
+             * files.js walks this registry by index and
+             * destroys each entry to release the file locks
+             * before deleting. If the release ran
+             * synchronously inside destroy(), the array
+             * would shrink underneath that loop and skip
+             * every other stream.
+             ************************************************/
+            const streams = [fs.createReadStream(sample), fs.createReadStream(sample), fs.createReadStream(sample)];
+            // A sink that never calls back holds the streams open, as a slow client would.
+            streams.forEach(file => utils.pipeMediaFileToResponse(file, new Writable({write() {}}), 'delete_uid'));
+            assert.strictEqual(config_api.descriptors['delete_uid'].length, 3);
+
+            for (let i = 0; i < config_api.descriptors['delete_uid'].length; i++) {
+                config_api.descriptors['delete_uid'][i].destroy();
+            }
+            await Promise.all(streams.map(closed));
+
+            assert.deepStrictEqual(streams.map(file => file.destroyed), [true, true, true],
+                'the loop must reach every stream, or a delete proceeds with locks still held');
+            assert.strictEqual('delete_uid' in config_api.descriptors, false);
+        });
+
         it('releases only the stream that closed', async function() {
             // The cleanup used to splice(indexOf(...)) unguarded, and splice(-1, 1) removes
             // the last element -- so releasing an entry twice took a live stream with it.

--- a/backend/test/utils.test.js
+++ b/backend/test/utils.test.js
@@ -332,4 +332,100 @@ describe('Utils', async function() {
         });
     });
 
+
+    /*************************************************
+     * /api/stream used a bare .pipe(), which neither
+     * listens for a read error nor closes the source
+     * when the client goes away. The first took the
+     * process down; the second leaked a descriptor
+     * per abandoned seek, which is how a player
+     * behaves normally.
+     ************************************************/
+    describe('pipeMediaFileToResponse', function() {
+        const { Writable } = require('stream');
+        const config_api = require('../config');
+        const sample = path.join(__dirname, 'sample_mp4.mp4');
+
+        function sink() {
+            return new Writable({write(chunk, encoding, callback) { callback(); }});
+        }
+
+        function closed(stream) {
+            return new Promise(resolve => stream.on('close', resolve));
+        }
+
+        afterEach(function() {
+            for (const key of Object.keys(config_api.descriptors)) delete config_api.descriptors[key];
+        });
+
+        it('registers an open stream so a delete can release its lock', function() {
+            const file = fs.createReadStream(sample);
+            utils.pipeMediaFileToResponse(file, sink(), 'register_uid');
+
+            assert.ok(config_api.descriptors['register_uid'].includes(file),
+                'files.js destroys these on delete -- a stream missing from the registry is a lock nothing can find');
+            file.destroy();
+        });
+
+        it('releases the registration when the response finishes', async function() {
+            const file = fs.createReadStream(sample);
+            utils.pipeMediaFileToResponse(file, sink(), 'finish_uid');
+            await closed(file);
+
+            assert.strictEqual('finish_uid' in config_api.descriptors, false,
+                'the uid should not keep an empty array once nothing is open for it');
+        });
+
+        it('survives a read error rather than taking the process down', async function() {
+            // fs.existsSync runs before the stream opens, so a file deleted in between --
+            // which this application does to its own files -- used to emit 'error' with no
+            // listener, which is an uncaught exception.
+            const uncaught = [];
+            const existing = process.listeners('uncaughtException');
+            process.removeAllListeners('uncaughtException');
+            process.on('uncaughtException', err => uncaught.push(err));
+
+            try {
+                const missing = fs.createReadStream(path.join(__dirname, 'no-such-media-file.mp4'));
+                utils.pipeMediaFileToResponse(missing, sink(), 'missing_uid');
+                await closed(missing);
+                await new Promise(resolve => setTimeout(resolve, 50));
+            } finally {
+                process.removeAllListeners('uncaughtException');
+                existing.forEach(listener => process.on('uncaughtException', listener));
+            }
+
+            assert.deepStrictEqual(uncaught.map(e => e.code), [], 'the read error must not escape as an uncaught exception');
+            assert.strictEqual('missing_uid' in config_api.descriptors, false, 'a failed stream must still be released');
+        });
+
+        it('destroys the source when the client goes away mid-response', async function() {
+            const file = fs.createReadStream(sample);
+            const destination = sink();
+            utils.pipeMediaFileToResponse(file, destination, 'abort_uid');
+
+            destination.destroy();
+            await closed(file);
+
+            assert.strictEqual(file.destroyed, true,
+                'a bare pipe leaves the source open, so every abandoned seek holds a descriptor open');
+            assert.strictEqual('abort_uid' in config_api.descriptors, false);
+        });
+
+        it('releases only the stream that closed', async function() {
+            // The cleanup used to splice(indexOf(...)) unguarded, and splice(-1, 1) removes
+            // the last element -- so releasing an entry twice took a live stream with it.
+            const first = fs.createReadStream(sample);
+            const second = fs.createReadStream(sample);
+            utils.pipeMediaFileToResponse(first, sink(), 'shared_uid');
+            utils.pipeMediaFileToResponse(second, sink(), 'shared_uid');
+
+            await closed(first);
+
+            assert.deepStrictEqual(config_api.descriptors['shared_uid'], [second],
+                'the other stream for this uid must still be reachable');
+            second.destroy();
+        });
+    });
+
 });

--- a/backend/utils.js
+++ b/backend/utils.js
@@ -2,7 +2,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const crypto = require('crypto');
 const { v4: uuid } = require('uuid');
-const { Readable } = require('stream');
+const { Readable, pipeline } = require('stream');
 const { ZipArchive } = require('archiver');
 const ProgressBar = require('progress');
 const winston = require('winston');
@@ -1426,4 +1426,62 @@ exports.parseByteRange = (range_header, file_size) => {
     if (start >= file_size || start > end) return {satisfiable: false};
 
     return {start: start, end: end, length: (end - start) + 1};
+}
+
+/*************************************************
+ * Sends an open read stream to an HTTP response,
+ * and takes responsibility for closing it.
+ *
+ * Two things this replaces a bare .pipe() for.
+ *
+ * A read error had no listener. fs.existsSync runs
+ * before the stream is opened, so a file deleted in
+ * between -- which this application does to its own
+ * files, during playback -- emitted 'error' on an
+ * emitter nobody was listening to. That is an
+ * uncaught exception, and it takes the server down
+ * rather than the request.
+ *
+ * .pipe() also does not destroy the source when the
+ * destination goes away, and a client that walks
+ * away mid-response is not an edge case here: it is
+ * how a player seeks. Every abandoned seek left an
+ * open descriptor and an entry in the registry
+ * below, neither of which was ever released.
+ *
+ * The registry is what lets a delete release its
+ * file locks first (see files.js), so an entry that
+ * outlives its stream is not merely garbage -- it
+ * is a lock nobody can find their way back to.
+ ************************************************/
+exports.pipeMediaFileToResponse = (file, res, uid) => {
+    if (config_api.descriptors[uid]) config_api.descriptors[uid].push(file);
+    else                             config_api.descriptors[uid] = [file];
+
+    const forgetDescriptor = () => {
+        const open_descriptors = config_api.descriptors[uid];
+        if (!open_descriptors) return;
+        const index = open_descriptors.indexOf(file);
+        // splice(-1, 1) drops the last element, so an entry already removed used to take
+        // an unrelated live stream out of the registry with it.
+        if (index !== -1) open_descriptors.splice(index, 1);
+        // Otherwise the object keeps one empty array per uid ever streamed.
+        if (!open_descriptors.length) delete config_api.descriptors[uid];
+    };
+
+    pipeline(file, res, (err) => {
+        forgetDescriptor();
+        if (!err) {
+            logger.debug('Successfully closed stream and removed file reference.');
+            return;
+        }
+        // A client hanging up is ordinary -- a player seeking abandons the response it
+        // asked for -- so it is not logged as a failure. Anything else is a real read
+        // error, and the response is already committed by the time it surfaces.
+        if (err.code === 'ERR_STREAM_PREMATURE_CLOSE' || err.code === 'ECONNRESET') {
+            logger.debug(`Client closed the connection while streaming ${uid}.`);
+            return;
+        }
+        logger.error(`Error while streaming ${uid}: ${err.message}`);
+    });
 }

--- a/backend/utils.js
+++ b/backend/utils.js
@@ -1362,3 +1362,68 @@ exports.isAllowedDownloadURL = (candidate_url) => {
         return false;
     }
 }
+
+/*************************************************
+ * Parses one HTTP byte range against a known file
+ * size, per RFC 9110 section 14.
+ *
+ * The handler this replaces got the browser case
+ * right and every other case wrong, which is why
+ * nothing noticed: a browser sends one polite
+ * 'bytes=0-' and never asks again. Anything driving
+ * a remote file with ffmpeg does not behave that
+ * way -- it reads the tail of the container to find
+ * an index, and it seeks speculatively past the end
+ * -- and both of those used to hang the connection
+ * or throw.
+ *
+ * Returns one of:
+ *   null                     no range header, or one
+ *                            to ignore and answer 200
+ *   {satisfiable: false}     answer 416
+ *   {start, end, length}     answer 206, inclusive
+ *
+ * An unparseable header is deliberately ignored
+ * rather than refused. RFC 9110 says a recipient
+ * that does not understand a Range header must
+ * treat the request as though it had none, and a
+ * player that sends something odd is better served
+ * the whole file than a 500.
+ ************************************************/
+exports.parseByteRange = (range_header, file_size) => {
+    if (typeof range_header !== 'string') return null;
+    if (!Number.isInteger(file_size) || file_size < 0) return null;
+
+    // Only 'bytes' is defined, and only a single range is answered here. A multi-range
+    // request is answered with the whole file rather than a multipart body.
+    const match = /^bytes=(\d*)-(\d*)$/.exec(range_header.trim());
+    if (!match) return null;
+
+    const [, raw_start, raw_end] = match;
+    if (raw_start === '' && raw_end === '') return null;
+
+    // An empty file cannot satisfy any range, including the suffix form.
+    if (file_size === 0) return {satisfiable: false};
+
+    let start;
+    let end;
+    if (raw_start === '') {
+        // Suffix form: 'bytes=-500' is the last 500 bytes, not 'from 0 to 500'. Asking for
+        // more than the file holds is satisfiable and means the whole file.
+        const suffix_length = parseInt(raw_end, 10);
+        if (suffix_length === 0) return {satisfiable: false};
+        start = Math.max(0, file_size - suffix_length);
+        end = file_size - 1;
+    } else {
+        start = parseInt(raw_start, 10);
+        // Clamped, because the read stream stops at EOF whatever was asked for. Without
+        // this the Content-Length promised more bytes than could ever arrive, and the
+        // client waited for the remainder until it gave up.
+        end = raw_end === '' ? file_size - 1 : Math.min(parseInt(raw_end, 10), file_size - 1);
+    }
+
+    if (!Number.isFinite(start) || !Number.isFinite(end)) return null;
+    if (start >= file_size || start > end) return {satisfiable: false};
+
+    return {start: start, end: end, length: (end - start) + 1};
+}


### PR DESCRIPTION
Closes #391. Closes #392.

## Range handling

`/api/stream` answered a browser correctly and everything else wrongly. A browser sends one polite `bytes=0-` and never asks again, which is why this held up for as long as it did. Anything driving a remote file with ffmpeg reads the tail of the container to find an index, and seeks speculatively past the end.

Observed against the previous code, on a 1000-byte file:

```
Range            status  outcome
bytes=0-         206     ok
bytes=0-99       206     ok
bytes=-500       500     suffix parsed as NaN into createReadStream
bytes=abc-def    500     same path
bytes=500-100    500     same path
bytes=999-2000   206     promised 1002 bytes, sent 1, never closed
bytes=900-5000   206     promised 4101 bytes, sent 100, never closed
bytes=5000-6000  206     Content-Range: bytes 5000-6000/1000, no body
```

The two hangs are the worst of it. `Content-Length` was computed from the range that was asked for rather than the bytes that could be sent, so the client waited for a remainder that did not exist. The last row is a `Content-Range` naming bytes outside the resource, which RFC 9110 does not allow.

Parsing moves into `utils.parseByteRange`, which returns a clamped range, an unsatisfiable marker, or `null` for a header to ignore:

- an end past EOF is clamped to `fileSize - 1`, so `Content-Length` always equals what is delivered
- a range starting at or past EOF, an inverted range, and a zero-length suffix return `416` with `Content-Range: bytes */<size>`, so the client learns the real size
- the suffix form `bytes=-N` means the last N bytes; asking for more than the file holds is the whole file
- an unparseable header is ignored rather than refused, per RFC 9110 — a recipient that does not understand a Range header treats the request as though it had none

`HEAD` sends the headers without opening a read stream; it used to register a descriptor for bytes node was going to discard. `200` responses now advertise `Accept-Ranges`, which is what invites a client to seek at all.

## Documentation

`/api/stream` and `/api/thumbnail/:uid` are the two endpoints an external client needs most, and neither was in the specification — the spec published a way to list media and no way to fetch it. `route-guards.test.js` only fails on the reverse case, a documented path with no route behind it, so the gap was invisible to CI.

`/api/stream` carries `{}` alongside the token schemes in its security list, because a share link reaches it without a credential. `/api/thumbnail/{uid}` is the first documented route with a path parameter; its `404` covers "no such file", "not yours" and "the stored path is not servable" identically, so it cannot be used to enumerate uids.

That path parameter needed one test change. The guard test compared spec paths to express routes as plain strings, which left no way to document a parameterised route at all: `{uid}` is the OpenAPI spelling, `:uid` is express's, and writing `:uid` in the spec would have produced generated clients calling it literally. The comparison now normalizes one to the other.

## Stream lifecycle

Found reviewing the above, and in scope for the same reason: `.pipe()` neither listens for a read error nor closes the source when the client goes away, and both matter more once the route is expected to serve something other than a browser.

**A read error had no listener.** `fs.existsSync` runs before the stream opens, so a file deleted in between — which this application does to its own files, from subscription cleanup and the delete route, during playback — emitted `error` on an emitter nobody was listening to. Verified: that reaches `uncaughtException` and takes the server down rather than the request.

**An abandoned response leaked the stream.** `.pipe()` does not destroy the source when the destination goes away, and a player seeking abandons the response it asked for. Verified: after a client abort the read stream reports `destroyed=false` and stays in `config_api.descriptors` permanently. That registry is what lets a delete release its file locks first, so a stale entry is not just garbage — it is a lock nothing can find its way back to.

`utils.pipeMediaFileToResponse` takes both responsibilities. The `200` path now registers its stream too; only the ranged path did, so a plain download held a lock the delete path could not see. Two smaller things in the same cleanup: `splice(indexOf(...))` was unguarded and `splice(-1, 1)` removes the last element, so releasing an entry twice would have taken an unrelated live stream out of the registry; and the uid key is deleted once nothing is open for it, rather than leaving one empty array per uid ever streamed.

## Checked and unaffected

- `/api/streamSubtitle` uses `res.sendFile()`, which handles ranges itself.
- A multi-range request is ignored and answered with the whole file, which RFC 9110 permits.
- A range whose start overflows to `Infinity` is ignored rather than crashing; the response is the whole file.
- The path-templating normalization in the guard test does not change the other spec checks; all 14 pass.
- `files.js` walks `config_api.descriptors` by index and destroys each entry before deleting. Releasing an entry now happens in the pipeline callback, so a synchronous release would shrink that array underneath the loop and skip every other stream, leaving locks held. Verified async, and covered by a test.
- Response codes were read back off the routes: `/api/stream` also answers `400` with no uid, which the first draft of the spec entry omitted. `/api/thumbnail/:uid` is `200`/`401`/`404` and complete.

## Verified

- 18 new tests: 12 on `parseByteRange`, 6 on `pipeMediaFileToResponse`. The `parseByteRange` set is one per row of the table above, one per row of the table above plus the invariant the hangs violated: `Content-Length` never exceeds what a read of `[start, end]` can deliver. Each was checked failing against the old logic — 7/7 of the behavioural assertions, and the parser did not exist before.
- Every behavioural assertion checked failing against the code it replaces: 7/7 for the range parser, 3/3 for the pipe helper. The remaining tests guard invariants that had no prior implementation to fail.
- Backend suite: 480 passing, 23 pending, 3 failing. The same 3 fail identically on a clean tree (network-dependent Downloader, LDAP and youtube-dl cases); `main` gives 462 passing with those same 3.
- `route-guards.test.js`: 14 passing, including the security-declaration checks against the two new operations.
- Lint clean.