### PR TITLE
chore(deps): drop overrides that pin what is already declared

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Docker pulls badge](https://img.shields.io/docker/pulls/voc0der/ytdl-material.svg)](https://hub.docker.com/r/voc0der/ytdl-material)
 [![Docker image size badge](https://img.shields.io/docker/image-size/voc0der/ytdl-material?sort=date)](https://hub.docker.com/r/voc0der/ytdl-material)
 <a href="https://github.com/voc0der/ytdl-material/blob/main/CONTRIBUTING.md#coverage">
-  <img src="https://img.shields.io/badge/coverage-59.2%25-orange" alt="Code coverage percentage" />
+  <img src="https://img.shields.io/badge/coverage-59.7%25-orange" alt="Code coverage percentage" />
 </a>
 [![GitHub issues badge](https://img.shields.io/github/issues/voc0der/ytdl-material)](https://github.com/voc0der/ytdl-material/issues)
 [![License badge](https://img.shields.io/github/license/voc0der/ytdl-material)](https://github.com/voc0der/ytdl-material/blob/main/LICENSE.md)

--- a/backend/test/utils.test.js
+++ b/backend/test/utils.test.js
@@ -442,7 +442,11 @@ describe('Utils', async function() {
             const first = fs.createReadStream(sample);
             const second = fs.createReadStream(sample);
             utils.pipeMediaFileToResponse(first, sink(), 'shared_uid');
-            utils.pipeMediaFileToResponse(second, sink(), 'shared_uid');
+            // Held open by a sink that never calls back, so this test asserts on which
+            // stream was released rather than on which one happened to finish first. With
+            // a draining sink both complete, and under coverage instrumentation they both
+            // completed before the assertion ran.
+            utils.pipeMediaFileToResponse(second, new Writable({write() {}}), 'shared_uid');
 
             await closed(first);
 

--- a/package.json
+++ b/package.json
@@ -75,13 +75,6 @@
   "overrides": {
     "@hono/node-server": "2.1.1",
     "@modelcontextprotocol/sdk": "1.30.0",
-    "@angular/build": {
-      "picomatch": "4.0.5"
-    },
-    "@angular-devkit/core": {
-      "ajv": "8.20.0",
-      "picomatch": "4.0.5"
-    },
     "esbuild": "0.28.2",
     "express-rate-limit": "8.6.2",
     "ngx-avatars": {


### PR DESCRIPTION
Found re-checking the pins in #373.

Three overrides stopped doing anything when Angular moved to 22.1.5, because the packages they constrain now declare exactly the versions the overrides were forcing:

```
@angular/build@22.1.5        declares picomatch 4.0.5
@angular-devkit/core@22.1.5  declares picomatch 4.0.5, ajv 8.20.0
```

Both override blocks consisted entirely of those, so both keys go. `ajv` 8.20.0 is also the latest release, so that pin had nowhere left to point either.

```diff
   "overrides": {
     "@hono/node-server": "2.1.1",
     "@modelcontextprotocol/sdk": "1.30.0",
-    "@angular/build": {
-      "picomatch": "4.0.5"
-    },
-    "@angular-devkit/core": {
-      "ajv": "8.20.0",
-      "picomatch": "4.0.5"
-    },
     "esbuild": "0.28.2",
```

An override that pins a package to the version it already asks for is worse than no override: it reads as a deliberate constraint, so the next person re-derives why it is there before concluding it is nothing. That is exactly the cost #373 exists to avoid.

## Verified

Rather than assumed, since a dependency change that "should" be inert is the kind that is not:

- `npm install --package-lock-only` with all three removed leaves `package-lock.json` identical.
- `npm ls picomatch ajv --all` resolves both to the same versions throughout, with no `invalid:` markers and no `overridden` markers left on those trees.
- Production build passes; output unchanged apart from the usual budget and CommonJS warnings.
- Frontend suite: 48 files, 252 tests passing.

#373 is updated separately - the picomatch entry is struck from it, since it was resolved by #378 and a settled item on a list of things still waiting is just noise. The three live pins there were re-checked against upstream today and none have moved.

## Coverage refresh

Follow-up commit. Badge moves **59.2% -> 59.7%**, measured with `dev/coverage/coverage.sh` per CONTRIBUTING.md with the local LDAP directory up:

```
frontend   50.8%  (2941/5791 lines, 63 files)
backend    62.1%  (13350/21500 lines, 28 files)
combined   59.7%  (16291/27291 lines)
```

The run turned up a test from #393 that only passes at speed. `releases only the stream that closed` piped its second stream to a sink that drains, so both ran to completion and the assertion depended on the first finishing first; under c8 both had finished before it ran. It now holds the second open with a sink that never calls back, so it asserts on which stream was *released* rather than which one won. Ten consecutive runs under c8, ten green.

Two environmental notes recorded in the commit for whoever runs this next. Mocha default timeout of 2s is not enough on a slow link: the Downloader and youtube-dl hooks reach the network, and when they time out they take their whole describe block with them, silently understating coverage of the two largest backend modules instead of failing loudly. And `coverage.sh` only detects an LDAP server it started itself, so one already listening on 3389 still triggers the "will be understated" warning even while the LDAP tests are running fine.