### PR TITLE
chore(release): bump version to 1.1.1

### DIFF
--- a/backend/consts.js
+++ b/backend/consts.js
@@ -491,4 +491,4 @@ exports.SUBSCRIPTION_BACKUP_PATH = 'subscription_backup.json'
 // we're using a Set here for performance
 exports.YTDL_ARGS_WITH_VALUES = new Set(YTDL_ARGS_WITH_VALUES);
 
-exports.CURRENT_VERSION = 'v1.1.0';
+exports.CURRENT_VERSION = 'v1.1.1';

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@discordjs/builders": "^1.14.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "backend for ytdl-material",
   "main": "index.js",
   "scripts": {

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.1.0"
+appVersion: "1.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ytdl-material",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ytdl-material",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^22.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ytdl-material",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/consts.ts
+++ b/src/app/consts.ts
@@ -1,1 +1,1 @@
-export const CURRENT_VERSION = 'v1.1.0';
+export const CURRENT_VERSION = 'v1.1.1';


### PR DESCRIPTION
Version bump for v1.1.1. Same seven files as the v1.1.0 bump (`719bd322`): both `package.json`s and lockfiles, `backend/consts.js`, `src/app/consts.ts`, and `chart/Chart.yaml` (`version` and `appVersion`).

## Why patch rather than minor

Two features landed, but this project reserves a minor for changes that break existing callers — the v1.1.0 bump commit justified itself that way, and v1.0.10 was a patch that added the yt-dlp update channel.

Nothing here qualifies. Automatic subscription playlists are off unless enabled per subscription, the playlist file count is display only, and no route, response shape or config key changed. Upgrading needs no action.

## Contents

13 PRs since v1.1.0 — two features (#402, #406), four fixes (#396, #403, #405, #407), and dependency work (#404, #408–#413).

## Verification

- Frontend `npm run test:headless` — **283 passing** across 48 files.
- Backend `npm test` — **558 passing**, 52 pending.
- No stray `1.1.0` left in the bumped files; the only remaining match is the unrelated `gotify: ^1.1.0` range.

## After merging

Release notes are drafted and ready. Tagging is left to you — `build.yml` creates the release from the tag and dispatches `docker-release`, which pushes images.