### PR TITLE
feat: add automatic subscription playlists and bulk source selection

### DIFF
--- a/Public API v1.yaml
+++ b/Public API v1.yaml
@@ -2362,6 +2362,8 @@ components:
           type: string
         useSubfolder:
           type: boolean
+        autoCreatePlaylist:
+          type: boolean
         maxQuality:
           type: string
     SubscribeResponse:
@@ -3087,6 +3089,9 @@ components:
           type: boolean
         sharingEnabled:
           type: boolean
+        source_sub_id:
+          type: string
+          description: Subscription whose downloads are automatically appended to this playlist
     Download:
       required:
         - url
@@ -3292,6 +3297,8 @@ components:
         custom_output:
           type: string
         use_subfolder:
+          type: boolean
+        auto_create_playlist:
           type: boolean
         downloading:
           type: boolean

--- a/backend/app.js
+++ b/backend/app.js
@@ -1871,6 +1871,7 @@ app.post('/api/subscribe', optionalJwt, requirePermission('subscriptions'), asyn
     let customArgs = req.body.customArgs;
     let customOutput = req.body.customFileOutput;
     let useSubfolder = req.body.useSubfolder;
+    let autoCreatePlaylist = req.body.autoCreatePlaylist;
     let user_uid = req.isAuthenticated() ? req.user.uid : null;
     const new_sub = {
                         name: name,
@@ -1879,7 +1880,8 @@ app.post('/api/subscribe', optionalJwt, requirePermission('subscriptions'), asyn
                         id: uuid(),
                         user_uid: user_uid,
                         type: audioOnly ? 'audio' : 'video',
-                        use_subfolder: useSubfolder !== false
+                        use_subfolder: useSubfolder !== false,
+                        auto_create_playlist: autoCreatePlaylist === true
                     };
 
     // adds timerange if it exists, otherwise all videos will be downloaded

--- a/backend/db.js
+++ b/backend/db.js
@@ -69,10 +69,12 @@ const tables = {
         primary_key: 'id',
         field_types: {
             id: 'text',
-            user_uid: 'text'
+            user_uid: 'text',
+            source_sub_id: 'text'
         },
         indexes: [
-            { keys: { user_uid: 1 } }
+            { keys: { user_uid: 1 } },
+            { keys: { user_uid: 1, source_sub_id: 1 } }
         ]
     },
     categories: {
@@ -92,6 +94,7 @@ const tables = {
             streamingOnly: 'boolean',
             isPlaylist: 'boolean',
             use_subfolder: 'boolean',
+            auto_create_playlist: 'boolean',
             name: 'text',
             url: 'text'
         },

--- a/backend/files.js
+++ b/backend/files.js
@@ -1584,28 +1584,98 @@ async function syncSubscriptionPlaylist(sub_id, user_uid = null, file_uid = null
     return await exports.updatePlaylist(playlist, user_uid) ? playlist : null;
 }
 
+async function queueSubscriptionPlaylistWork(sub_id, user_uid, work) {
+    const sync_key = `${user_uid || ''}:${sub_id}`;
+    const previous_sync = subscription_playlist_syncs.get(sync_key) || Promise.resolve();
+    const current_sync = previous_sync
+        .catch(() => null)
+        .then(work);
+    subscription_playlist_syncs.set(sync_key, current_sync);
+
+    try {
+        return await current_sync;
+    } finally {
+        if (subscription_playlist_syncs.get(sync_key) === current_sync) {
+            subscription_playlist_syncs.delete(sync_key);
+        }
+    }
+}
+
+async function cleanupSubscriptionPlaylists(sub_id, user_uid = null, source_file_uids = null) {
+    const playlist_filter = {source_sub_id: sub_id};
+    if (shouldRestrictToUser(user_uid)) playlist_filter['user_uid'] = user_uid;
+    const playlists = await db_api.getRecords('playlists', playlist_filter);
+    if (playlists.length === 0) return true;
+
+    if (!Array.isArray(source_file_uids)) {
+        const files_filter = {sub_id: sub_id};
+        if (shouldRestrictToUser(user_uid)) files_filter['user_uid'] = user_uid;
+        source_file_uids = (await db_api.getRecords('files', files_filter)).map(file => file.uid);
+    }
+    const source_uid_set = new Set(source_file_uids);
+    let success = true;
+
+    for (const playlist of playlists) {
+        const stored_uids = Array.isArray(playlist['uids']) ? playlist['uids'] : [];
+        const remaining_candidates = stored_uids.filter(uid => !source_uid_set.has(uid));
+        const remaining_files = await exports.getVideosByUIDs(remaining_candidates, user_uid);
+        const remaining_uid_set = new Set(remaining_files.map(file => file.uid));
+        const remaining_uids = remaining_candidates.filter(uid => remaining_uid_set.has(uid));
+        const stored_playlist_filter = {id: playlist.id};
+        if (shouldRestrictToUser(user_uid)) stored_playlist_filter['user_uid'] = user_uid;
+
+        if (remaining_uids.length === 0) {
+            success = await db_api.removeRecord('playlists', stored_playlist_filter) && success;
+            continue;
+        }
+
+        playlist['uids'] = remaining_uids;
+        if (!(await exports.updatePlaylist(playlist, user_uid))) {
+            success = false;
+            continue;
+        }
+
+        const thumbnail_url = remaining_files[0] && remaining_files[0]['thumbnailURL'];
+        if (thumbnail_url !== undefined) {
+            success = await db_api.updateRecord('playlists', stored_playlist_filter, {thumbnailURL: thumbnail_url}) && success;
+        }
+        success = await db_api.removePropertyFromRecord('playlists', stored_playlist_filter, {source_sub_id: true}) && success;
+    }
+
+    return success;
+}
+
 exports.syncSubscriptionPlaylist = async (sub_id, user_uid = null, file_uid = null) => {
     if (!sub_id) return null;
 
     // Downloads for one subscription can finish concurrently. Serialize only this
     // subscription's updates so two completions cannot create duplicate playlists or
-    // overwrite each other's appended uid.
-    const sync_key = `${user_uid || ''}:${sub_id}`;
-    const previous_sync = subscription_playlist_syncs.get(sync_key) || Promise.resolve();
-    const current_sync = previous_sync
-        .catch(() => null)
-        .then(() => syncSubscriptionPlaylist(sub_id, user_uid, file_uid));
-    subscription_playlist_syncs.set(sync_key, current_sync);
-
+    // overwrite each other's appended uid. Teardown uses the same queue so an in-flight
+    // completion cannot recreate a playlist after unsubscribe cleanup.
     try {
-        return await current_sync;
+        return await queueSubscriptionPlaylistWork(
+            sub_id,
+            user_uid,
+            () => syncSubscriptionPlaylist(sub_id, user_uid, file_uid)
+        );
     } catch (err) {
         logger.error(`Failed to sync the automatic playlist for subscription ${sub_id}: ${err.message}`);
         return null;
-    } finally {
-        if (subscription_playlist_syncs.get(sync_key) === current_sync) {
-            subscription_playlist_syncs.delete(sync_key);
-        }
+    }
+}
+
+exports.cleanupSubscriptionPlaylists = async (sub_id, user_uid = null, source_file_uids = null) => {
+    if (!sub_id) return true;
+
+    try {
+        return await queueSubscriptionPlaylistWork(
+            sub_id,
+            user_uid,
+            () => cleanupSubscriptionPlaylists(sub_id, user_uid, source_file_uids)
+        );
+    } catch (err) {
+        logger.error(`Failed to clean up automatic playlists for subscription ${sub_id}: ${err.message}`);
+        return false;
     }
 }
 

--- a/backend/files.js
+++ b/backend/files.js
@@ -17,6 +17,7 @@ const MEDIA_EXTENSIONS_BY_TYPE = {
 };
 const SIDECAR_SCAN_EXTENSIONS = ['json', 'webp', 'jpg', 'png', 'nfo', 'vtt'];
 const MANAGED_SIDECAR_EXTENSIONS = ['.webp', '.jpg', '.png', '.nfo'];
+const subscription_playlist_syncs = new Map();
 
 function shouldRestrictToUser(user_uid) {
     return config_api.getConfigItem('ytdl_multi_user_mode') && user_uid !== null && user_uid !== undefined;
@@ -1186,6 +1187,10 @@ exports.registerFileDB = async (file_path, type, user_uid = null, category = nul
 
     const file_obj = await registerFileDBManual(file_object);
 
+    if (sub_id && file_obj) {
+        await exports.syncSubscriptionPlaylist(sub_id, user_uid, file_obj.uid);
+    }
+
     // remove metadata JSON if needed
     if (!config_api.getConfigItem('ytdl_include_metadata')) {
         utils.deleteJSONFile(file_path, type)
@@ -1522,6 +1527,86 @@ exports.createPlaylist = async (playlist_name, uids, user_uid = null) => {
     await db_api.updateRecord('playlists', {id: new_playlist.id}, {duration: duration});
 
     return new_playlist;
+}
+
+async function syncSubscriptionPlaylist(sub_id, user_uid = null, file_uid = null) {
+    const subscription_filter = {id: sub_id};
+    if (shouldRestrictToUser(user_uid)) subscription_filter['user_uid'] = user_uid;
+    const subscription = await db_api.getRecord('subscriptions', subscription_filter);
+    if (!subscription || subscription['auto_create_playlist'] !== true || !subscription['name']) return null;
+
+    const playlist_filter = {source_sub_id: sub_id};
+    if (shouldRestrictToUser(user_uid)) playlist_filter['user_uid'] = user_uid;
+    let playlist = await db_api.getRecord('playlists', playlist_filter);
+
+    if (playlist && file_uid) {
+        const stored_uids = Array.isArray(playlist['uids']) ? playlist['uids'] : [];
+        const existing_files = await exports.getVideosByUIDs(stored_uids, user_uid);
+        const existing_uids = new Set(existing_files.map(file => file.uid));
+        playlist['uids'] = stored_uids.filter(uid => existing_uids.has(uid));
+        if (playlist['uids'].includes(file_uid) && playlist['uids'].length === stored_uids.length) return playlist;
+        if (playlist['uids'].includes(file_uid)) {
+            return await exports.updatePlaylist(playlist, user_uid) ? playlist : null;
+        }
+        playlist['uids'].push(file_uid);
+        return await exports.updatePlaylist(playlist, user_uid) ? playlist : null;
+    }
+
+    const files_filter = {sub_id: sub_id};
+    if (shouldRestrictToUser(user_uid)) files_filter['user_uid'] = user_uid;
+    const subscription_files = await db_api.getRecords('files', files_filter, false, {by: 'registered', order: 1});
+    if (subscription_files.length === 0) return playlist;
+
+    if (!playlist) {
+        playlist = await exports.createPlaylist(subscription['name'], subscription_files.map(file => file.uid), user_uid);
+        if (!playlist) return null;
+        playlist['source_sub_id'] = sub_id;
+        await db_api.updateRecord('playlists', {id: playlist.id}, {source_sub_id: sub_id});
+        return playlist;
+    }
+
+    const stored_uids = Array.isArray(playlist['uids']) ? playlist['uids'] : [];
+    const playlist_files = await exports.getVideosByUIDs(stored_uids, user_uid);
+    const valid_playlist_uids = new Set(playlist_files.map(file => file.uid));
+    const merged_uids = stored_uids.filter(uid => valid_playlist_uids.has(uid));
+    let playlist_changed = merged_uids.length !== stored_uids.length;
+    const existing_uids = new Set(merged_uids);
+    for (const file of subscription_files) {
+        if (!existing_uids.has(file.uid)) {
+            existing_uids.add(file.uid);
+            merged_uids.push(file.uid);
+            playlist_changed = true;
+        }
+    }
+    if (!playlist_changed) return playlist;
+
+    playlist['uids'] = merged_uids;
+    return await exports.updatePlaylist(playlist, user_uid) ? playlist : null;
+}
+
+exports.syncSubscriptionPlaylist = async (sub_id, user_uid = null, file_uid = null) => {
+    if (!sub_id) return null;
+
+    // Downloads for one subscription can finish concurrently. Serialize only this
+    // subscription's updates so two completions cannot create duplicate playlists or
+    // overwrite each other's appended uid.
+    const sync_key = `${user_uid || ''}:${sub_id}`;
+    const previous_sync = subscription_playlist_syncs.get(sync_key) || Promise.resolve();
+    const current_sync = previous_sync
+        .catch(() => null)
+        .then(() => syncSubscriptionPlaylist(sub_id, user_uid, file_uid));
+    subscription_playlist_syncs.set(sync_key, current_sync);
+
+    try {
+        return await current_sync;
+    } catch (err) {
+        logger.error(`Failed to sync the automatic playlist for subscription ${sub_id}: ${err.message}`);
+        return null;
+    } finally {
+        if (subscription_playlist_syncs.get(sync_key) === current_sync) {
+            subscription_playlist_syncs.delete(sync_key);
+        }
+    }
 }
 
 exports.getPlaylist = async (playlist_id, user_uid = null, require_sharing = false) => {

--- a/backend/subscriptions.js
+++ b/backend/subscriptions.js
@@ -2147,6 +2147,9 @@ exports.updateSubscription = async (sub, user_uid = null) => {
 
     const updated = await db_api.updateRecord('subscriptions', filter_obj, sub);
     if (!updated) return false;
+    if (sub['auto_create_playlist'] === true) {
+        await files_api.syncSubscriptionPlaylist(sub.id, user_uid);
+    }
     exports.writeSubscriptionMetadata(sub);
     await cleanupSubscriptionPathChange(current_sub, sub, user_uid);
     return true;

--- a/backend/subscriptions.js
+++ b/backend/subscriptions.js
@@ -1138,7 +1138,14 @@ exports.unsubscribe = async (sub_id, deleteMode, user_uid = null) => {
         }
     }
 
+    const remove_sub_filter = {id: id};
+    if (shouldRestrictToUser(user_uid)) remove_sub_filter['user_uid'] = user_uid;
+    // Stop any registration callback that arrives after teardown begins from creating a
+    // new managed playlist. Cleanup is also serialized behind callbacks already in flight.
+    await db_api.updateRecord('subscriptions', remove_sub_filter, {auto_create_playlist: false});
+
     await killSubDownloads(sub_id, true);
+    await files_api.cleanupSubscriptionPlaylists(id, user_uid, sub_files.map(file => file.uid));
 
     if (deleteMode && !utils.usesSubscriptionSubfolder(sub)) {
         for (const sub_file of sub_files) {
@@ -1146,8 +1153,6 @@ exports.unsubscribe = async (sub_id, deleteMode, user_uid = null) => {
         }
     }
 
-    const remove_sub_filter = {id: id};
-    if (shouldRestrictToUser(user_uid)) remove_sub_filter['user_uid'] = user_uid;
     await db_api.removeRecord('subscriptions', remove_sub_filter);
     await db_api.removeAllRecords('files', {sub_id: id, ...(shouldRestrictToUser(user_uid) ? {user_uid: user_uid} : {})});
 

--- a/backend/test/files.test.js
+++ b/backend/test/files.test.js
@@ -125,6 +125,45 @@ describe('Files', function() {
         }
     });
 
+    it('registerFileDB appends subscription downloads to their automatic playlist', async function() {
+        const original_sync_subscription_playlist = files_api.syncSubscriptionPlaylist;
+        const original_include_metadata = config_api.getConfigItem('ytdl_include_metadata');
+        let sync_args = null;
+
+        files_api.syncSubscriptionPlaylist = async (...args) => {
+            sync_args = args;
+            return true;
+        };
+
+        try {
+            config_api.setConfigItem('ytdl_include_metadata', true);
+            await fs.writeFile(fixture_file_path, 'fixture');
+            const output = await files_api.registerFileDB(
+                fixture_file_path,
+                'video',
+                null,
+                null,
+                'subscription-1',
+                null,
+                {
+                    path: fixture_file_path,
+                    title: 'Subscription file',
+                    thumbnailURL: 'https://example.com/thumb.jpg',
+                    duration: 30,
+                    isAudio: false,
+                    source_metadata_checked: true
+                }
+            );
+
+            assert(output);
+            assert.deepStrictEqual(sync_args, ['subscription-1', null, output.uid]);
+        } finally {
+            files_api.syncSubscriptionPlaylist = original_sync_subscription_playlist;
+            config_api.setConfigItem('ytdl_include_metadata', original_include_metadata);
+            await db_api.removeAllRecords('files', {path: fixture_file_path});
+        }
+    });
+
     it('attachFileChaptersCollection returns empty chapters when metadata is missing', function() {
         const output = files_api.attachFileChaptersCollection([{
             path: path.join(fixture_dir, 'missing-video.mp4'),

--- a/backend/test/subscriptions.test.js
+++ b/backend/test/subscriptions.test.js
@@ -86,6 +86,118 @@ describe('Subscriptions', function() {
         const sub_exists = await db_api.getRecord('subscriptions', {id: new_sub['id']});
         assert(!sub_exists);
     });
+    it('Cleans up an automatic playlist when unsubscribing', async function () {
+        const sub = Object.assign({}, new_sub, {
+            id: uuid(),
+            name: 'unsubscribe_playlist_sub',
+            auto_create_playlist: true
+        });
+        const source_file = {
+            uid: uuid(),
+            sub_id: sub.id,
+            title: 'Subscription file',
+            thumbnailURL: 'https://example.com/source.jpg',
+            duration: 30,
+            registered: 100
+        };
+
+        await db_api.insertRecordIntoTable('subscriptions', sub);
+        await db_api.insertRecordIntoTable('files', source_file);
+        await files_api.syncSubscriptionPlaylist(sub.id);
+        assert(await db_api.getRecord('playlists', {source_sub_id: sub.id}));
+
+        const result = await subscriptions_api.unsubscribe(sub.id, true);
+
+        assert.strictEqual(result.success, true);
+        assert.strictEqual(await db_api.getRecord('playlists', {source_sub_id: sub.id}), undefined);
+    });
+    it('Keeps custom playlist entries when unsubscribing from its automatic source', async function () {
+        const sub = Object.assign({}, new_sub, {
+            id: uuid(),
+            name: 'detach_playlist_sub',
+            auto_create_playlist: true
+        });
+        const source_file = {
+            uid: uuid(),
+            sub_id: sub.id,
+            title: 'Subscription file',
+            thumbnailURL: 'https://example.com/source.jpg',
+            duration: 30,
+            registered: 100
+        };
+        const custom_file = {
+            uid: uuid(),
+            title: 'Custom file',
+            thumbnailURL: 'https://example.com/custom.jpg',
+            duration: 45,
+            registered: 200
+        };
+
+        await db_api.insertRecordIntoTable('subscriptions', sub);
+        await db_api.insertRecordIntoTable('files', source_file);
+        await db_api.insertRecordIntoTable('files', custom_file);
+        let playlist = await files_api.syncSubscriptionPlaylist(sub.id);
+        playlist['uids'].push(custom_file.uid);
+        assert.strictEqual(await files_api.updatePlaylist(playlist), true);
+
+        const result = await subscriptions_api.unsubscribe(sub.id, true);
+
+        assert.strictEqual(result.success, true);
+        playlist = await db_api.getRecord('playlists', {id: playlist.id});
+        assert(playlist);
+        assert.deepStrictEqual(playlist.uids, [custom_file.uid]);
+        assert.strictEqual(playlist.source_sub_id, undefined);
+        assert.strictEqual(playlist.thumbnailURL, custom_file.thumbnailURL);
+        assert.strictEqual(playlist.duration, 45);
+    });
+    it('Does not recreate an automatic playlist when a download finishes during unsubscribe', async function () {
+        const sub = Object.assign({}, new_sub, {
+            id: uuid(),
+            name: 'concurrent_unsubscribe_sub',
+            auto_create_playlist: true
+        });
+        const source_file = {
+            uid: uuid(),
+            sub_id: sub.id,
+            title: 'Subscription file',
+            thumbnailURL: 'https://example.com/source.jpg',
+            duration: 30,
+            registered: 100
+        };
+        const original_create_playlist = files_api.createPlaylist;
+        let release_create_playlist;
+        let signal_create_started;
+        const create_started = new Promise(resolve => { signal_create_started = resolve; });
+        const create_released = new Promise(resolve => { release_create_playlist = resolve; });
+
+        files_api.createPlaylist = async (...args) => {
+            signal_create_started();
+            await create_released;
+            return await original_create_playlist(...args);
+        };
+
+        try {
+            await db_api.insertRecordIntoTable('subscriptions', sub);
+            await db_api.insertRecordIntoTable('files', source_file);
+            const sync_promise = files_api.syncSubscriptionPlaylist(sub.id);
+            await create_started;
+
+            const unsubscribe_promise = subscriptions_api.unsubscribe(sub.id, true);
+            assert(await waitForCondition(async () => {
+                const stored_sub = await db_api.getRecord('subscriptions', {id: sub.id});
+                return stored_sub && stored_sub.auto_create_playlist === false;
+            }));
+            release_create_playlist();
+
+            await sync_promise;
+            const result = await unsubscribe_promise;
+            assert.strictEqual(result.success, true);
+            assert.strictEqual(await db_api.getRecord('playlists', {source_sub_id: sub.id}), undefined);
+        } finally {
+            files_api.createPlaylist = original_create_playlist;
+            release_create_playlist();
+        }
+    });
     it('Delete subscription file', async function () {
         
     });

--- a/backend/test/subscriptions.test.js
+++ b/backend/test/subscriptions.test.js
@@ -18,6 +18,7 @@ describe('Subscriptions', function() {
         await db_api.removeAllRecords('download_queue');
         await db_api.removeAllRecords('files');
         await db_api.removeAllRecords('archives');
+        await db_api.removeAllRecords('playlists');
         config_api.setConfigItem('ytdl_allow_subscriptions', true);
         config_api.setConfigItem('ytdl_subscriptions_redownload_fresh_uploads', false);
         config_api.setConfigItem('ytdl_custom_args', '');
@@ -554,6 +555,64 @@ describe('Subscriptions', function() {
         await subscriptions_api.updateSubscription(sub_update);
         const updated_sub = await db_api.getRecord('subscriptions', {id: new_sub['id']});
         assert(updated_sub['name'] === 'updated_name');
+    });
+    it('Backfills and appends to an automatic subscription playlist', async function () {
+        const sub = Object.assign({}, new_sub, {
+            id: uuid(),
+            name: 'automatic_playlist_sub',
+            auto_create_playlist: false
+        });
+        const first_file = {
+            uid: uuid(),
+            sub_id: sub.id,
+            title: 'First file',
+            thumbnailURL: 'https://example.com/first.jpg',
+            duration: 30,
+            registered: 100
+        };
+        const second_file = {
+            uid: uuid(),
+            sub_id: sub.id,
+            title: 'Second file',
+            thumbnailURL: 'https://example.com/second.jpg',
+            duration: 45,
+            registered: 200
+        };
+        const third_file = {
+            uid: uuid(),
+            sub_id: sub.id,
+            title: 'Third file',
+            thumbnailURL: 'https://example.com/third.jpg',
+            duration: 60,
+            registered: 300
+        };
+
+        await subscriptions_api.subscribe(sub, null, true);
+        await db_api.insertRecordIntoTable('files', second_file);
+        await db_api.insertRecordIntoTable('files', first_file);
+
+        const enabled_sub = Object.assign({}, sub, {auto_create_playlist: true});
+        assert.strictEqual(await subscriptions_api.updateSubscription(enabled_sub), true);
+
+        let playlists = await db_api.getRecords('playlists', {source_sub_id: sub.id});
+        assert.strictEqual(playlists.length, 1);
+        assert.strictEqual(playlists[0].name, sub.name);
+        assert.deepStrictEqual(playlists[0].uids, [first_file.uid, second_file.uid]);
+        assert.strictEqual(playlists[0].duration, 75);
+
+        await db_api.updateRecord('playlists', {id: playlists[0].id}, {
+            uids: [...playlists[0].uids, 'deleted-file']
+        });
+        await db_api.insertRecordIntoTable('files', third_file);
+        await Promise.all([
+            files_api.syncSubscriptionPlaylist(sub.id, null, third_file.uid),
+            files_api.syncSubscriptionPlaylist(sub.id, null, third_file.uid)
+        ]);
+
+        playlists = await db_api.getRecords('playlists', {source_sub_id: sub.id});
+        assert.strictEqual(playlists.length, 1);
+        assert.deepStrictEqual(playlists[0].uids, [first_file.uid, second_file.uid, third_file.uid]);
+        assert.strictEqual(playlists[0].duration, 135);
     });
     it('Update subscription property', async function () {
         await subscriptions_api.subscribe(new_sub, null, true);

--- a/src/api-types/models/Playlist.ts
+++ b/src/api-types/models/Playlist.ts
@@ -27,4 +27,8 @@ export type Playlist = {
     user_uid?: string;
     auto?: boolean;
     sharingEnabled?: boolean;
+    /**
+     * Subscription whose downloads are automatically appended to this playlist
+     */
+    source_sub_id?: string;
 };

--- a/src/api-types/models/SubscribeRequest.ts
+++ b/src/api-types/models/SubscribeRequest.ts
@@ -10,5 +10,6 @@ export type SubscribeRequest = {
     customArgs?: string;
     customFileOutput?: string;
     useSubfolder?: boolean;
+    autoCreatePlaylist?: boolean;
     maxQuality?: string;
 };

--- a/src/api-types/models/Subscription.ts
+++ b/src/api-types/models/Subscription.ts
@@ -18,6 +18,7 @@ export type Subscription = {
     custom_args?: string;
     custom_output?: string;
     use_subfolder?: boolean;
+    auto_create_playlist?: boolean;
     downloading?: boolean;
     paused?: boolean;
     refresh_status?: SubscriptionRefreshStatus;

--- a/src/app/components/media-library/media-library.component.html
+++ b/src/app/components/media-library/media-library.component.html
@@ -231,6 +231,21 @@
         }
       </mat-tab>
       <mat-tab label="Select files" i18n-label="Select files">
+        <div class="d-flex align-items-center flex-wrap mt-2 mb-3" style="gap: 12px;">
+          @if (selection_sources_received && selection_sources.length > 0) {
+            <mat-form-field appearance="outline">
+              <mat-label i18n="Playlist source filter label">Download source</mat-label>
+              <mat-select [value]="sub_id" (selectionChange)="selectionSourceChanged($event.value)">
+                <mat-option [value]="null" i18n="All download sources option">All files</mat-option>
+                @for (subscription of selection_sources; track subscription.id) {
+                  <mat-option [value]="subscription.id">{{subscription.name}}</mat-option>
+                }
+              </mat-select>
+            </mat-form-field>
+          }
+          <button mat-stroked-button type="button" (click)="selectAllAvailableFiles()" [disabled]="!paged_data?.length || allAvailableFilesSelected()" i18n="Select all playlist files button">Select all files</button>
+          <button mat-stroked-button type="button" (click)="clearFileSelection()" [disabled]="selected_data.length === 0" i18n="Clear playlist selection button">Clear selection</button>
+        </div>
         @if (normal_files_received) {
           <mat-selection-list (selectionChange)="fileSelectionChanged($event)">
             @for (file of paged_data; track file.uid) {

--- a/src/app/components/media-library/media-library.component.spec.ts
+++ b/src/app/components/media-library/media-library.component.spec.ts
@@ -49,6 +49,7 @@ describe('MediaLibraryComponent', () => {
       })),
       openSnackBar: vi.fn().mockName('openSnackBar'),
       getAllFiles: vi.fn().mockName('getAllFiles').mockReturnValue(of({ files: [], file_count: 0 })),
+      getAllSubscriptions: vi.fn().mockName('getAllSubscriptions').mockReturnValue(of({ subscriptions: [] })),
       getPlaylists: vi.fn().mockName('getPlaylists').mockReturnValue(of({ playlists: [] })),
       files_changed: new BehaviorSubject(false),
       playlists_changed: new BehaviorSubject(false),
@@ -114,6 +115,55 @@ describe('MediaLibraryComponent', () => {
     expect(postsServiceStub.getAllFiles).toHaveBeenCalledWith({ by: 'registered', order: -1 }, [0, 12], null, 'both', false, null, false, []);
     expect(component.paged_data.length).toBe(2);
     expect(component.file_count).toBe(40);
+  });
+
+  it('should load the complete library in playlist selection mode', () => {
+    component.selectMode = true;
+    component.usePaginator = false;
+
+    component.getAllFiles();
+
+    expect(postsServiceStub.getAllFiles).toHaveBeenCalledWith(
+      { by: 'registered', order: -1 }, null, null, 'both', false, null, false, []
+    );
+  });
+
+  it('should filter playlist candidates by subscription source', () => {
+    component.selectMode = true;
+    component.usePaginator = false;
+
+    component.selectionSourceChanged('subscription-1');
+
+    expect(component.sub_id).toBe('subscription-1');
+    expect(postsServiceStub.getAllFiles).toHaveBeenCalledWith(
+      { by: 'registered', order: -1 }, null, null, 'both', false, 'subscription-1', false, []
+    );
+  });
+
+  it('should select hundreds of loaded playlist candidates without duplicates', () => {
+    const selection_emitter = vi.spyOn(component.fileSelectionEmitter, 'emit');
+    component.paged_data = Array.from({length: 300}, (_, index) => ({
+      uid: `file-${index}`,
+      thumbnailURL: `https://example.com/${index}.jpg`
+    })) as any;
+
+    component.selectAllAvailableFiles();
+    component.selectAllAvailableFiles();
+
+    expect(component.selected_data.length).toBe(300);
+    expect(new Set(component.selected_data).size).toBe(300);
+    expect(selection_emitter).toHaveBeenLastCalledWith({
+      new_selection: component.selected_data,
+      thumbnailURL: 'https://example.com/0.jpg'
+    });
+  });
+
+  it('should clear an empty playlist selection without requiring a thumbnail', () => {
+    const selection_emitter = vi.spyOn(component.fileSelectionEmitter, 'emit');
+
+    component.clearFileSelection();
+
+    expect(selection_emitter).toHaveBeenCalledWith({new_selection: [], thumbnailURL: null});
   });
 
   it('should append the next auto-pagination batch without duplicating files', () => {

--- a/src/app/components/media-library/media-library.component.spec.ts
+++ b/src/app/components/media-library/media-library.component.spec.ts
@@ -128,6 +128,21 @@ describe('MediaLibraryComponent', () => {
     );
   });
 
+  it('should ignore persisted library filters in playlist selection mode', () => {
+    localStorage.setItem('file_filter', JSON.stringify(['audio_only', 'favorited']));
+    fixture = TestBed.createComponent(MediaLibraryComponent);
+    component = fixture.componentInstance;
+    component.selectMode = true;
+    component.usePaginator = false;
+
+    component.ngOnInit();
+
+    expect(component.selectedFilters).toEqual([]);
+    expect(postsServiceStub.getAllFiles).toHaveBeenCalledWith(
+      { by: 'registered', order: -1 }, null, null, 'both', false, null, false, []
+    );
+  });
+
   it('should filter playlist candidates by subscription source', () => {
     component.selectMode = true;
     component.usePaginator = false;
@@ -138,6 +153,31 @@ describe('MediaLibraryComponent', () => {
     expect(postsServiceStub.getAllFiles).toHaveBeenCalledWith(
       { by: 'registered', order: -1 }, null, null, 'both', false, 'subscription-1', false, []
     );
+  });
+
+  it('should not apply an earlier source response after the source changes', () => {
+    const initial_response = new Subject<any>();
+    const filtered_response = new Subject<any>();
+    postsServiceStub.getAllFiles
+      .mockReturnValueOnce(initial_response.asObservable())
+      .mockReturnValueOnce(filtered_response.asObservable());
+    component.selectMode = true;
+    component.usePaginator = false;
+
+    component.getAllFiles();
+    component.selectionSourceChanged('subscription-1');
+    initial_response.next({files: [{uid: 'wrong-source'}], file_count: 1});
+    initial_response.complete();
+
+    expect(component.paged_data).toEqual([]);
+    expect(postsServiceStub.getAllFiles).toHaveBeenLastCalledWith(
+      { by: 'registered', order: -1 }, null, null, 'both', false, 'subscription-1', false, []
+    );
+
+    filtered_response.next({files: [{uid: 'right-source'}], file_count: 1});
+    filtered_response.complete();
+
+    expect(component.paged_data.map(file => file.uid)).toEqual(['right-source']);
   });
 
   it('should select hundreds of loaded playlist candidates without duplicates', () => {

--- a/src/app/components/media-library/media-library.component.ts
+++ b/src/app/components/media-library/media-library.component.ts
@@ -209,15 +209,22 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.refreshScrollListener();
 
+    // Playlist selection does not expose the library filter controls. Inputs are
+    // assigned after construction, so clear any persisted filters here rather than
+    // letting an invisible audio/favorite/category filter omit candidates.
+    if (this.selectMode) this.selectedFilters = [];
+
     if (this.sub_id) {
       // subscriptions can't download both audio and video (for now), so don't let users filter for these
       delete this.fileFilters['audio_only'];
       delete this.fileFilters['video_only'];
     }
 
-    this.pendingNavigationRestoreState = this.mediaLibraryNavigationState.consumePendingRestoreState(this.getCurrentRouteKey(), this.sub_id);
-    if (this.pendingNavigationRestoreState) {
-      this.applyRestoredNavigationSnapshot(this.pendingNavigationRestoreState.snapshot);
+    if (!this.selectMode) {
+      this.pendingNavigationRestoreState = this.mediaLibraryNavigationState.consumePendingRestoreState(this.getCurrentRouteKey(), this.sub_id);
+      if (this.pendingNavigationRestoreState) {
+        this.applyRestoredNavigationSnapshot(this.pendingNavigationRestoreState.snapshot);
+      }
     }
 
     const initializeLibrary = () => {
@@ -1595,6 +1602,9 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
 
   selectionSourceChanged(sub_id: string | null): void {
     this.sub_id = sub_id || null;
+    // If the previous source is still loading, its response must not repopulate the
+    // selector while the replacement request is queued.
+    this.latestFileRequestId += 1;
     this.manualPageIndex = 0;
     this.paged_data = [];
     this.normal_files_received = false;

--- a/src/app/components/media-library/media-library.component.ts
+++ b/src/app/components/media-library/media-library.component.ts
@@ -1,7 +1,7 @@
 import { Component, ElementRef, EventEmitter, HostListener, Input, NgZone, OnDestroy, OnInit, Output, ViewChild, ChangeDetectionStrategy } from '@angular/core';
 import { PostsService } from 'app/posts.services';
 import { Router } from '@angular/router';
-import { Category, DatabaseFile, DeletePlaylistResponse, FileType, FileTypeFilter, Playlist, Sort } from 'api-types';
+import { Category, DatabaseFile, DeletePlaylistResponse, FileType, FileTypeFilter, Playlist, Sort, Subscription } from 'api-types';
 import { Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, filter, take, takeUntil } from 'rxjs/operators';
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
@@ -61,7 +61,7 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
   @Input() sub_id = null;
   @Input() customHeader = null;
   @Input() selectedIndex = 1;
-  @Output() fileSelectionEmitter = new EventEmitter<{new_selection: string[], thumbnailURL: string}>();
+  @Output() fileSelectionEmitter = new EventEmitter<{new_selection: string[], thumbnailURL: string | null}>();
 
   pageSize = 10;
   paged_data: DatabaseFile[] = null;
@@ -72,6 +72,8 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
   selected_data: string[] = [];
   selected_data_objs: DatabaseFile[] = [];
   reverse_order = false;
+  selection_sources: Subscription[] = [];
+  selection_sources_received = false;
 
   // File listing (with cards)
 
@@ -219,6 +221,7 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
     }
 
     const initializeLibrary = () => {
+      if (this.selectMode) this.getSelectionSources();
       const restored_from_navigation = this.restoreLibraryFromNavigationState();
       if (!restored_from_navigation) {
         this.getAllFiles();
@@ -1577,7 +1580,54 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
       this.selected_data_objs = this.selected_data_objs.filter(e => e.uid !== value.uid);
     }
 
-    this.fileSelectionEmitter.emit({new_selection: this.selected_data, thumbnailURL: this.selected_data_objs[0].thumbnailURL});
+    this.emitFileSelection();
+  }
+
+  getSelectionSources(): void {
+    this.postsService.getAllSubscriptions().subscribe(res => {
+      this.selection_sources = res['subscriptions'] || [];
+      this.selection_sources_received = true;
+    }, () => {
+      this.selection_sources = [];
+      this.selection_sources_received = true;
+    });
+  }
+
+  selectionSourceChanged(sub_id: string | null): void {
+    this.sub_id = sub_id || null;
+    this.manualPageIndex = 0;
+    this.paged_data = [];
+    this.normal_files_received = false;
+    this.getAllFiles();
+  }
+
+  selectAllAvailableFiles(): void {
+    const selected_uids = new Set(this.selected_data);
+    for (const file of this.paged_data || []) {
+      if (selected_uids.has(file.uid)) continue;
+      selected_uids.add(file.uid);
+      this.selected_data.push(file.uid);
+      this.selected_data_objs.push(file);
+    }
+    this.emitFileSelection();
+  }
+
+  clearFileSelection(): void {
+    this.selected_data = [];
+    this.selected_data_objs = [];
+    this.emitFileSelection();
+  }
+
+  allAvailableFilesSelected(): boolean {
+    return (this.paged_data?.length ?? 0) > 0
+      && this.paged_data.every(file => this.selected_data.includes(file.uid));
+  }
+
+  private emitFileSelection(): void {
+    this.fileSelectionEmitter.emit({
+      new_selection: this.selected_data,
+      thumbnailURL: this.selected_data_objs[0]?.thumbnailURL ?? null
+    });
   }
 
   toggleSelectionOrder(): void {
@@ -1592,7 +1642,7 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
     }
     moveItemInArray(this.selected_data, event.previousIndex, event.currentIndex);
     moveItemInArray(this.selected_data_objs, event.previousIndex, event.currentIndex);
-    this.fileSelectionEmitter.emit({new_selection: this.selected_data, thumbnailURL: this.selected_data_objs[0].thumbnailURL});
+    this.emitFileSelection();
   }
 
   removeSelectedFile(index: number): void {
@@ -1601,7 +1651,7 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
     }
     this.selected_data.splice(index, 1);
     this.selected_data_objs.splice(index, 1);
-    this.fileSelectionEmitter.emit({new_selection: this.selected_data, thumbnailURL: this.selected_data_objs[0].thumbnailURL});
+    this.emitFileSelection();
   }
 
   toggleFavorite(file_obj): void {

--- a/src/app/create-playlist/create-playlist.component.html
+++ b/src/app/create-playlist/create-playlist.component.html
@@ -15,7 +15,7 @@
             <input [(ngModel)]="name" matInput type="text" required aria-required [ngModelOptions]="{standalone: true}">
           </mat-form-field>
         </div>
-        <app-media-library [selectMode]="true" [defaultSelected]="preselected_files" [customHeader]="'Select files'" (fileSelectionEmitter)="fileSelectionChanged($event)" [selectedIndex]="create_mode ? 1 : 0"></app-media-library>
+        <app-media-library [selectMode]="true" [usePaginator]="false" [defaultSelected]="preselected_files" [customHeader]="'Select files'" (fileSelectionEmitter)="fileSelectionChanged($event)" [selectedIndex]="create_mode ? 1 : 0"></app-media-library>
       </div>
     }
   </form>

--- a/src/app/create-playlist/create-playlist.component.ts
+++ b/src/app/create-playlist/create-playlist.component.ts
@@ -20,7 +20,7 @@ export class CreatePlaylistComponent implements OnInit {
   audiosToSelectFrom = null;
   videosToSelectFrom = null;
   name = '';
-  cached_thumbnail_url = null;
+  cached_thumbnail_url: string | null = null;
 
   create_in_progress = false;
   create_mode = false;
@@ -82,7 +82,7 @@ export class CreatePlaylistComponent implements OnInit {
     return this.cached_thumbnail_url;
   }
 
-  fileSelectionChanged({new_selection, thumbnailURL}: {new_selection: string[], thumbnailURL: string}): void {
+  fileSelectionChanged({new_selection, thumbnailURL}: {new_selection: string[], thumbnailURL: string | null}): void {
     this.filesSelect.setValue(new_selection);
     if (new_selection.length) this.cached_thumbnail_url = thumbnailURL;
     else                      this.cached_thumbnail_url = null;

--- a/src/app/dialogs/edit-subscription-dialog/edit-subscription-dialog.component.html
+++ b/src/app/dialogs/edit-subscription-dialog/edit-subscription-dialog.component.html
@@ -14,6 +14,9 @@
       <div class="col-12 mt-3">
         <mat-checkbox [(ngModel)]="new_sub.use_subfolder"><ng-container i18n="Use subscription name folder setting">Save downloads in subscription name folder</ng-container></mat-checkbox>
       </div>
+      <div class="col-12 mt-3">
+        <mat-checkbox [(ngModel)]="new_sub.auto_create_playlist"><ng-container i18n="Automatic subscription playlist setting">Automatically add downloads to a playlist</ng-container></mat-checkbox>
+      </div>
       @if (editor_initialized) {
         <div class="col-12">
           <ng-container i18n="Download time range prefix">Download videos uploaded in the last</ng-container>

--- a/src/app/dialogs/edit-subscription-dialog/edit-subscription-dialog.component.ts
+++ b/src/app/dialogs/edit-subscription-dialog/edit-subscription-dialog.component.ts
@@ -67,6 +67,8 @@ export class EditSubscriptionDialogComponent implements OnInit {
     this.new_sub = JSON.parse(JSON.stringify(this.sub));
     this.sub.use_subfolder = this.sub.use_subfolder !== false;
     this.new_sub.use_subfolder = this.new_sub.use_subfolder !== false;
+    this.sub.auto_create_playlist = this.sub.auto_create_playlist === true;
+    this.new_sub.auto_create_playlist = this.new_sub.auto_create_playlist === true;
 
     // ignore videos to keep requests small
     delete this.sub['videos'];

--- a/src/app/dialogs/subscribe-dialog/subscribe-dialog.component.html
+++ b/src/app/dialogs/subscribe-dialog/subscribe-dialog.component.html
@@ -28,6 +28,9 @@
         <mat-checkbox [(ngModel)]="useSubfolder"><ng-container i18n="Use subscription name folder setting">Save downloads in subscription name folder</ng-container></mat-checkbox>
       </div>
       <div class="col-12">
+        <mat-checkbox [(ngModel)]="autoCreatePlaylist"><ng-container i18n="Automatic subscription playlist setting">Automatically add downloads to a playlist</ng-container></mat-checkbox>
+      </div>
+      <div class="col-12">
         <span i18n="Download time range prefix">Download videos uploaded in the last</span>
         <div>
           <mat-form-field color="accent" style="width: 100px; text-align: center;">

--- a/src/app/dialogs/subscribe-dialog/subscribe-dialog.component.spec.ts
+++ b/src/app/dialogs/subscribe-dialog/subscribe-dialog.component.spec.ts
@@ -1,7 +1,9 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { of } from 'rxjs';
 
 import { SubscribeDialogComponent } from './subscribe-dialog.component';
 import { configureTestBed } from '../../../testing/test-bed';
+import { PostsService } from 'app/posts.services';
 
 describe('SubscribeDialogComponent', () => {
   let component: SubscribeDialogComponent;
@@ -22,5 +24,26 @@ describe('SubscribeDialogComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should include the automatic playlist option when subscribing', () => {
+    const postsService = TestBed.inject(PostsService) as any;
+    postsService.createSubscription = vi.fn().mockReturnValue(of({new_sub: {id: 'subscription-1'}}));
+    component.url = 'https://example.com/channel';
+    component.autoCreatePlaylist = true;
+
+    component.subscribeClicked();
+
+    expect(postsService.createSubscription).toHaveBeenCalledWith(
+      component.url,
+      component.name,
+      null,
+      component.maxQuality,
+      component.audioOnlyMode,
+      component.customArgs,
+      component.customFileOutput,
+      component.useSubfolder,
+      true
+    );
   });
 });

--- a/src/app/dialogs/subscribe-dialog/subscribe-dialog.component.ts
+++ b/src/app/dialogs/subscribe-dialog/subscribe-dialog.component.ts
@@ -16,6 +16,7 @@ export class SubscribeDialogComponent implements OnInit {
   timerange_unit = 'days';
   download_all = true;
   useSubfolder = true;
+  autoCreatePlaylist = false;
   url = null;
   name = null;
 
@@ -89,7 +90,8 @@ export class SubscribeDialogComponent implements OnInit {
         timerange = 'now-' + this.timerange_amount.toString() + this.timerange_unit;
       }
       this.postsService.createSubscription(this.url, this.name, timerange, this.maxQuality,
-                                          this.audioOnlyMode, this.customArgs, this.customFileOutput, this.useSubfolder).subscribe(res => {
+                                          this.audioOnlyMode, this.customArgs, this.customFileOutput, this.useSubfolder,
+                                          this.autoCreatePlaylist).subscribe(res => {
         this.subscribing = false;
         if (res['new_sub']) {
           this.dialogRef.close(res['new_sub']);

--- a/src/app/posts.services.ts
+++ b/src/app/posts.services.ts
@@ -663,9 +663,10 @@ export class PostsService {
         return this.http.post<DeletePlaylistResponse>(this.path + 'deletePlaylist', body, this.httpOptions);
     }
 
-    createSubscription(url, name, timerange = null, maxQuality = 'best', audioOnly = false, customArgs: string = null, customFileOutput: string = null, useSubfolder = true) {
+    createSubscription(url, name, timerange = null, maxQuality = 'best', audioOnly = false, customArgs: string = null, customFileOutput: string = null, useSubfolder = true, autoCreatePlaylist = false) {
         const body: SubscribeRequest = {url: url, name: name, timerange: timerange, maxQuality: maxQuality,
-            audioOnly: audioOnly, customArgs: customArgs, customFileOutput: customFileOutput, useSubfolder: useSubfolder};
+            audioOnly: audioOnly, customArgs: customArgs, customFileOutput: customFileOutput, useSubfolder: useSubfolder,
+            autoCreatePlaylist: autoCreatePlaylist};
         return this.http.post<SubscribeResponse>(this.path + 'subscribe', body, this.httpOptions);
     }
     


### PR DESCRIPTION
## Summary

- add an opt-in automatic playlist setting to subscription creation and editing
- create or backfill a channel-named playlist, then append completed subscription downloads idempotently
- serialize concurrent download completions and prune stale playlist entries during synchronization
- load the complete library in the playlist editor and add subscription-source filtering, Select all files, and Clear selection actions
- ignore hidden persisted library filters and stale responses while switching sources
- clean up managed playlists on unsubscribe while preserving and detaching any custom entries

## Testing

- npx ng test --watch=false — 280 passing
- npm test in backend — 558 passing, 52 environment-dependent tests pending
- npm run lint -- --quiet
- focused backend ESLint checks
- npm run build

Closes #399