### PR TITLE
chore(deps): refresh frontend lockfile to satisfy declared ranges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -145,9 +145,9 @@
       }
     },
     "node_modules/@angular/animations": {
-      "version": "22.1.3",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-22.1.3.tgz",
-      "integrity": "sha512-EgL1BrPcn3yaRamr/R9NlYlV6hZzzKRGxVp/cnfkYzzWKG4Wcno7lkGEo6eA2Vry66AJuXUu4M1BMyhHJ96zzg==",
+      "version": "22.1.4",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-22.1.4.tgz",
+      "integrity": "sha512-DZqSHhmSRBVfLlrFxNLQj6PYVhu1w8vj1iUdD6fmlhfGGafuiw/VcUpBgYmy2YNcXmGmwbZsKr1oeJP7fT8zNQ==",
       "deprecated": "@angular/animations is deprecated. Use `animate.enter` and `animate.leave` instead. For more information see: https://v22.angular.dev/guide/animations.",
       "license": "MIT",
       "dependencies": {
@@ -157,7 +157,7 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "22.1.3"
+        "@angular/core": "22.1.4"
       }
     },
     "node_modules/@angular/build": {
@@ -268,9 +268,9 @@
       }
     },
     "node_modules/@angular/cdk": {
-      "version": "22.1.3",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-22.1.3.tgz",
-      "integrity": "sha512-6N3S71J877j9zGpCqU0PDIP4AGQf+SjJrA1Pouy+xfC8GE8sfCyIVr0Y6qnpxr5D2k2lROykAMbQekZtKEiEeA==",
+      "version": "22.1.4",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-22.1.4.tgz",
+      "integrity": "sha512-//KICh/rxeLbYLgNj8HawaliVAPNlSV0aRmki45Tf/YhoXVhzon9DfFqCs5u1cLvmMkMTHdFm5ghGTB8SUv3DA==",
       "license": "MIT",
       "dependencies": {
         "parse5": "^8.0.0",
@@ -315,9 +315,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "22.1.3",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-22.1.3.tgz",
-      "integrity": "sha512-QtMkjhiRd0EnmKR50bw3WbCWYTi6CmA72nnSz1BLQPpaLSi2goloCrPPniHz8fP+w2ESrmmlOWxs1Da3COgnQg==",
+      "version": "22.1.4",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-22.1.4.tgz",
+      "integrity": "sha512-UtWCloA/d0I5twV9Lu/Fcc7T6uQb40f/k0Hj5HLohIsiLTyvXVxWINBfa7LWWLtcq/0UOIY/yCs9Zq9Sj4dWqA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -326,14 +326,14 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "22.1.3",
+        "@angular/core": "22.1.4",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "22.1.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-22.1.3.tgz",
-      "integrity": "sha512-L8Mw2r7bGG/obqgQC+RU3mdFJ3NtLgO5gWhEC1ylcHpLCMPIAXYsMKJIL8dnS78S1wXo/omXwmJ4FiIlCwWahg==",
+      "version": "22.1.4",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-22.1.4.tgz",
+      "integrity": "sha512-o+W0shjR5KmPPWchFmqN9bLINYAy14zIW//g9T5WqKDMOqjt4IbeY6AKOoE1db/dXffprLEH9nyPOmi19iKNxg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -343,9 +343,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "22.1.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-22.1.3.tgz",
-      "integrity": "sha512-37lLaDp0RHWZ/lmJqCmIEr0HOM2D5ulHy61gqTBm7KRj3Y6ZaxR8B/JqZmeIpPzKFILVsga+NQ4A8apBUkmezw==",
+      "version": "22.1.4",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-22.1.4.tgz",
+      "integrity": "sha512-h9CcVG614TJLbk+dswlzSjYARYJh2MLOEwcnpt9zUGtOffhrrSS9BFJGjSwzdDSVM3J5mvf5ZuW+0hPAuRRoOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -366,7 +366,7 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "22.1.3",
+        "@angular/compiler": "22.1.4",
         "typescript": ">=6.0 <6.1"
       },
       "peerDependenciesMeta": {
@@ -376,9 +376,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "22.1.3",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-22.1.3.tgz",
-      "integrity": "sha512-313+Xkf970AmStJE0E/zNJW/9xvDExQG+6TNltBBl+KJsW0q5dffK2w2PQfV4mtTquBqYoeHSRsms4WgjBKL8g==",
+      "version": "22.1.4",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-22.1.4.tgz",
+      "integrity": "sha512-0dW+lw8nHo6RGBUOXtjs02vjHIPJ8rEbw4fd0NH3Dii4p+gIB4ZaTw+o7Se3Nf4m1oZ8+2qAYmWVHXlfhKcCDg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -387,7 +387,7 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "22.1.3",
+        "@angular/compiler": "22.1.4",
         "rxjs": "^6.5.3 || ^7.4.0",
         "zone.js": "~0.15.0 || ~0.16.0"
       },
@@ -401,9 +401,9 @@
       }
     },
     "node_modules/@angular/forms": {
-      "version": "22.1.3",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-22.1.3.tgz",
-      "integrity": "sha512-b4ual9pgfNqcnEHord50w960DDFIytG3Qb3bu2aCgzmagvRlg9wrtwQNqY+oqY2FVq7c9McNUN7MZRcWl9HNdQ==",
+      "version": "22.1.4",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-22.1.4.tgz",
+      "integrity": "sha512-w8ZXe4oURrb/DS5zAFrR4AmGXC84sdLeOKXRM76ndRRgSCzyRLEe4wDU1KHnDejNVIGvoSZYJJjOajG1lpj8TA==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -414,16 +414,16 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "22.1.3",
-        "@angular/core": "22.1.3",
-        "@angular/platform-browser": "22.1.3",
+        "@angular/common": "22.1.4",
+        "@angular/core": "22.1.4",
+        "@angular/platform-browser": "22.1.4",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/language-service": {
-      "version": "22.1.3",
-      "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-22.1.3.tgz",
-      "integrity": "sha512-Nc5cHyuYTTH9uENTSmJFiqR85xPGFkpOwxN6Ms2qlqz767FyOXna0iqw2DprNRB1+xG/WtP4RbCI6ofyXHbM0w==",
+      "version": "22.1.4",
+      "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-22.1.4.tgz",
+      "integrity": "sha512-ptl9fz3VKeZjv44Baps0NIkt91lkhTOQBBruGePqaBbInfU3KQWJoHasYPCUNl8NpyKm+EtMLMf5w/xOIDjk+Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -431,9 +431,9 @@
       }
     },
     "node_modules/@angular/localize": {
-      "version": "22.1.3",
-      "resolved": "https://registry.npmjs.org/@angular/localize/-/localize-22.1.3.tgz",
-      "integrity": "sha512-/u0nCz2AY+RXB4HUdw3Y7C/ZiierPPmUuWR/nDPCylHwllVdMKpi6PPtKvfzgM5ZvaISzDghTVykOVjU7obMhg==",
+      "version": "22.1.4",
+      "resolved": "https://registry.npmjs.org/@angular/localize/-/localize-22.1.4.tgz",
+      "integrity": "sha512-U9Kq6b/JuSQBEmkpwlspbPHb5/Z2ZOEOBbgeZWOytmAud2FIYR9kW6mcyXbYNRbB4Jnv3GzNrP8avbCMG984PQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "8.0.1",
@@ -449,20 +449,20 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "22.1.3",
-        "@angular/compiler-cli": "22.1.3"
+        "@angular/compiler": "22.1.4",
+        "@angular/compiler-cli": "22.1.4"
       }
     },
     "node_modules/@angular/material": {
-      "version": "22.1.3",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-22.1.3.tgz",
-      "integrity": "sha512-JNIhfEzJBc3WgOb2lPX4EBc/SE67Q7W0WL6U0nf7ahGwS4sce9yapbZoe3AE7zRCl8oiRbe346SwL0bFyxGHmA==",
+      "version": "22.1.4",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-22.1.4.tgz",
+      "integrity": "sha512-d4+uajpIYmyjar/4dypd5L+z8pbgkaCOsSxsrslmE0o0wK7mfFvXCkn0wwfucey5yUHXjswlKu1X5RzJZLOZ+w==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/cdk": "22.1.3",
+        "@angular/cdk": "22.1.4",
         "@angular/common": "^22.0.0 || ^23.0.0",
         "@angular/core": "^22.0.0 || ^23.0.0",
         "@angular/forms": "^22.0.0 || ^23.0.0",
@@ -471,9 +471,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "22.1.3",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-22.1.3.tgz",
-      "integrity": "sha512-A8McE6AclwZa2ese4jMfZZu+qZfBFQ4Hl6CaMpzJ1C6Vv6+sXkLu9pouTosJEsUE+etVdepDsqau90lhzgw3Eg==",
+      "version": "22.1.4",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-22.1.4.tgz",
+      "integrity": "sha512-zhEWnRShG6GjnEvCVROD68XfnrV6+HJ9bPjwZx4LsAz7spX823Nhiml8Uqpvijsa1w7UdWLU7nK/magr9IEMOQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -482,9 +482,9 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "22.1.3",
-        "@angular/common": "22.1.3",
-        "@angular/core": "22.1.3"
+        "@angular/animations": "22.1.4",
+        "@angular/common": "22.1.4",
+        "@angular/core": "22.1.4"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -493,9 +493,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "22.1.3",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-22.1.3.tgz",
-      "integrity": "sha512-dXI8U7C4QZOvWIA2VWPFjGQjJ6ceHlYRkShdvaluKmml6CxxPPvirjwQGj+G/syfAaArSzLijK4hM9xDuMo41w==",
+      "version": "22.1.4",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-22.1.4.tgz",
+      "integrity": "sha512-gtaQ05csHot468owe3AOXJYd2/VPlIQFr3tyXV8O2vhkfTokAyynpaMLc2q7EWbrDDuMvzETR2sBKBhgqIul+A==",
       "deprecated": "@angular/platform-browser-dynamic is deprecated. Use `@angular/platform-browser` instead.",
       "license": "MIT",
       "dependencies": {
@@ -505,16 +505,16 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "22.1.3",
-        "@angular/compiler": "22.1.3",
-        "@angular/core": "22.1.3",
-        "@angular/platform-browser": "22.1.3"
+        "@angular/common": "22.1.4",
+        "@angular/compiler": "22.1.4",
+        "@angular/core": "22.1.4",
+        "@angular/platform-browser": "22.1.4"
       }
     },
     "node_modules/@angular/router": {
-      "version": "22.1.3",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-22.1.3.tgz",
-      "integrity": "sha512-23owvZKCpdL7Yh3EzBj4OLf3x0z+jT9b57Qk96wdwI8Lsyf9L78/RJPYCutJ5r+zq3pFM/BHVKyd+2hkfH7N6Q==",
+      "version": "22.1.4",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-22.1.4.tgz",
+      "integrity": "sha512-vCwJLRnFBSRH5LxSF8OXKBhdmJ526hVGb/5sfeLTQW/oWCdcfXb2RvHfB077m5cdqKX9sBwFVlkJ8Z8kgx/pLQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -523,9 +523,9 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "22.1.3",
-        "@angular/core": "22.1.3",
-        "@angular/platform-browser": "22.1.3",
+        "@angular/common": "22.1.4",
+        "@angular/core": "22.1.4",
+        "@angular/platform-browser": "22.1.4",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -1745,16 +1745,16 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.2.tgz",
-      "integrity": "sha512-Y5/bAScMy5Y+9isCx0SKbyJebMCaXXX5em0kxkj115eZNscgV9srOHrgyfS0e5xAVymIfOh9piYBKDILktsMMg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.3.tgz",
+      "integrity": "sha512-XEYX2WA8SBkLPczL6/yXPHLPCvDoptmh9v56Cy05BSV1Smk1vWy19bTC4qJBuIffw7+6l4CcaYYzGqG60RfW1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.0",
+        "@inquirer/core": "^12.0.1",
         "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.0.7"
+        "@inquirer/type": "^4.1.0"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -1769,15 +1769,15 @@
       }
     },
     "node_modules/@inquirer/checkbox/node_modules/@inquirer/core": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.0.tgz",
-      "integrity": "sha512-+nnvFEXIB08CZNVXpvW3B+zHW96QXvGUjNKJ8NJIPqAZi5Kd4WhYt2S3C234ReepG1qw2HOlEUbjYVHBowXObA==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-JMD5Jy/ScL5TZE18m83Nw25HjqGFLoWXwnEkW7IdwwAhZpB9Bus55/WU7zn3UqR1MOCjjTQOIYpiD4vjWA3LPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.7",
         "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.0.7",
+        "@inquirer/type": "^4.1.0",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
@@ -1845,15 +1845,15 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.0.tgz",
-      "integrity": "sha512-nnsP/IdJ8s83q7ZuObmgn12QM+uLCkab9E0Oordojbn62WUg1c+v9Ou/F/057pgh0ppX0W+Hj5bO/Dp5hsxQtA==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.1.tgz",
+      "integrity": "sha512-y43COoyVUjPWIobn2Qep/uI1drPS78aaZZZ9kVi94Tyu/GuW2N8d8Q4rifJXGAXCEAXCPTTMjD8gC1HyvM5ukA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.0",
+        "@inquirer/core": "^12.0.1",
         "@inquirer/external-editor": "^3.0.4",
-        "@inquirer/type": "^4.0.7"
+        "@inquirer/type": "^4.1.0"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -1868,15 +1868,15 @@
       }
     },
     "node_modules/@inquirer/editor/node_modules/@inquirer/core": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.0.tgz",
-      "integrity": "sha512-+nnvFEXIB08CZNVXpvW3B+zHW96QXvGUjNKJ8NJIPqAZi5Kd4WhYt2S3C234ReepG1qw2HOlEUbjYVHBowXObA==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-JMD5Jy/ScL5TZE18m83Nw25HjqGFLoWXwnEkW7IdwwAhZpB9Bus55/WU7zn3UqR1MOCjjTQOIYpiD4vjWA3LPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.7",
         "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.0.7",
+        "@inquirer/type": "^4.1.0",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
@@ -1895,14 +1895,14 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.2.tgz",
-      "integrity": "sha512-OWIH1IyyWqEKIyqC9Xy+Bnga7NkGMovFdo4atYZMUOTRqf6rO2WCv9E/1MyzvOErDBCxs+9UFliRUDc50xs/jw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.3.tgz",
+      "integrity": "sha512-3NQJiXNJ/aj9wiAsr7pECdp5Qe9J0X9YUJCKsaFXS+ddOxfL6J4AIl3w3T4Gq3kK0WsQY5GMoDokK5X94m6lHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.0",
-        "@inquirer/type": "^4.0.7"
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -1917,15 +1917,15 @@
       }
     },
     "node_modules/@inquirer/expand/node_modules/@inquirer/core": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.0.tgz",
-      "integrity": "sha512-+nnvFEXIB08CZNVXpvW3B+zHW96QXvGUjNKJ8NJIPqAZi5Kd4WhYt2S3C234ReepG1qw2HOlEUbjYVHBowXObA==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-JMD5Jy/ScL5TZE18m83Nw25HjqGFLoWXwnEkW7IdwwAhZpB9Bus55/WU7zn3UqR1MOCjjTQOIYpiD4vjWA3LPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.7",
         "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.0.7",
+        "@inquirer/type": "^4.1.0",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
@@ -1976,14 +1976,14 @@
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.3.tgz",
-      "integrity": "sha512-F/BZHtyEzP+HO+IGVd4AjBRgvX/ywm42bx8S0+dENk2YclzE9tJ3X/15THwtT6ehApmKvdYDMsVTuyyDod0gOQ==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.4.tgz",
+      "integrity": "sha512-3xQkQrOvgOzpSN2ciTVdRDlg1FWMCA8l+0KfB6SNlILoTCGzJTzO/gc0Rwjcb3usuGyKdaGtI6OiyMdeMeLWkg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.0",
-        "@inquirer/type": "^4.0.7"
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -1998,15 +1998,15 @@
       }
     },
     "node_modules/@inquirer/input/node_modules/@inquirer/core": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.0.tgz",
-      "integrity": "sha512-+nnvFEXIB08CZNVXpvW3B+zHW96QXvGUjNKJ8NJIPqAZi5Kd4WhYt2S3C234ReepG1qw2HOlEUbjYVHBowXObA==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-JMD5Jy/ScL5TZE18m83Nw25HjqGFLoWXwnEkW7IdwwAhZpB9Bus55/WU7zn3UqR1MOCjjTQOIYpiD4vjWA3LPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.7",
         "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.0.7",
+        "@inquirer/type": "^4.1.0",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
@@ -2025,14 +2025,14 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.0.tgz",
-      "integrity": "sha512-ew+fSDijsQ/WhD4TV3XLb+if400cDuzTzHfGR8sTNBXkK9CYDWoGE8fhaO8GbT312pNv1AJEOsDxy/z/HVettA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.1.tgz",
+      "integrity": "sha512-5KaqwZNLRpUuWcoCrYghPP9TMaXL5v2Sk4xqePM7RCVegcJStoXdWibio60YIC1bec+z1fCyb67N6XPJIkZtGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.0",
-        "@inquirer/type": "^4.0.7"
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -2047,15 +2047,15 @@
       }
     },
     "node_modules/@inquirer/number/node_modules/@inquirer/core": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.0.tgz",
-      "integrity": "sha512-+nnvFEXIB08CZNVXpvW3B+zHW96QXvGUjNKJ8NJIPqAZi5Kd4WhYt2S3C234ReepG1qw2HOlEUbjYVHBowXObA==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-JMD5Jy/ScL5TZE18m83Nw25HjqGFLoWXwnEkW7IdwwAhZpB9Bus55/WU7zn3UqR1MOCjjTQOIYpiD4vjWA3LPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.7",
         "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.0.7",
+        "@inquirer/type": "^4.1.0",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
@@ -2074,15 +2074,15 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.1.2.tgz",
-      "integrity": "sha512-nSdufycW8xynEVssFkNQEYIzTySilog0UlfOVRwh3pXzPSk4frXUT2jZWjHnKae6RU9PaoF9wfy1pGwewQuqGw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.0.tgz",
+      "integrity": "sha512-CvVcW09emkBESEOW+4R8CjLNkP3fB3XrjeL8CDvfpjgrJN+V9oerXmJAXXM3l+4xqYPD5Yaujzy/Ph0PLOdDuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.0",
-        "@inquirer/type": "^4.0.7"
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -2097,15 +2097,15 @@
       }
     },
     "node_modules/@inquirer/password/node_modules/@inquirer/core": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.0.tgz",
-      "integrity": "sha512-+nnvFEXIB08CZNVXpvW3B+zHW96QXvGUjNKJ8NJIPqAZi5Kd4WhYt2S3C234ReepG1qw2HOlEUbjYVHBowXObA==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-JMD5Jy/ScL5TZE18m83Nw25HjqGFLoWXwnEkW7IdwwAhZpB9Bus55/WU7zn3UqR1MOCjjTQOIYpiD4vjWA3LPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.7",
         "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.0.7",
+        "@inquirer/type": "^4.1.0",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
@@ -2154,14 +2154,14 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.2.tgz",
-      "integrity": "sha512-oPSKrYK1X1bMkjXDzIKHUkJp195LFSfgbnVtXnjSKGFjrCbS6I+wyvfAZTwKE9BSt3HwWgfD7JfsXALBgCogzQ==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.3.tgz",
+      "integrity": "sha512-Mu7WrtmDLaXBDEyrRLS70SZgX9ZSm4Up1w0ZxiH8C1OOp9oaVCn2k8q3QGgmlnhsKYUhuaU3zFWhAP6wxkVIMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.0",
-        "@inquirer/type": "^4.0.7"
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -2176,15 +2176,15 @@
       }
     },
     "node_modules/@inquirer/rawlist/node_modules/@inquirer/core": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.0.tgz",
-      "integrity": "sha512-+nnvFEXIB08CZNVXpvW3B+zHW96QXvGUjNKJ8NJIPqAZi5Kd4WhYt2S3C234ReepG1qw2HOlEUbjYVHBowXObA==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-JMD5Jy/ScL5TZE18m83Nw25HjqGFLoWXwnEkW7IdwwAhZpB9Bus55/WU7zn3UqR1MOCjjTQOIYpiD4vjWA3LPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.7",
         "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.0.7",
+        "@inquirer/type": "^4.1.0",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
@@ -2203,15 +2203,15 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.0.tgz",
-      "integrity": "sha512-HFxXE5w727ctSUcAwrDquftJGjMgu36OeV5SHEXMlr2j/ahzmRX9xSEeVolV8tzYnTf45cg6vGkdMMRdm3RPhQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.1.tgz",
+      "integrity": "sha512-0VWOvsHWI0rPj6CG70MoP4oXNCB6adcyN8bVFZXnh11eLDdPIK2f2XCmva78acPPDfJisfab7qNakwBh7hdBXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.0",
+        "@inquirer/core": "^12.0.1",
         "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.0.7"
+        "@inquirer/type": "^4.1.0"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -2226,15 +2226,15 @@
       }
     },
     "node_modules/@inquirer/search/node_modules/@inquirer/core": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.0.tgz",
-      "integrity": "sha512-+nnvFEXIB08CZNVXpvW3B+zHW96QXvGUjNKJ8NJIPqAZi5Kd4WhYt2S3C234ReepG1qw2HOlEUbjYVHBowXObA==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-JMD5Jy/ScL5TZE18m83Nw25HjqGFLoWXwnEkW7IdwwAhZpB9Bus55/WU7zn3UqR1MOCjjTQOIYpiD4vjWA3LPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.7",
         "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.0.7",
+        "@inquirer/type": "^4.1.0",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
@@ -2253,16 +2253,16 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.2.tgz",
-      "integrity": "sha512-RkI8dRHWt+bh04oLixvF1kFzKC7e5rqJoHKkzcqSHATebBXFC6GmrT8ddbVkgSzLV0HnHs2cPFuBINr8otij8Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.3.tgz",
+      "integrity": "sha512-KuRTodDa6xBXX2noIpjuitpX/QT7Sfav7dIZ/OfUY54Hxg95nrGoshSzxx6Ey7qqLbImKdiGkSDt7KjPXjQgmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.7",
-        "@inquirer/core": "^12.0.0",
+        "@inquirer/core": "^12.0.1",
         "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.0.7"
+        "@inquirer/type": "^4.1.0"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -2277,15 +2277,15 @@
       }
     },
     "node_modules/@inquirer/select/node_modules/@inquirer/core": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.0.tgz",
-      "integrity": "sha512-+nnvFEXIB08CZNVXpvW3B+zHW96QXvGUjNKJ8NJIPqAZi5Kd4WhYt2S3C234ReepG1qw2HOlEUbjYVHBowXObA==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-JMD5Jy/ScL5TZE18m83Nw25HjqGFLoWXwnEkW7IdwwAhZpB9Bus55/WU7zn3UqR1MOCjjTQOIYpiD4vjWA3LPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.7",
         "@inquirer/figures": "^2.0.8",
-        "@inquirer/type": "^4.0.7",
+        "@inquirer/type": "^4.1.0",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
@@ -2304,9 +2304,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
-      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.0.tgz",
+      "integrity": "sha512-FMiJpuHUG3Dk0ex+UIXkre7i+i4OcwHWk9YdcVtZHFwb/r2rnrU2ipTCNAB7A+QOP0ryzIcqOfy76fRyyvOEAw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4075,9 +4075,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.3.0.tgz",
-      "integrity": "sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw==",
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Fixes the `outdated` job failure on main: https://github.com/voc0der/ytdl-material/actions/runs/33079228092/job/98541538113

## What broke

The Dependencies workflow's frontend check flags any package whose installed version differs from what its declared range *wants*. The root lockfile had drifted behind on 14 direct packages:

| Package | Installed | Range wants |
|---|---|---|
| 13 × `@angular/*` | 22.1.3 | 22.1.4 |
| `@types/node` | 26.3.0 | 26.4.0 |

The backend check passed — this is entirely the root lockfile.

## Why it appeared on the merge commit

Nothing to do with #415. The check [only fails the run on pushes to main](.github/workflows/dependencies.yml) and downgrades to a warning on pull requests, on the reasoning that the drift is upstream rather than in the change under review. Angular 22.1.4 published after the last lockfile touch, so the next push to main was always going to be the one that reported it.

## The change

`npm update` within the existing ranges. **No manifest changes** — `package.json` is untouched, so every bump is one the declared caret ranges already permitted. 33 lockfile entries move: the 13 Angular packages, `@types/node`, and the transitive `@inquirer/*` set pulled in under `@angular/cli`.

## Verification

Ran the full CI gate sequence locally:

- **Dependencies check** — reproduced the exact workflow script; frontend now reports nothing behind wanted
- **`npm run build`** — succeeds, only the pre-existing Sass `@import` deprecation and CSS budget warnings
- **`npx tsc -p src/tsconfig.spec.json --noEmit`** — clean
- **`npm run test:headless`** — 283 tests passing across 48 files
- **`npm run lint`** — clean