### PR TITLE
fix(subscriptions): confirm and cancel archive downloads

### DIFF
--- a/src/app/subscription/subscription/subscription.component.html
+++ b/src/app/subscription/subscription/subscription.component.html
@@ -68,8 +68,14 @@
     </div>
 
     <button class="watch-button" color="primary" (click)="watchSubscription()" matTooltip="Play all" i18n-matTooltip="Play all" mat-fab><mat-icon class="save-icon">video_library</mat-icon></button>
-    <button class="save-button" color="primary" (click)="downloadContent()" [disabled]="downloading" matTooltip="Download zip" i18n-matTooltip="Download zip" mat-fab><mat-icon class="save-icon">save</mat-icon>@if (downloading) {
-      <mat-spinner class="spinner" [diameter]="50"></mat-spinner>
-    }</button>
+    @if (!downloading) {
+      <button class="save-button" color="primary" (click)="downloadContent()" matTooltip="Download zip" i18n-matTooltip="Download zip" aria-label="Download subscription as a zip" i18n-aria-label="Download subscription zip label" mat-fab><mat-icon class="save-icon">save</mat-icon></button>
+    }
+    @if (downloading) {
+      <button class="save-button" color="primary" (click)="cancelSubscriptionDownload()" matTooltip="Cancel subscription download" i18n-matTooltip="Cancel subscription download" aria-label="Cancel subscription download" i18n-aria-label="Cancel subscription download label" mat-fab>
+        <mat-icon class="save-icon">cancel</mat-icon>
+        <mat-spinner class="spinner" [diameter]="50"></mat-spinner>
+      </button>
+    }
   }
 </div>

--- a/src/app/subscription/subscription/subscription.component.spec.ts
+++ b/src/app/subscription/subscription/subscription.component.spec.ts
@@ -6,6 +6,7 @@ describe('SubscriptionComponent', () => {
   let component: SubscriptionComponent;
   let postsService: any;
   let router: any;
+  let dialog: any;
 
   beforeEach(() => {
     postsService = {
@@ -33,9 +34,66 @@ describe('SubscriptionComponent', () => {
     router = {
       navigate: vi.fn().mockName('navigate')
     };
+    dialog = {
+      open: vi.fn().mockName('open')
+    };
 
-    component = new SubscriptionComponent(postsService, { params: of({ id: 'sub-1' }) } as any, router, { open: vi.fn().mockName('open') } as any);
+    component = new SubscriptionComponent(postsService, { params: of({ id: 'sub-1' }) } as any, router, dialog);
     component.id = 'sub-1';
+  });
+
+  it('should confirm before preparing a subscription archive', () => {
+    component.subscription = {
+      id: 'sub-1',
+      name: 'Test subscription',
+      file_count: 125
+    } as any;
+    dialog.open.mockReturnValue({afterClosed: () => of(false)});
+
+    component.downloadContent();
+
+    expect(dialog.open).toHaveBeenCalledWith(expect.any(Function), {
+      data: {
+        dialogTitle: 'Download subscription?',
+        dialogText: expect.stringContaining('125 files from Test subscription'),
+        submitText: 'Download'
+      }
+    });
+    expect(postsService.downloadSubFromServer).not.toHaveBeenCalled();
+  });
+
+  it('should start preparing the archive after confirmation', () => {
+    component.subscription = {
+      id: 'sub-1',
+      name: 'Test subscription',
+      file_count: 2
+    } as any;
+    dialog.open.mockReturnValue({afterClosed: () => of(true)});
+    postsService.downloadSubFromServer.mockReturnValue(new Subject<Blob>());
+
+    component.downloadContent();
+
+    expect(postsService.downloadSubFromServer).toHaveBeenCalledWith('sub-1');
+    expect(component.downloading).toBe(true);
+  });
+
+  it('should cancel an in-progress subscription archive request', () => {
+    const archive_response = new Subject<Blob>();
+    component.subscription = {
+      id: 'sub-1',
+      name: 'Test subscription',
+      file_count: 2
+    } as any;
+    postsService.downloadSubFromServer.mockReturnValue(archive_response);
+    component.startSubscriptionDownload();
+    const unsubscribe_spy = vi.spyOn(component.archiveDownloadSubscription, 'unsubscribe');
+
+    component.cancelSubscriptionDownload();
+
+    expect(unsubscribe_spy).toHaveBeenCalled();
+    expect(component.archiveDownloadSubscription).toBeNull();
+    expect(component.downloading).toBe(false);
+    expect(postsService.openSnackBar).toHaveBeenCalledWith('Subscription download cancelled.');
   });
 
   it('should preserve the existing videos array during low-cost refresh polling', () => {

--- a/src/app/subscription/subscription/subscription.component.ts
+++ b/src/app/subscription/subscription/subscription.component.ts
@@ -3,8 +3,10 @@ import { PostsService } from 'app/posts.services';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 import { EditSubscriptionDialogComponent } from 'app/dialogs/edit-subscription-dialog/edit-subscription-dialog.component';
+import { ConfirmDialogComponent } from 'app/dialogs/confirm-dialog/confirm-dialog.component';
 import { Subscription, SubscriptionRefreshStatus } from 'api-types';
 import { saveAs } from 'file-saver';
+import { Subscription as RxSubscription } from 'rxjs';
 import { filter, finalize, take } from 'rxjs/operators';
 
 @Component({
@@ -23,6 +25,7 @@ export class SubscriptionComponent implements OnInit, OnDestroy {
   use_youtubedl_archive = false;
   descendingMode = true;
   downloading = false;
+  archiveDownloadSubscription: RxSubscription | null = null;
   sub_interval = null;
   check_clicked = false;
   cancel_clicked = false;
@@ -54,6 +57,9 @@ export class SubscriptionComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
+    this.archiveDownloadSubscription?.unsubscribe();
+    this.archiveDownloadSubscription = null;
+
     // prevents subscription getter from running in the background
     if (this.sub_interval) {
       clearInterval(this.sub_interval);
@@ -122,15 +128,44 @@ export class SubscriptionComponent implements OnInit, OnDestroy {
   }
 
   downloadContent(): void {
-    this.downloading = true;
-    this.postsService.downloadSubFromServer(this.subscription.id).subscribe(res => {
-      this.downloading = false;
-      const blob: Blob = res;
-      saveAs(blob, this.subscription.name + '.zip');
-    }, err => {
-      console.log(err);
-      this.downloading = false;
+    if (this.downloading) return;
+
+    const file_count = this.getSubscriptionFileCount(this.subscription);
+    const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+      data: {
+        dialogTitle: $localize`Download subscription?`,
+        dialogText: $localize`Download all ${file_count}:subscription file count: files from ${this.subscription.name}:subscription name: as a zip? Creating the archive can take a while and use significant disk space.`,
+        submitText: $localize`Download`
+      }
     });
+
+    dialogRef.afterClosed().pipe(take(1)).subscribe(confirmed => {
+      if (confirmed) this.startSubscriptionDownload();
+    });
+  }
+
+  startSubscriptionDownload(): void {
+    const zip_name = this.subscription.name;
+    this.downloading = true;
+    this.archiveDownloadSubscription = this.postsService.downloadSubFromServer(this.subscription.id).subscribe(res => {
+      this.downloading = false;
+      this.archiveDownloadSubscription = null;
+      const blob: Blob = res;
+      saveAs(blob, zip_name + '.zip');
+    }, err => {
+      console.error(err);
+      this.downloading = false;
+      this.archiveDownloadSubscription = null;
+    });
+  }
+
+  cancelSubscriptionDownload(): void {
+    if (!this.downloading) return;
+
+    this.archiveDownloadSubscription?.unsubscribe();
+    this.archiveDownloadSubscription = null;
+    this.downloading = false;
+    this.postsService.openSnackBar($localize`Subscription download cancelled.`);
   }
 
   editSubscription(): void {


### PR DESCRIPTION
Follow-up to #398 and #405. The original fix covered custom playlist archives but missed the separate archive action on subscription pages.

## Summary

- ask for confirmation before preparing a subscription ZIP
- show a cancel action while the archive request is active
- unsubscribe on cancellation or page teardown so the backend aborts archive creation and removes partial output
- cover decline, confirmation, and cancellation behavior

## Testing

- npm run test:headless (283 passing)
- npm run build
- focused ESLint check