### PR TITLE
fix(deps): declare @discordjs/rest and js-yaml in the backend

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@discordjs/builders": "^1.14.1",
         "@discordjs/core": "^2.6.0",
+        "@discordjs/rest": "^2.6.3",
         "@scalar/express-api-reference": "^0.10.11",
         "archiver": "^8.0.0",
         "async": "^3.2.3",
@@ -60,6 +61,7 @@
       },
       "devDependencies": {
         "c8": "^12.0.0",
+        "js-yaml": "4.3.1",
         "pg-mem": "^3.0.14",
         "supertest": "^7.2.2"
       },

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@discordjs/builders": "^1.14.1",
     "@discordjs/core": "^2.6.0",
+    "@discordjs/rest": "^2.6.3",
     "@scalar/express-api-reference": "^0.10.11",
     "archiver": "^8.0.0",
     "async": "^3.2.3",
@@ -85,6 +86,7 @@
   },
   "devDependencies": {
     "c8": "^12.0.0",
+    "js-yaml": "4.3.1",
     "pg-mem": "^3.0.14",
     "supertest": "^7.2.2"
   }


### PR DESCRIPTION
## What

Two modules are `require`d directly by backend code but were never declared in `backend/package.json`. They resolve today only because npm hoists them in as transitive dependencies of other packages.

| Module | Required by | Arrives via |
| --- | --- | --- |
| `@discordjs/rest` | `backend/notifications.js:12` | `@discordjs/core` |
| `js-yaml` | `backend/test/route-guards.test.js:164`, `backend/test/api-hardening.test.js:1397` | `mocha`, `xmlbuilder2` |

Neither provider is obliged to keep supplying them. If `@discordjs/core` drops or bumps `@discordjs/rest` in a future release, Discord notifications break at require time with no change on our side; the same applies to the test suite if `mocha` drops `js-yaml`.

## Changes

- `@discordjs/rest` added to `dependencies` as `^2.6.3` (the version already resolved).
- `js-yaml` added to `devDependencies` as `4.3.1` — it is only used by tests.

`js-yaml` is pinned exactly rather than as a caret range because `overrides` already pins it to `4.3.1`, and npm refuses the install outright when a direct range contradicts its own override:

```
npm error code EOVERRIDE
npm error Override for js-yaml@^4.3.1 conflicts with direct dependency
```

The exact pin keeps the existing supply-chain pin intact and matches how `multer` is already declared in this file.

## Verification

- `npm install` in `backend/` resolves clean — no version changes, both modules now recorded as direct dependencies in the lockfile.
- `require.resolve` confirms both still resolve, and `notifications.js` loads.
- `npx mocha test/route-guards.test.js test/api-hardening.test.js` — **143 passing**.

No dependency versions changed; the diff is 2 lines of `package.json` plus the matching lockfile entries.

---

*Follow-up: moving `mocha` out of `dependencies` is handled separately, since it was not part of this merge.*