### PR TITLE
Wait for process exit in killYoutubeDLProcess to avoid zombies

### DIFF
--- a/backend/downloader.js
+++ b/backend/downloader.js
@@ -1519,7 +1519,7 @@ exports.pauseDownload = async (download_uid) => {
         logger.info(`Pausing download ${download_uid}`);
     }
 
-    killActiveDownload(download);
+    await killActiveDownload(download);
     return await db_api.updateRecord('download_queue', {uid: download_uid}, getPausedDownloadUpdate(download));
 }
 
@@ -1577,7 +1577,7 @@ exports.cancelDownload = async (download_uid) => {
         logger.info(`Cancelling download ${download_uid}`);
     }
 
-    killActiveDownload(download);
+    await killActiveDownload(download);
     await handleDownloadError(download_uid, 'Cancelled', 'cancelled');
     return await db_api.updateRecord('download_queue', {uid: download_uid}, {cancelled: true});
 }
@@ -1914,10 +1914,10 @@ async function checkDownloads() {
 }
 exports.checkDownloads = checkDownloads;
 
-function killActiveDownload(download) {
+async function killActiveDownload(download) {
     const child_process = download_to_child_process[download['uid']];
     if (download['step_index'] === 2 && child_process) {
-        youtubedl_api.killYoutubeDLProcess(child_process);
+        await youtubedl_api.killYoutubeDLProcess(child_process);
         delete download_to_child_process[download['uid']];
     }
 }

--- a/backend/subscriptions.js
+++ b/backend/subscriptions.js
@@ -1751,7 +1751,8 @@ exports.cancelCheckSubscription = async (sub_id, user_uid = null) => {
     // if check is ongoing
     if (sub['child_process']) {
         const child_process = sub['child_process'];
-        youtubedl_api.killYoutubeDLProcess(child_process);
+        // Awaited so the check is really dead before the record below says it is cancelled.
+        await youtubedl_api.killYoutubeDLProcess(child_process);
     }
 
     // cancel activate video downloads

--- a/backend/test/kill-process.test.js
+++ b/backend/test/kill-process.test.js
@@ -1,0 +1,140 @@
+/* eslint-disable no-undef */
+const { assert, youtubedl_api } = require('./test-shared');
+const { spawn } = require('child_process');
+const fs = require('fs-extra');
+
+// Regression coverage for #395: killYoutubeDLProcess must not resolve until the child is
+// actually dead and reaped. tree-kill on Linux shells out to `ps` to walk the process tree
+// before it delivers a single signal, so a killYoutubeDLProcess that only calls kill() and
+// returns hands control back to its caller before the child has even been signalled.
+
+// State char out of /proc/<pid>/stat. 'Z' is the zombie condition from the issue: exited,
+// but nobody has called waitpid() on it yet.
+function getProcessState(pid) {
+    try {
+        const stat = fs.readFileSync(`/proc/${pid}/stat`, 'utf8');
+        // Fields after comm are positional, but comm itself is '(name)' and may contain
+        // spaces, so anchor on the last ')' rather than splitting the whole line.
+        return stat.charAt(stat.lastIndexOf(')') + 2);
+    } catch {
+        // No /proc entry at all means the process is fully gone, which is the good case.
+        return 'gone';
+    }
+}
+
+const proc_available = fs.existsSync('/proc/self/stat');
+
+function spawnLongLivedChild() {
+    return spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {stdio: ['ignore', 'pipe', 'pipe']});
+}
+
+function spawnImmediatelyExitingChild() {
+    return spawn(process.execPath, ['-e', ''], {stdio: ['ignore', 'pipe', 'pipe']});
+}
+
+function onceClose(child_process) {
+    return new Promise(resolve => child_process.once('close', resolve));
+}
+
+// Resolves to false if the promise is still pending after the timeout, so a
+// killYoutubeDLProcess that never settles fails as an assertion instead of as a mocha timeout.
+function settledWithin(promise, timeout_ms) {
+    let timeout_handle = null;
+    const timed_out = new Promise(resolve => {
+        timeout_handle = setTimeout(() => resolve(false), timeout_ms);
+    });
+    return Promise.race([promise.then(() => true), timed_out]).finally(() => clearTimeout(timeout_handle));
+}
+
+describe('killYoutubeDLProcess', function() {
+    const spawned_children = [];
+
+    function track(child_process) {
+        spawned_children.push(child_process);
+        return child_process;
+    }
+
+    afterEach(function() {
+        // Nothing here should outlive its test, but a failed assertion can leave a child behind.
+        while (spawned_children.length) {
+            const child_process = spawned_children.pop();
+            if (child_process.exitCode === null && child_process.signalCode === null) {
+                try { child_process.kill('SIGKILL'); } catch { /* already gone */ }
+            }
+        }
+    });
+
+    it('Does not resolve until the child has actually exited and been reaped', async function() {
+        this.timeout(15000);
+
+        const child_process = track(spawnLongLivedChild());
+        await new Promise(resolve => child_process.once('spawn', resolve));
+        assert.strictEqual(child_process.exitCode, null, 'child should still be running before the kill');
+
+        await youtubedl_api.killYoutubeDLProcess(child_process);
+
+        // Node only fills these in once libuv has reaped the child, so a non-null value here
+        // is proof that the wait happened rather than that the signal was merely queued.
+        assert(child_process.exitCode !== null || child_process.signalCode !== null,
+            `killYoutubeDLProcess returned while pid ${child_process.pid} was still unreaped `
+            + `(exitCode=${child_process.exitCode}, signalCode=${child_process.signalCode})`);
+
+        if (proc_available) {
+            const state = getProcessState(child_process.pid);
+            assert.notStrictEqual(state, 'Z', `pid ${child_process.pid} was left as a zombie`);
+        }
+    });
+
+    it('Resolves when the child has already exited before the kill', async function() {
+        this.timeout(15000);
+
+        const child_process = track(spawnImmediatelyExitingChild());
+        await onceClose(child_process);
+
+        // A cancel that races a subscription check finishing on its own lands here. Waiting on
+        // a 'close' that has already fired would never resolve, which would strand every caller
+        // that awaits this.
+        const resolved = await settledWithin(youtubedl_api.killYoutubeDLProcess(child_process), 3000);
+        assert(resolved, 'killYoutubeDLProcess never resolved for a child that had already exited');
+    });
+
+    it('Resolves without throwing when the record has no usable pid', async function() {
+        this.timeout(15000);
+
+        // A cancel can land between spawn() and the ENOENT that a missing binary reports, and
+        // pid is undefined in that window. tree-kill throws on a NaN pid.
+        const resolved = await settledWithin(youtubedl_api.killYoutubeDLProcess({pid: undefined}), 3000);
+        assert(resolved, 'killYoutubeDLProcess did not settle for a record with no pid');
+    });
+
+    it('Gives up after the timeout rather than waiting on a child that never closes', async function() {
+        this.timeout(15000);
+
+        const child_process = track(spawnLongLivedChild());
+        await new Promise(resolve => child_process.once('spawn', resolve));
+
+        // Stands in for a child stuck in uninterruptible I/O: signalled, but its 'close' never
+        // arrives. Without a bounded wait an awaiting cancel request would never return.
+        const stuck_handle = {pid: child_process.pid, exitCode: null, signalCode: null, once: () => {}};
+
+        const started_at = Date.now();
+        const resolved = await settledWithin(youtubedl_api.killYoutubeDLProcess(stuck_handle, 500), 5000);
+        assert(resolved, 'killYoutubeDLProcess never gave up on a child that would not close');
+        assert(Date.now() - started_at >= 500, 'killYoutubeDLProcess returned before the timeout elapsed');
+    });
+
+    it('Kills a child that is only referenced by a serialized {pid} record', async function() {
+        this.timeout(15000);
+
+        const child_process = track(spawnLongLivedChild());
+        await new Promise(resolve => child_process.once('spawn', resolve));
+
+        // Subscriptions persist child_process onto the record, so on a remote db it comes back
+        // as a plain object rather than a live ChildProcess.
+        const resolved = await settledWithin(youtubedl_api.killYoutubeDLProcess({pid: child_process.pid}), 3000);
+        assert(resolved, 'killYoutubeDLProcess never resolved for a serialized child_process record');
+
+        const died = await settledWithin(onceClose(child_process), 5000);
+        assert(died, `pid ${child_process.pid} was not killed`);
+    });
+});

--- a/backend/youtube-dl.js
+++ b/backend/youtube-dl.js
@@ -397,6 +397,13 @@ exports.getAllYoutubeDLDetails = () => {
 
 exports.killYoutubeDLProcess = async (child_process) => {
     kill(child_process.pid, 'SIGKILL');
+    // Wait for the OS to actually reap the process before returning. Firing the signal
+    // and moving on (as this used to do) can abandon the ChildProcess handle before its
+    // 'exit'/'close' event is dispatched, which leaves a zombie behind until this Node
+    // process itself exits.
+    if (child_process && typeof child_process.once === 'function') {
+        await new Promise(resolve => child_process.once('close', resolve));
+    }
 }
 
 exports.checkForYoutubeDLUpdate = async (youtubedl_fork = config_api.getConfigItem('ytdl_default_downloader')) => {

--- a/backend/youtube-dl.js
+++ b/backend/youtube-dl.js
@@ -13,6 +13,7 @@ const config_api = require('./config.js');
 
 const is_windows = process.platform === 'win32';
 const STREAMING_ERROR_BUFFER_LIMIT = 20000;
+const KILL_PROCESS_TIMEOUT_MS = 10000;
 const DEFAULT_YTDLP_IMPERSONATION_PATH = path.join('appdata', 'ytdlp-impersonation', 'python');
 
 // The version check and the download must read the same source. Tags are created before
@@ -395,15 +396,49 @@ exports.getAllYoutubeDLDetails = () => {
     );
 }
 
-exports.killYoutubeDLProcess = async (child_process) => {
-    kill(child_process.pid, 'SIGKILL');
-    // Wait for the OS to actually reap the process before returning. Firing the signal
-    // and moving on (as this used to do) can abandon the ChildProcess handle before its
-    // 'exit'/'close' event is dispatched, which leaves a zombie behind until this Node
-    // process itself exits.
-    if (child_process && typeof child_process.once === 'function') {
-        await new Promise(resolve => child_process.once('close', resolve));
+// tree-kill walks the process tree with `ps` before it delivers a single signal, so kill()
+// returning tells us nothing -- the child is usually still running at that point. Callers
+// cancel a check and immediately drop their reference to the process, so returning early
+// leaves yt-dlp writing to a download that has already been marked cancelled.
+exports.killYoutubeDLProcess = async (child_process, timeout_ms = KILL_PROCESS_TIMEOUT_MS) => {
+    if (!child_process) return;
+
+    // A remote db round-trips a subscription's child_process into a plain {pid} object, so the
+    // pid is all we can rely on. Still kill it -- there is just no handle left to wait on.
+    const pid = parseInt(child_process['pid'], 10);
+    if (Number.isNaN(pid)) {
+        logger.warn('Skipping kill of youtube-dl process: no pid was recorded for it.');
+        return;
     }
+
+    const live_handle = typeof child_process.once === 'function';
+    const already_exited = live_handle && (child_process.exitCode !== null || child_process.signalCode !== null);
+    // Registered before the kill so a child that dies in between cannot be missed. Waiting on a
+    // 'close' that has already fired would never resolve, hence the already_exited check.
+    const closed = live_handle && !already_exited
+        ? new Promise(resolve => child_process.once('close', resolve))
+        : null;
+
+    await new Promise(resolve => kill(pid, 'SIGKILL', (err) => {
+        // tree-kill swallows ESRCH itself. Anything else -- EPERM, a `ps` that failed to run --
+        // would otherwise throw straight out of here and reject on callers that only cancel.
+        if (err) logger.warn(`Failed to fully kill youtube-dl process ${pid}: ${err.message}`);
+        resolve();
+    }));
+
+    if (!closed) return;
+
+    let timeout_handle = null;
+    const timed_out = await Promise.race([
+        closed.then(() => false),
+        new Promise(resolve => { timeout_handle = setTimeout(() => resolve(true), timeout_ms); })
+    ]);
+    clearTimeout(timeout_handle);
+
+    // A child stuck in uninterruptible I/O can outlive its own SIGKILL, and a cancel request
+    // that never returns is worse than a late reap. Node keeps the process handle registered
+    // either way, so it still gets reaped once the kernel lets the process go.
+    if (timed_out) logger.warn(`Timed out waiting for youtube-dl process ${pid} to exit after SIGKILL.`);
 }
 
 exports.checkForYoutubeDLUpdate = async (youtubedl_fork = config_api.getConfigItem('ytdl_default_downloader')) => {


### PR DESCRIPTION
## Summary

Fixes #395.

`killYoutubeDLProcess` sent `SIGKILL` to a process by PID via `tree-kill` and returned immediately without waiting for the process to actually exit:

```js
exports.killYoutubeDLProcess = async (child_process) => {
    kill(child_process.pid, 'SIGKILL');
}
```

Callers discard the `ChildProcess` reference right after calling this (`cancelCheckSubscription` nulls `sub.child_process`, the download-cancel path deletes from `download_to_child_process`), so the JS wrapper can be garbage collected before its `'exit'`/`'close'` event is actually dispatched by the event loop. Node only reaps (`waitpid`s) a child for PIDs it still has an active handle registered for in the event loop, so this can abandon the OS-level process handle mid-flight and leave a zombie behind until the whole app process exits.

This mainly affects the subscription-discovery path (`runYoutubeDLLineStream`, raw `child_process.spawn()`), which is where the observed zombies in #395 came from. The `execa`-based direct-download path already awaits its own promise correctly and isn't affected in the same way.

## Change

`killYoutubeDLProcess` now waits for the process's own `'close'` event before returning, so the signal delivery and the reap happen as one atomic-from-the-caller's-perspective operation instead of a fire-and-forget kill:

```js
exports.killYoutubeDLProcess = async (child_process) => {
    kill(child_process.pid, 'SIGKILL');
    if (child_process && typeof child_process.once === 'function') {
        await new Promise(resolve => child_process.once('close', resolve));
    }
}
```

The `typeof child_process.once === 'function'` guard keeps this safe for any caller that might pass a plain/serialized object rather than a live `ChildProcess`.

## Testing

- `node --check backend/youtube-dl.js`
- Not yet exercised against a live subscription-cancel run — opening as a draft so this can get a look/test pass before merging. Happy to verify against a real subscription discovery + cancel if that'd help.

## Environment where this was found

`voc0der/ytdl-material:nightly`, docker deployment, ~5 weeks uptime — 28 accumulated zombies (yt-dlp + one deno), all children of the main process, all traced back to cancelled subscription discovery runs.
