### PR TITLE
fix(player): confirm and cancel playlist archive downloads

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -2364,6 +2364,22 @@ app.post('/api/downloadFileFromServer', optionalJwt, requireAuthenticatedOrShare
     // named by the server -- so it is carried separately and used for the header.
     let download_display_name = null;
 
+    // Container archives are prepared before Express starts sending the response. Tie
+    // that work to the connection so cancelling the browser request stops archiver and
+    // removes its partial file instead of filling appdata in the background.
+    const createContainerArchive = async (name, file_objs, user_uid) => {
+        const controller = new AbortController();
+        const abortArchive = () => controller.abort();
+        req.once('aborted', abortArchive);
+        res.once('close', abortArchive);
+        try {
+            return await utils.createContainerZipFile(name, file_objs, user_uid, {signal: controller.signal});
+        } finally {
+            req.removeListener('aborted', abortArchive);
+            res.removeListener('close', abortArchive);
+        }
+    };
+
     if (req.user && req.user.uid) uuid = req.user.uid;
 
     let zip_file_generated = false;
@@ -2383,7 +2399,7 @@ app.post('/api/downloadFileFromServer', optionalJwt, requireAuthenticatedOrShare
 
         // generate zip
         download_display_name = playlist['name'];
-        file_path_to_download = await utils.createContainerZipFile(playlist['name'], playlist_files_to_download, uuid);
+        file_path_to_download = await createContainerArchive(playlist['name'], playlist_files_to_download, uuid);
     } else if (sub_id && !uid) {
         zip_file_generated = true;
         const sub = await subscriptions_api.getSubscription(sub_id, req.isAuthenticated() ? req.user.uid : null);
@@ -2395,7 +2411,7 @@ app.post('/api/downloadFileFromServer', optionalJwt, requireAuthenticatedOrShare
 
         // generate zip
         download_display_name = sub['name'];
-        file_path_to_download = await utils.createContainerZipFile(sub['name'], sub_files_to_download,
+        file_path_to_download = await createContainerArchive(sub['name'], sub_files_to_download,
             req.isAuthenticated() ? req.user.uid : null);
     } else {
         const file_obj = await files_api.getVideo(uid, uuid, sub_id)
@@ -2414,6 +2430,7 @@ app.post('/api/downloadFileFromServer', optionalJwt, requireAuthenticatedOrShare
         }
     }
     if (!file_path_to_download) {
+        if (req.aborted || res.destroyed) return;
         // The archive could not be built -- every record was refused, or the write failed.
         logger.error('Failed to build an archive to send.');
         res.sendStatus(500);

--- a/backend/test/api-hardening.test.js
+++ b/backend/test/api-hardening.test.js
@@ -1073,6 +1073,18 @@ describe('Container archives', function() {
 
         if (zip_path) { await fs.remove(zip_path); }
     });
+
+    it('stops archive creation and deletes the partial file when cancelled', async function() {
+        const zip_path = path.join(media.base, 'cancelled.zip');
+        const controller = new AbortController();
+        const archive_promise = utils.createZipFile(zip_path, [alice_file], {signal: controller.signal});
+
+        controller.abort();
+        const result = await archive_promise;
+
+        assert.strictEqual(result, null);
+        assert.strictEqual(await fs.pathExists(zip_path), false, 'the partial archive should be removed');
+    });
 });
 
 describe('The yt-dlp command line', function() {

--- a/backend/utils.js
+++ b/backend/utils.js
@@ -142,7 +142,7 @@ exports.getDownloadedFilesByType = async (basePath, type, full_metadata = false)
  * it goes in the Content-Disposition header, which
  * is what a filename is actually for.
  ************************************************/
-exports.createContainerZipFile = async (file_name, container_file_objs, user_uid = null) => {
+exports.createContainerZipFile = async (file_name, container_file_objs, user_uid = null, options = {}) => {
     const container_files_to_download = [];
     for (const container_file_obj of container_file_objs) {
         // Every path here came out of a database record. Records written before the path
@@ -156,10 +156,13 @@ exports.createContainerZipFile = async (file_name, container_file_objs, user_uid
     }
 
     const zip_file_path = path.join('appdata', `container-${uuid()}.zip`);
-    return await exports.createZipFile(zip_file_path, container_files_to_download);
+    return await exports.createZipFile(zip_file_path, container_files_to_download, options);
 }
 
-exports.createZipFile = async (zip_file_path, file_paths) => {
+exports.createZipFile = async (zip_file_path, file_paths, options = {}) => {
+    const signal = options.signal;
+    if (signal?.aborted) return null;
+
     const output = fs.createWriteStream(zip_file_path);
 
     // archiver 8 replaced the callable factory with exported classes, so archiver('zip')
@@ -168,6 +171,15 @@ exports.createZipFile = async (zip_file_path, file_paths) => {
     const archive = new ZipArchive({
         zlib: { level: 9 } // Sets the compression level.
     });
+    let aborted = false;
+    const abortArchive = () => {
+        aborted = true;
+        // Archiver lets its one active worker finish, then drops the rest of the
+        // queue and closes the output. Keeping the output writable until that close
+        // avoids stranding the active worker behind backpressure.
+        archive.abort();
+    };
+    signal?.addEventListener('abort', abortArchive, {once: true});
 
     // Both ends need a handler. An unhandled 'error' on either stream is an uncaught
     // exception, which takes the process down rather than failing the one request --
@@ -188,12 +200,15 @@ exports.createZipFile = async (zip_file_path, file_paths) => {
     }
 
     try {
-        archive.finalize();
+        archive.finalize().catch(() => null);
         await archive_finished;
+        if (aborted) throw new Error('Archive creation cancelled');
     } catch (err) {
-        logger.error(`Failed to build ${zip_file_path}: ${err.message}`);
+        if (!aborted) logger.error(`Failed to build ${zip_file_path}: ${err.message}`);
         await fs.remove(zip_file_path).catch(() => null);
         return null;
+    } finally {
+        signal?.removeEventListener('abort', abortArchive);
     }
 
     return zip_file_path;

--- a/src/app/player/player.component.html
+++ b/src/app/player/player.component.html
@@ -114,8 +114,11 @@
                   <span class="action-buttons-row">
                     @if (db_playlist) {
                       <span class="buttons">
-                        <button (click)="downloadContent()" [disabled]="downloading" matTooltip="Download the whole playlist as a zip" i18n-matTooltip="Download playlist tooltip" aria-label="Download the whole playlist as a zip" i18n-aria-label="Download playlist label" mat-icon-button><mat-icon>folder_zip</mat-icon></button>
+                        @if (!downloading) {
+                          <button (click)="downloadContent()" matTooltip="Download the whole playlist as a zip" i18n-matTooltip="Download playlist tooltip" aria-label="Download the whole playlist as a zip" i18n-aria-label="Download playlist label" mat-icon-button><mat-icon>folder_zip</mat-icon></button>
+                        }
                         @if (downloading) {
+                          <button (click)="cancelPlaylistDownload()" matTooltip="Cancel playlist download" i18n-matTooltip="Cancel playlist download tooltip" aria-label="Cancel playlist download" i18n-aria-label="Cancel playlist download label" mat-icon-button><mat-icon>cancel</mat-icon></button>
                           <mat-spinner class="spinner" [diameter]="35"></mat-spinner>
                         }
                         @if ((!postsService.isLoggedIn || postsService.permissions.includes('sharing')) && !auto) {

--- a/src/app/player/player.component.spec.ts
+++ b/src/app/player/player.component.spec.ts
@@ -4,6 +4,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { VgApiService } from '@videogular/ngx-videogular/core';
+import { Observable, Subject } from 'rxjs';
 import { DatabaseFile } from '../../api-types';
 import { PostsService } from '../posts.services';
 import { IChapter, IMedia, ISubtitleTrack, PlayerComponent } from './player.component';
@@ -13,6 +14,7 @@ describe('PlayerComponent', () => {
   let component: PlayerComponent;
   let fixture: ComponentFixture<PlayerComponent>;
   let postsServiceStub: any;
+  let matDialogStub: any;
 
   beforeEach(waitForAsync(() => {
     postsServiceStub = {
@@ -42,12 +44,15 @@ describe('PlayerComponent', () => {
       },
       sidenav: null
     };
+    matDialogStub = {
+      open: vi.fn().mockName('openDialog')
+    };
 
     configureTestBed({
       declarations: [PlayerComponent],
       providers: [
         { provide: PostsService, useValue: postsServiceStub },
-        { provide: MatDialog, useValue: {} },
+        { provide: MatDialog, useValue: matDialogStub },
         {
           provide: Router,
           useValue: {
@@ -125,6 +130,45 @@ describe('PlayerComponent', () => {
     expect(download).toBeDefined();
     // A floppy disk said nothing about scope; both the icon and the name now do.
     expect(download.getAttribute('aria-label')).toBe('Download the whole playlist as a zip');
+  });
+
+  it('should require confirmation before preparing a playlist archive', () => {
+    const confirmation = new Subject<boolean>();
+    postsServiceStub.downloadPlaylistFromServer = vi.fn().mockName('downloadPlaylistFromServer');
+    matDialogStub.open.mockReturnValue({afterClosed: () => confirmation.asObservable()});
+    component.db_playlist = {id: 'p1', name: 'A playlist', uids: ['f1', 'f2']} as any;
+    component.file_objs = [
+      {uid: 'f1', size: 1024} as DatabaseFile,
+      {uid: 'f2', size: 2048} as DatabaseFile
+    ];
+
+    component.downloadContent();
+
+    expect(postsServiceStub.downloadPlaylistFromServer).not.toHaveBeenCalled();
+    expect(matDialogStub.open.mock.calls[0][1].data.dialogText).toContain('2 files');
+    confirmation.next(false);
+    expect(postsServiceStub.downloadPlaylistFromServer).not.toHaveBeenCalled();
+  });
+
+  it('should abort an in-progress playlist archive request', () => {
+    const confirmation = new Subject<boolean>();
+    const requestTeardown = vi.fn().mockName('playlistRequestTeardown');
+    postsServiceStub.downloadPlaylistFromServer = vi.fn().mockName('downloadPlaylistFromServer').mockReturnValue(
+      new Observable(() => requestTeardown)
+    );
+    matDialogStub.open.mockReturnValue({afterClosed: () => confirmation.asObservable()});
+    component.db_playlist = {id: 'p1', name: 'A playlist', uids: ['f1']} as any;
+    component.playlist_id = 'p1';
+
+    component.downloadContent();
+    confirmation.next(true);
+
+    expect(component.downloading).toBe(true);
+    expect(postsServiceStub.downloadPlaylistFromServer).toHaveBeenCalledWith('p1', null);
+    component.cancelPlaylistDownload();
+    expect(requestTeardown).toHaveBeenCalled();
+    expect(component.downloading).toBe(false);
+    expect(postsServiceStub.openSnackBar).toHaveBeenCalledWith('Playlist download cancelled.');
   });
 
   it('should mark only the engaged playback toggles', () => {

--- a/src/app/player/player.component.ts
+++ b/src/app/player/player.component.ts
@@ -8,7 +8,10 @@ import { ShareMediaDialogComponent } from '../dialogs/share-media-dialog/share-m
 import { DatabaseFile, FileType, FileTypeFilter, Playlist, Sort } from '../../api-types';
 import { TwitchChatComponent } from 'app/components/twitch-chat/twitch-chat.component';
 import { VideoInfoDialogComponent } from 'app/dialogs/video-info-dialog/video-info-dialog.component';
+import { ConfirmDialogComponent } from 'app/dialogs/confirm-dialog/confirm-dialog.component';
 import { saveAs } from 'file-saver';
+import { filesize } from 'filesize';
+import { Subscription } from 'rxjs';
 import { filter, take } from 'rxjs/operators';
 
 export interface IMedia {
@@ -99,6 +102,7 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
   name = null;
 
   downloading = false;
+  playlistDownloadSubscription: Subscription | null = null;
 
   save_volume_timer = null;
   original_volume = null;
@@ -177,6 +181,8 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.destroyed = true;
+    this.playlistDownloadSubscription?.unsubscribe();
+    this.playlistDownloadSubscription = null;
     this.subtitleTrackRefreshToken += 1;
     // prevents volume save feature from running in the background
     clearInterval(this.save_volume_timer);
@@ -458,16 +464,48 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   downloadContent(): void {
+    if (this.downloading) return;
+
+    const file_count = this.db_playlist?.uids?.length ?? this.file_objs.length;
+    const total_size = this.file_objs.reduce((size, file) => size + (Number(file?.size) || 0), 0);
+    const playlist_summary = total_size > 0
+      ? $localize`${file_count}:playlist file count: files, ${filesize(total_size)}:playlist size:`
+      : $localize`${file_count}:playlist file count: files`;
+    const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+      data: {
+        dialogTitle: $localize`Download playlist?`,
+        dialogText: $localize`Download the entire playlist as a zip (${playlist_summary})? Creating the archive can take a while and use significant disk space.`,
+        submitText: $localize`Download`
+      }
+    });
+
+    dialogRef.afterClosed().pipe(take(1)).subscribe(confirmed => {
+      if (confirmed) this.startPlaylistDownload();
+    });
+  }
+
+  startPlaylistDownload(): void {
     const zipName = this.db_playlist.name;
     this.downloading = true;
-    this.postsService.downloadPlaylistFromServer(this.playlist_id, this.uuid).subscribe(res => {
+    this.playlistDownloadSubscription = this.postsService.downloadPlaylistFromServer(this.playlist_id, this.uuid).subscribe(res => {
       this.downloading = false;
+      this.playlistDownloadSubscription = null;
       const blob: Blob = res;
       saveAs(blob, zipName + '.zip');
     }, err => {
       console.error(err);
       this.downloading = false;
+      this.playlistDownloadSubscription = null;
     });
+  }
+
+  cancelPlaylistDownload(): void {
+    if (!this.downloading) return;
+
+    this.playlistDownloadSubscription?.unsubscribe();
+    this.playlistDownloadSubscription = null;
+    this.downloading = false;
+    this.postsService.openSnackBar($localize`Playlist download cancelled.`);
   }
 
   downloadFile(): void {


### PR DESCRIPTION
## Summary

- Add a confirmation dialog before creating a playlist zip.
- Show the playlist file count and estimated uncompressed size so the scope is clear before downloading.
- Replace the archive action with a visible Cancel button while preparation or transfer is in progress.
- Abort the HTTP request when the user cancels or leaves the player.
- Tie server-side archive generation to the client connection, stop queued archive work after cancellation, and remove partial zip files.

## Testing

- `npx ng test --watch=false` — 273 passing
- `npm test` in `backend` — 553 passing, 52 pending
- ESLint — passing
- Production build — passing

Closes #398