### PR TITLE
fix(library): add-to-playlist menu and player action bar

### DIFF
--- a/Public API v1.yaml
+++ b/Public API v1.yaml
@@ -3049,7 +3049,6 @@ components:
         - id
         - name
         - thumbnailURL
-        - type
         - registered
         - duration
       type: object
@@ -3073,8 +3072,6 @@ components:
             A playlist has no thumbnail of its own -- an automatic one borrows the
             thumbnail of a file it contains. This is the uid of that file, and it is what
             the thumbnail endpoint expects.
-        type:
-          $ref: '#/components/schemas/FileType'
         registered:
           type: number
         duration:

--- a/src/api-types/models/Playlist.ts
+++ b/src/api-types/models/Playlist.ts
@@ -2,8 +2,6 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import type { FileType } from './FileType';
-
 export type Playlist = {
     name: string;
     uids: Array<string>;
@@ -19,7 +17,6 @@ export type Playlist = {
      * the thumbnail endpoint expects.
      */
     thumbnailFileUid?: string;
-    type: FileType;
     registered: number;
     duration: number;
     /**

--- a/src/app/components/unified-file-card/unified-file-card.component.html
+++ b/src/app/components/unified-file-card/unified-file-card.component.html
@@ -44,12 +44,10 @@
       @if (file_obj.sub_id) {
         <button (click)="navigateToSubscription()" mat-menu-item><mat-icon>{{file_obj.isAudio ? 'library_music' : 'video_library'}}</mat-icon>&nbsp;<ng-container i18n="Go to subscription menu item">Go to subscription</ng-container></button>
       }
-      <button [disabled]="!availablePlaylists || availablePlaylists.length === 0" [matMenuTriggerFor]="addtoplaylist" mat-menu-item><mat-icon>playlist_add</mat-icon>&nbsp;<ng-container i18n="Add to playlist menu item">Add to playlist</ng-container></button>
+      <button [disabled]="playlistsToAddTo.length === 0" [matMenuTriggerFor]="addtoplaylist" mat-menu-item><mat-icon>playlist_add</mat-icon>&nbsp;<ng-container i18n="Add to playlist menu item">Add to playlist</ng-container></button>
       <mat-menu #addtoplaylist="matMenu">
-        @for (playlist of availablePlaylists; track playlist.id) {
-          @if ((playlist.type === 'audio') === file_obj.isAudio) {
-            <button [disabled]="$safeNavigationMigration(playlist.uids?.includes(file_obj.uid))" (click)="emitAddFileToPlaylist(playlist.id)" mat-menu-item>{{playlist.name}}</button>
-          }
+        @for (playlist of playlistsToAddTo; track playlist.id) {
+          <button [disabled]="playlistContainsFile(playlist)" (click)="emitAddFileToPlaylist(playlist.id)" mat-menu-item>{{playlist.name}}</button>
         }
       </mat-menu>
       <mat-divider></mat-divider>

--- a/src/app/components/unified-file-card/unified-file-card.component.spec.ts
+++ b/src/app/components/unified-file-card/unified-file-card.component.spec.ts
@@ -2,6 +2,8 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { MatDialog } from '@angular/material/dialog';
+import { MatMenuTrigger } from '@angular/material/menu';
+import { OverlayContainer } from '@angular/cdk/overlay';
 
 import { UnifiedFileCardComponent } from './unified-file-card.component';
 import { configureTestBed } from '../../../testing/test-bed';
@@ -28,6 +30,78 @@ describe('UnifiedFileCardComponent', () => {
       ghost_primary: '#000000',
       ghost_secondary: '#111111'
     } as any;
+  });
+
+
+  // "Add to playlist" is a nested lazy menu inside the card's own lazy action menu, so both
+  // have to be opened before the playlist buttons exist anywhere to assert on.
+  function openAddToPlaylistMenu(): HTMLButtonElement[] {
+    const outer = fixture.debugElement.query(By.css('button.menuButton'));
+    outer.injector.get(MatMenuTrigger).openMenu();
+    fixture.detectChanges();
+
+    const nested = fixture.debugElement.queryAll(By.directive(MatMenuTrigger))
+      .find(candidate => candidate.nativeElement.textContent.includes('Add to playlist'));
+    expect(nested).toBeDefined();
+    nested.injector.get(MatMenuTrigger).openMenu();
+    fixture.detectChanges();
+
+    const panels = TestBed.inject(OverlayContainer).getContainerElement()
+      .querySelectorAll('.mat-mdc-menu-panel');
+    const playlist_panel = panels[panels.length - 1];
+    return Array.from(playlist_panel.querySelectorAll('button.mat-mdc-menu-item'));
+  }
+
+  function setUpFileCard(file_obj: any, playlists: any[] = [{id: 'p1', name: 'Alpha', uids: []}, {id: 'p2', name: 'Beta', uids: []}]): void {
+    component.loading = false;
+    component.is_playlist = false;
+    component.availablePlaylists = playlists as any;
+    component.file_obj = file_obj;
+    fixture.detectChanges();
+  }
+
+  it('should offer every playlist for a video file', () => {
+    setUpFileCard({uid: 'f1', title: 'A video', isAudio: false, registered: Date.now(), duration: 5});
+
+    expect(openAddToPlaylistMenu().map(button => button.textContent.trim())).toEqual(['Alpha', 'Beta']);
+  });
+
+  it('should offer every playlist for an audio file', () => {
+    // A playlist's type is never written, so matching the file's type against it left this
+    // menu empty for everything that was not strictly video.
+    setUpFileCard({uid: 'f1', title: 'A song', isAudio: true, registered: Date.now(), duration: 5});
+
+    expect(openAddToPlaylistMenu().map(button => button.textContent.trim())).toEqual(['Alpha', 'Beta']);
+  });
+
+  it('should offer every playlist for a record that has no isAudio at all', () => {
+    setUpFileCard({uid: 'f1', title: 'An older record', registered: Date.now(), duration: 5});
+
+    expect(openAddToPlaylistMenu().map(button => button.textContent.trim())).toEqual(['Alpha', 'Beta']);
+  });
+
+  it('should disable a playlist that already holds the file', () => {
+    setUpFileCard(
+      {uid: 'f1', title: 'A video', isAudio: false, registered: Date.now(), duration: 5},
+      [{id: 'p1', name: 'Holds it', uids: ['f1']}, {id: 'p2', name: 'Does not', uids: ['other']}]
+    );
+
+    const buttons = openAddToPlaylistMenu();
+    expect(buttons.map(button => button.textContent.trim())).toEqual(['Holds it', 'Does not']);
+    expect(buttons[0].disabled).toBe(true);
+    expect(buttons[1].disabled).toBe(false);
+  });
+
+  it('should leave a playlist enabled when it carries no uids array', () => {
+    component.file_obj = {uid: 'f1'} as any;
+
+    expect(component.playlistContainsFile({name: 'No uids'} as any)).toBe(false);
+  });
+
+  it('should treat a missing playlist list as nothing to add to', () => {
+    component.availablePlaylists = null;
+
+    expect(component.playlistsToAddTo).toEqual([]);
   });
 
   it('should create', () => {

--- a/src/app/components/unified-file-card/unified-file-card.component.ts
+++ b/src/app/components/unified-file-card/unified-file-card.component.ts
@@ -9,7 +9,7 @@ import localeES from '@angular/common/locales/es';
 import localeDE from '@angular/common/locales/de';
 import localeZH from '@angular/common/locales/zh';
 import localeNB from '@angular/common/locales/nb';
-import { DatabaseFile } from 'api-types';
+import { DatabaseFile, Playlist } from 'api-types';
 
 registerLocaleData(localeGB);
 registerLocaleData(localeFR);
@@ -138,6 +138,22 @@ export class UnifiedFileCardComponent implements OnInit {
    */
   get showPlaylistItemCount(): boolean {
     return this.card_size !== 'small' && this.playlistItemCountLabel !== null;
+  }
+
+  /**
+   * Every playlist can hold every file. The menu used to offer only playlists whose type
+   * matched the file's, but a playlist's type is never written -- so the comparison came
+   * down to "the file is strictly video", and the menu opened empty for audio and for any
+   * older record with no isAudio at all. Nothing else in the app draws that distinction:
+   * the create and edit dialog picks from every file regardless of type, and the player
+   * types each item as it plays it.
+   */
+  get playlistsToAddTo(): Playlist[] {
+    return Array.isArray(this.availablePlaylists) ? this.availablePlaylists : [];
+  }
+
+  playlistContainsFile(playlist: Playlist): boolean {
+    return Array.isArray(playlist?.uids) && playlist.uids.includes(this.file_obj?.uid);
   }
 
   private hasDisplayableUploadDate(): boolean {

--- a/src/app/player/player.component.css
+++ b/src/app/player/player.component.css
@@ -411,10 +411,12 @@
     margin-bottom: 15px;
 }
 
-.playback-mode-button {
-    opacity: 0.6;
-}
-
+/* A playback toggle is not dimmed when idle -- it sits at the same colour as the actions
+   beside it, and shows that it is engaged with a chip behind the icon instead.
+   The chip is a neutral scrim rather than a theme colour on purpose: the light theme's
+   accent is brown 200, which on its own near-white background leaves an engaged toggle
+   fainter than the idle ones. Grey at this alpha darkens a light surface and lightens a
+   dark one, so it reads in all three themes. */
 .playback-mode-button.active {
-    opacity: 1;
+    background-color: rgba(128, 128, 128, 0.28);
 }

--- a/src/app/player/player.component.html
+++ b/src/app/player/player.component.html
@@ -114,44 +114,44 @@
                   <span class="action-buttons-row">
                     @if (db_playlist) {
                       <span class="buttons">
-                        <button (click)="downloadContent()" [disabled]="downloading" mat-icon-button><mat-icon>save</mat-icon></button>
+                        <button (click)="downloadContent()" [disabled]="downloading" matTooltip="Download the whole playlist as a zip" i18n-matTooltip="Download playlist tooltip" aria-label="Download the whole playlist as a zip" i18n-aria-label="Download playlist label" mat-icon-button><mat-icon>folder_zip</mat-icon></button>
                         @if (downloading) {
                           <mat-spinner class="spinner" [diameter]="35"></mat-spinner>
                         }
                         @if ((!postsService.isLoggedIn || postsService.permissions.includes('sharing')) && !auto) {
-                          <button (click)="openShareDialog()" mat-icon-button><mat-icon>share</mat-icon></button>
+                          <button (click)="openShareDialog()" matTooltip="Share" i18n-matTooltip="Share tooltip" aria-label="Share" i18n-aria-label="Share label" mat-icon-button><mat-icon>share</mat-icon></button>
                         }
                       </span>
                     }
                     @if (db_file) {
                       <span class="buttons">
-                        <button (click)="downloadFile()" [disabled]="downloading" mat-icon-button><mat-icon>cloud_download</mat-icon></button>
+                        <button (click)="downloadFile()" [disabled]="downloading" matTooltip="Download this file" i18n-matTooltip="Download file tooltip" aria-label="Download this file" i18n-aria-label="Download file label" mat-icon-button><mat-icon>cloud_download</mat-icon></button>
                         @if (downloading) {
                           <mat-spinner class="spinner" [diameter]="35"></mat-spinner>
                         }
                         @if (!postsService.isLoggedIn || postsService.permissions.includes('sharing')) {
-                          <button (click)="openShareDialog()" mat-icon-button><mat-icon>share</mat-icon></button>
+                          <button (click)="openShareDialog()" matTooltip="Share" i18n-matTooltip="Share tooltip" aria-label="Share" i18n-aria-label="Share label" mat-icon-button><mat-icon>share</mat-icon></button>
                         }
                       </span>
                     }
                     @if (db_file || playlist[currentIndex]) {
                       @if (canToggleSubtitles()) {
-                        <button class="playback-mode-button" [class.active]="subtitlesEnabled" [attr.aria-label]="getSubtitleToggleTooltip()" (click)="toggleSubtitles()" [matTooltip]="getSubtitleToggleTooltip()" i18n-matTooltip="Subtitle toggle tooltip" mat-icon-button>
+                        <button class="playback-mode-button" [class.active]="subtitlesEnabled" [attr.aria-pressed]="subtitlesEnabled" [attr.aria-label]="getSubtitleToggleTooltip()" (click)="toggleSubtitles()" [matTooltip]="getSubtitleToggleTooltip()" i18n-matTooltip="Subtitle toggle tooltip" mat-icon-button>
                           <mat-icon>closed_caption</mat-icon>
                         </button>
                       }
-                      <button class="playback-mode-button" [class.active]="autoplay_enabled" (click)="toggleAutoplay()" matTooltip="Autoplay" i18n-matTooltip="Autoplay toggle tooltip" mat-icon-button>
+                      <button class="playback-mode-button" [class.active]="autoplay_enabled" [attr.aria-pressed]="autoplay_enabled" (click)="toggleAutoplay()" matTooltip="Autoplay" i18n-matTooltip="Autoplay toggle tooltip" aria-label="Autoplay" i18n-aria-label="Autoplay toggle label" mat-icon-button>
                         <mat-icon>playlist_play</mat-icon>
                       </button>
-                      <button class="playback-mode-button" [class.active]="repeat_enabled" (click)="toggleRepeat()" matTooltip="Repeat current video" i18n-matTooltip="Repeat current video toggle tooltip" mat-icon-button>
+                      <button class="playback-mode-button" [class.active]="repeat_enabled" [attr.aria-pressed]="repeat_enabled" (click)="toggleRepeat()" matTooltip="Repeat current video" i18n-matTooltip="Repeat current video toggle tooltip" aria-label="Repeat current video" i18n-aria-label="Repeat toggle label" mat-icon-button>
                         <mat-icon>repeat_one</mat-icon>
                       </button>
                     }
                     @if (db_file || db_playlist) {
-                      <button (click)="openFileInfoDialog()" mat-icon-button><mat-icon>info</mat-icon></button>
+                      <button (click)="openFileInfoDialog()" matTooltip="Details" i18n-matTooltip="Details tooltip" aria-label="Details" i18n-aria-label="Details label" mat-icon-button><mat-icon>info</mat-icon></button>
                     }
                     @if (db_file && db_file.url.includes('twitch.tv')) {
-                      <button (click)="drawer.toggle()" mat-icon-button><mat-icon>chat</mat-icon></button>
+                      <button (click)="drawer.toggle()" matTooltip="Chat" i18n-matTooltip="Chat toggle tooltip" aria-label="Chat" i18n-aria-label="Chat toggle label" mat-icon-button><mat-icon>chat</mat-icon></button>
                     }
                   </span>
                 </div>

--- a/src/app/player/player.component.spec.ts
+++ b/src/app/player/player.component.spec.ts
@@ -1,6 +1,7 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
 import { MatDialog } from '@angular/material/dialog';
+import { By } from '@angular/platform-browser';
 import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { VgApiService } from '@videogular/ngx-videogular/core';
 import { DatabaseFile } from '../../api-types';
@@ -75,6 +76,85 @@ describe('PlayerComponent', () => {
     component = fixture.componentInstance;
     fixture.detectChanges();
     postsServiceStub.setPageTitle.mockClear();
+  });
+
+
+  function actionBarButtons(): HTMLButtonElement[] {
+    const row = fixture.debugElement.query(By.css('.action-buttons-row'));
+    return row ? Array.from(row.nativeElement.querySelectorAll('button')) : [];
+  }
+
+  // The whole toolbar sits behind the player's own guard, so a spec has to get far enough
+  // for the player to be showing before any action button exists. ngOnInit runs on the
+  // first detectChanges and rebuilds this state, so it has to settle first.
+  function showPlayer(): void {
+    fixture.detectChanges();
+    component.playlist_id = 'playlist-1';
+    component.file_objs = [{
+      uid: 'f1',
+      title: 'A video',
+      isAudio: false,
+      url: 'https://example.com/video'
+    } as DatabaseFile];
+    component.uids = ['f1'];
+    component.parseFileNames();
+    expect(component.show_player).toBe(true);
+  }
+
+  it('should give every action bar button an accessible name', () => {
+    showPlayer();
+    component.db_file = {uid: 'f1', title: 'A video', url: 'https://example.com/watch', isAudio: false} as any;
+    fixture.detectChanges();
+
+    const buttons = actionBarButtons();
+    expect(buttons.length).toBeGreaterThan(0);
+    for (const button of buttons) {
+      // An icon on its own says nothing to a screen reader, and said nothing on hover
+      // either until each of these carried a name.
+      expect(button.getAttribute('aria-label')).toBeTruthy();
+    }
+  });
+
+  it('should name the playlist download for what it actually downloads', () => {
+    showPlayer();
+    component.db_playlist = {id: 'p1', name: 'A playlist', uids: ['f1']} as any;
+    fixture.detectChanges();
+
+    const download = actionBarButtons()
+      .find(button => button.querySelector('mat-icon')?.textContent.trim() === 'folder_zip');
+    expect(download).toBeDefined();
+    // A floppy disk said nothing about scope; both the icon and the name now do.
+    expect(download.getAttribute('aria-label')).toBe('Download the whole playlist as a zip');
+  });
+
+  it('should mark only the engaged playback toggles', () => {
+    showPlayer();
+    component.db_file = {uid: 'f1', title: 'A video', url: 'https://example.com/watch', isAudio: false} as any;
+    component.autoplay_enabled = true;
+    component.repeat_enabled = false;
+    fixture.detectChanges();
+
+    const toggles = actionBarButtons().filter(button => button.classList.contains('playback-mode-button'));
+    const autoplay = toggles.find(button => button.getAttribute('aria-label') === 'Autoplay');
+    const repeat = toggles.find(button => button.getAttribute('aria-label') === 'Repeat current video');
+    // Idle toggles carry no marker at all, so they render at the same colour as the
+    // actions beside them rather than dimmed.
+    expect(autoplay.classList.contains('active')).toBe(true);
+    expect(repeat.classList.contains('active')).toBe(false);
+  });
+
+  it('should mark playback toggles as pressed for assistive tech', () => {
+    showPlayer();
+    component.db_file = {uid: 'f1', title: 'A video', url: 'https://example.com/watch', isAudio: false} as any;
+    component.autoplay_enabled = true;
+    component.repeat_enabled = false;
+    fixture.detectChanges();
+
+    const toggles = actionBarButtons().filter(button => button.classList.contains('playback-mode-button'));
+    const autoplay = toggles.find(button => button.getAttribute('aria-label') === 'Autoplay');
+    const repeat = toggles.find(button => button.getAttribute('aria-label') === 'Repeat current video');
+    expect(autoplay.getAttribute('aria-pressed')).toBe('true');
+    expect(repeat.getAttribute('aria-pressed')).toBe('false');
   });
 
   it('should create', () => {

--- a/src/testing/test-bed.ts
+++ b/src/testing/test-bed.ts
@@ -13,6 +13,10 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatMenuModule } from '@angular/material/menu';
+// The player template resolves #group="matButtonToggleGroup", and an exportAs reference
+// needs the real directive -- NO_ERRORS_SCHEMA does not cover it, so without this the whole
+// template fails to render with NG0301.
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
@@ -218,6 +222,7 @@ export function configureTestBed(moduleDef: any = {}) {
       NoopAnimationsModule,
       MatAutocompleteModule,
       MatMenuModule,
+      MatButtonToggleModule,
       ...(moduleDef.imports || [])
     ],
     providers: [


### PR DESCRIPTION
Closes #401. Closes #397.

Two fixes in the same area of the UI, rolled together.

---

## #401 — "Add to playlist" rendered an empty menu

The menu offered only playlists whose type matched the file's:

```html
@if ((playlist.type === 'audio') === file_obj.isAudio) {
```

A playlist's `type` is never written. `createPlaylist` does not set one, nothing else ever has, and `playlist.type` was read in exactly one place in the codebase — this line. So the left side was always `false` and the condition reduced to **"the file is strictly video"**.

Reproduced at DOM level before touching anything, by opening the real nested menu in a spec:

| `file_obj.isAudio` | playlists rendered |
| --- | --- |
| `false` | `Alpha`, `Beta` |
| `true` | **none** |
| `undefined` | **none** |

Audio files never had a playlist to add to, and neither did older records stored without an `isAudio` — which matches the report of some channels working and others not, since an audio-type subscription produces audio files. The menu opened blank rather than showing as unavailable because the trigger only checked whether any playlists existed, not whether any survived the filter.

### Why the filter goes rather than the type getting written

Nothing else in the app draws that distinction:

- The create/edit playlist dialog feeds `app-media-library [selectMode]` with no type filter, so a playlist mixing audio and video has always been buildable through the UI.
- The player types each item individually in `createMediaObject`, so a mixed playlist plays correctly.
- `addFileToPlaylist` does no type validation server-side.

Writing a real `type` would add an enforced restriction no other path respects, plus a migration for every existing playlist.

`type` is dropped from the `Playlist` schema and model too. It sat in `required` while no response has ever carried it — a guarantee on paper that was a trap for the next caller who believed it.

The `$safeNavigationMigration(...)` wrapper left by the Angular `safe-optional-chaining` schematic is replaced with an explicit `Array.isArray` check. Same behaviour, without depending on a compiler marker.

---

## #397 — player action bar

**Tooltips.** Download, share and info had none, and neither did the chat toggle the report did not catch. Each now carries a tooltip *and* an `aria-label` — an icon-only button with no name says nothing on hover and nothing to a screen reader.

**The ambiguous save icon.** The playlist download was a floppy disk that gave no hint of scope. It builds a zip of every file in the playlist, so it is `folder_zip` now and says "Download the whole playlist as a zip". The single-file button keeps `cloud_download` and reads "Download this file". This is the label that was missing when #398 was filed — a misclick no longer happens without warning.

**The colour inconsistency.** The cause was `.playback-mode-button { opacity: 0.6 }` — the two toggles were dimmed *because they were switched off*, which read as them simply being a different colour. Idle toggles are no longer dimmed, so every icon in the row rests at the same colour, and an engaged one shows a chip behind the icon.

The obvious choice for the engaged state was the button's own `color="accent"`, and I built it that way first. Rendering it against all three themes showed why that is wrong here:

| theme | accent | result |
| --- | --- | --- |
| default | blue 700 | fine |
| `.dark-theme` | blue 500 | fine |
| `.light-theme` | **brown 200** | engaged toggle *fainter than the idle ones* |

So the chip is a neutral grey scrim instead — it darkens a light surface and lightens a dark one, and reads in all three. The toggles also gained `aria-pressed`, which is what the opacity was standing in for and never conveyed.

---

## Tests

**#401** — 6 specs, including a helper that opens the nested lazy menu so assertions run against real rendered DOM: every playlist offered for video, audio, and a record with no `isAudio`; a playlist already holding the file is disabled while its sibling is not; a playlist with no `uids` stays enabled; a null list yields nothing.

**#397** — 4 specs: every action-bar button has a non-empty accessible name, the playlist download is named for what it downloads, only engaged toggles are marked, and `aria-pressed` tracks state.

`MatButtonToggleModule` is added to the shared test bed. The player template resolves `#group="matButtonToggleGroup"`, and an `exportAs` reference needs the real directive — `NO_ERRORS_SCHEMA` does not cover it, so the whole template failed to render under test with NG0301 and none of the above was assertable.

Every new test was mutation-checked: restoring the old filter fails exactly the audio and missing-`isAudio` cases; reverting the icon, dropping one `aria-label`, or dropping `aria-pressed` each fail their own spec.

Full run: 271 frontend tests, `npm run lint`, both `tsc --noEmit` projects, and a production build — all clean.