### PR TITLE
feat(library): show how many files a playlist holds

### DIFF
--- a/Public API v1.yaml
+++ b/Public API v1.yaml
@@ -3079,6 +3079,11 @@ components:
           type: number
         duration:
           type: number
+        file_count:
+          type: number
+          description: >-
+            How many files the playlist holds. Only automatic playlists carry it, as they
+            have no uids array to count; for a normal playlist, count uids.
         user_uid:
           type: string
         auto:

--- a/backend/categories.js
+++ b/backend/categories.js
@@ -305,6 +305,9 @@ async function getCategoriesAsPlaylists(user_uid = null) {
         // The thumbnail endpoint takes a file uid, so say which file it is borrowing from.
         category_playlist['thumbnailFileUid'] = files_that_match[0].uid;
         category_playlist['duration'] = files_that_match.reduce((a, b) => a + utils.durationStringToNumber(b.duration), 0);
+        // A category has no uids array, so a caller cannot count its contents the way it
+        // counts a real playlist's. Carry the count instead.
+        category_playlist['file_count'] = files_that_match.length;
         category_playlist['id'] = category_playlist['uid'];
         category_playlist['auto'] = true;
         categories_as_playlists.push(category_playlist);

--- a/backend/test/categories.test.js
+++ b/backend/test/categories.test.js
@@ -130,6 +130,31 @@ describe('Categories', async function() {
         }
     });
 
+    it('Categories as playlists - carries a file count', async function() {
+        const category = await db_api.getRecord('categories', {name: 'test_category'});
+        const categorized_uids = ['category-count-1', 'category-count-2', 'category-count-3'];
+        try {
+            for (const categorized_uid of categorized_uids) {
+                await db_api.insertRecordIntoTable('files', {
+                    ...sample_video_json,
+                    uid: categorized_uid,
+                    category: {uid: category['uid'], name: category['name']}
+                });
+            }
+
+            const categories_as_playlists = await categories_api.getCategoriesAsPlaylists();
+            const category_playlist = categories_as_playlists.find(playlist => playlist['name'] === 'test_category');
+
+            // A category has no uids array, so the count is the only way a caller can say
+            // how much it holds.
+            assert(category_playlist);
+            assert.strictEqual(category_playlist['uids'], undefined);
+            assert.strictEqual(category_playlist['file_count'], categorized_uids.length);
+        } finally {
+            await db_api.removeAllRecords('files', {uid: {$in: categorized_uids}});
+        }
+    });
+
     it('Create default categories', async function() {
         await db_api.removeAllRecords('categories');
         try {

--- a/src/api-types/models/Playlist.ts
+++ b/src/api-types/models/Playlist.ts
@@ -22,6 +22,11 @@ export type Playlist = {
     type: FileType;
     registered: number;
     duration: number;
+    /**
+     * How many files the playlist holds. Only automatic playlists carry it, as they
+     * have no uids array to count; for a normal playlist, count uids.
+     */
+    file_count?: number;
     user_uid?: string;
     auto?: boolean;
     sharingEnabled?: boolean;

--- a/src/app/components/unified-file-card/unified-file-card.component.html
+++ b/src/app/components/unified-file-card/unified-file-card.component.html
@@ -98,7 +98,14 @@
       }
 
       @if (!loading) {
-        <span [ngClass]="{'max-two-lines': card_size !== 'small', 'max-one-line': card_size === 'small' }">{{card_size === 'large' && file_obj.uploader ? file_obj.uploader + ' - ' : ''}}<strong>{{!is_playlist ? file_obj.title : file_obj.name}}</strong></span>
+        @if (showPlaylistItemCount) {
+          <div class="playlist-text">
+            <span class="max-one-line"><strong>{{file_obj.name}}</strong></span>
+            <span class="playlist-item-count">{{playlistItemCountLabel}}</span>
+          </div>
+        } @else {
+          <span [ngClass]="{'max-two-lines': card_size !== 'small', 'max-one-line': card_size === 'small' }">{{card_size === 'large' && file_obj.uploader ? file_obj.uploader + ' - ' : ''}}<strong>{{!is_playlist ? file_obj.title : file_obj.name}}</strong></span>
+        }
       }
       @if (loading) {
         <span class="title-loading"><content-loader [backgroundColor]="theme.ghost_primary" [foregroundColor]="theme.ghost_secondary" viewBox="0 0 250 30"><svg:rect x="0" y="0" rx="3" ry="3" width="250" height="30" /></content-loader></span>

--- a/src/app/components/unified-file-card/unified-file-card.component.scss
+++ b/src/app/components/unified-file-card/unified-file-card.component.scss
@@ -129,6 +129,29 @@
   position: absolute;
 }
 
+.playlist-text {
+  bottom: 5px;
+  position: absolute;
+  width: calc(100% - 10px);
+}
+
+/* A title anchors itself to the bottom of the card. Inside this block the block does the
+   anchoring instead, so the count can sit on its own line underneath the title.
+   The clamp is set to the one line max-height already allows, so an overlong name ends in
+   an ellipsis rather than being cut off at the edge of the card. */
+.playlist-text .max-one-line {
+  bottom: auto;
+  position: static;
+  -webkit-line-clamp: 1;
+}
+
+.playlist-item-count {
+  display: block;
+  font-size: 0.75em;
+  line-height: 1.2em;
+  opacity: 0.7;
+}
+
 .duration-time {
   position: absolute;
   bottom: 5px;

--- a/src/app/components/unified-file-card/unified-file-card.component.spec.ts
+++ b/src/app/components/unified-file-card/unified-file-card.component.spec.ts
@@ -69,6 +69,119 @@ describe('UnifiedFileCardComponent', () => {
     expect(component.displayedDateTimezone).toBeUndefined();
   });
 
+  it('should count a playlist by the uids it holds', () => {
+    component.is_playlist = true;
+    component.file_obj = {
+      name: 'Example playlist',
+      uids: ['one', 'two', 'three']
+    } as any;
+
+    expect(component.playlistItemCount).toBe(3);
+    expect(component.playlistItemCountLabel).toBe('3 items');
+  });
+
+  it('should count an automatic playlist by the file count the server sent', () => {
+    component.is_playlist = true;
+    component.file_obj = {
+      name: 'Music',
+      auto: true,
+      file_count: 157
+    } as any;
+
+    expect(component.playlistItemCount).toBe(157);
+    expect(component.playlistItemCountLabel).toBe('157 items');
+  });
+
+  it('should count an empty playlist rather than treating it as unknown', () => {
+    component.is_playlist = true;
+    component.file_obj = {
+      name: 'Empty playlist',
+      uids: []
+    } as any;
+
+    expect(component.playlistItemCount).toBe(0);
+    expect(component.playlistItemCountLabel).toBe('0 items');
+  });
+
+  it('should say item rather than items for a playlist holding one file', () => {
+    component.is_playlist = true;
+    component.file_obj = {
+      name: 'Single',
+      uids: ['only']
+    } as any;
+
+    expect(component.playlistItemCountLabel).toBe('1 item');
+  });
+
+  it('should not count a playlist whose size is unknown', () => {
+    component.is_playlist = true;
+    component.file_obj = {
+      name: 'Unknown size'
+    } as any;
+
+    expect(component.playlistItemCount).toBeNull();
+    expect(component.playlistItemCountLabel).toBeNull();
+    expect(component.showPlaylistItemCount).toBe(false);
+  });
+
+  it('should not count a card that is not a playlist', () => {
+    component.is_playlist = false;
+    component.file_obj = {
+      title: 'Example video',
+      uids: ['one', 'two']
+    } as any;
+
+    expect(component.playlistItemCount).toBeNull();
+    expect(component.showPlaylistItemCount).toBe(false);
+  });
+
+  it('should leave the count off a small card, which has no room for it', () => {
+    component.is_playlist = true;
+    component.card_size = 'small';
+    component.file_obj = {
+      name: 'Example playlist',
+      uids: ['one', 'two']
+    } as any;
+
+    expect(component.playlistItemCountLabel).toBe('2 items');
+    expect(component.showPlaylistItemCount).toBe(false);
+  });
+
+  it('should render the count under the playlist title', () => {
+    component.loading = false;
+    component.is_playlist = true;
+    component.file_obj = {
+      name: 'Example playlist',
+      duration: 0,
+      registered: Date.now(),
+      uids: ['one', 'two', 'three']
+    } as any;
+    fixture.detectChanges();
+
+    const count_element = fixture.debugElement.query(By.css('.playlist-item-count'));
+    expect(count_element).not.toBeNull();
+    expect(count_element.nativeElement.textContent.trim()).toBe('3 items');
+
+    // The title gives up its second line to the count, so the block stays the same height.
+    expect(fixture.debugElement.query(By.css('.playlist-text .max-one-line'))).not.toBeNull();
+    expect(fixture.debugElement.query(By.css('.playlist-text .max-two-lines'))).toBeNull();
+  });
+
+  it('should render a file card title without a count', () => {
+    component.loading = false;
+    component.is_playlist = false;
+    component.file_obj = {
+      uid: 'example-uid',
+      title: 'Example title',
+      duration: 90,
+      registered: Date.now()
+    } as any;
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.query(By.css('.playlist-item-count'))).toBeNull();
+    expect(fixture.debugElement.query(By.css('.max-two-lines'))).not.toBeNull();
+  });
+
   it('should keep the thumbnail rendered while the hover preview is active', () => {
     component.loading = false;
     component.locale = { ngID: 'en-GB' } as any;

--- a/src/app/components/unified-file-card/unified-file-card.component.ts
+++ b/src/app/components/unified-file-card/unified-file-card.component.ts
@@ -102,6 +102,44 @@ export class UnifiedFileCardComponent implements OnInit {
     return this.locale?.ngID;
   }
 
+  /**
+   * A normal playlist carries the uids it holds, so it is counted here. An automatic one
+   * has no uids array -- the server counts it and sends the total as file_count.
+   */
+  get playlistItemCount(): number | null {
+    if (!this.is_playlist || !this.file_obj) {
+      return null;
+    }
+
+    if (Array.isArray(this.file_obj.uids)) {
+      return this.file_obj.uids.length;
+    }
+
+    return Number.isFinite(this.file_obj.file_count) ? this.file_obj.file_count : null;
+  }
+
+  get playlistItemCountLabel(): string | null {
+    const item_count = this.playlistItemCount;
+    if (item_count === null) {
+      return null;
+    }
+
+    // A playlist holds audio as readily as video, and carries nothing that says which,
+    // so the count stays neutral about what it is counting.
+    return item_count === 1
+      ? $localize`:Playlist card single item count:1 item`
+      : $localize`:Playlist card item count:${item_count}:count: items`;
+  }
+
+  /**
+   * The count needs a line of its own beneath the title, and a small card has no room for
+   * one -- its text block would run up into the thumbnail above it. Where the count does
+   * show, the title gives up its second line to it, so the block stays as tall as before.
+   */
+  get showPlaylistItemCount(): boolean {
+    return this.card_size !== 'small' && this.playlistItemCountLabel !== null;
+  }
+
   private hasDisplayableUploadDate(): boolean {
     return typeof this.file_obj?.upload_date === 'string'
       && /^\d{4}-\d{2}-\d{2}$/.test(this.file_obj.upload_date);


### PR DESCRIPTION
Closes #400.

Playlist cards in the library gave no sense of how much a playlist held — the only way to find out was to open it and count. The count now sits under the title as subtext.

### Where the count comes from

A normal playlist carries the uids it holds, so the card counts those. An automatic (category) playlist has no uids array, so `getCategoriesAsPlaylists` sends the total as a new `file_count` field, documented on the `Playlist` schema.

`Playlist.ts` is hand-edited to match rather than regenerated: the installed generator no longer produces the committed output — a full `npm run generate` rewrites all ~137 models and deletes `DeletePlaylistResponse.ts`. That drift is worth a separate look, but not here.

### Fitting it on the card

The card is a fixed height and its text block is absolutely positioned against the bottom, so an extra line pushes the title up into the thumbnail. The title gives up its second line to the count instead, which keeps the block shorter than it was. Measured in Chromium against the real component CSS, the gap between the thumbnail and the text block:

| card | today | with the count |
| --- | --- | --- |
| medium, one-line name | 28.7px | 16.1px |
| medium, wrapping name | 11.9px | 16.1px |
| large, one-line name | 23.7px | 11.1px |
| large, wrapping name | **6.9px** | 11.1px |

The tightest case on a playlist card improves. A small card is 150px tall and has no room for a second line either way — it keeps showing the title alone.

Clamping the title to one line also needed `-webkit-line-clamp: 1` scoped to the new block: `.max-one-line` sets `line-clamp: 2` with `max-height: 1.2em`, so the ellipsis lands on the line that `max-height` hides and an overlong name was simply cut off at the card edge.

### "items", not "videos"

The issue asked for `157 videos`. A playlist holds audio as readily as video, and carries nothing that says which — the `type` field the frontend reads is never written by the backend at all (that is #401's root cause). So the label stays neutral: `157 items`, `1 item`.

### Tests

- `unified-file-card.component.spec.ts` — 9 new cases: counting by uids, counting an automatic playlist by `file_count`, an empty playlist counting 0 rather than reading as unknown, the singular label, an unknown size, a non-playlist card, suppression on a small card, and two rendering assertions.
- `categories.test.js` — `getCategoriesAsPlaylists` carries `file_count` and still has no `uids`.

Both new paths were mutation-checked: breaking the uids branch fails 5 frontend specs, dropping `file_count` fails the backend one.

Full run: 261 frontend tests, 552 backend tests, `npm run lint`, both `tsc --noEmit` projects, `node --check` on the touched backend files, and a production build — all clean.