### PR TITLE
feat(player): add row autoplay and video blackout

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Docker pulls badge](https://img.shields.io/docker/pulls/voc0der/ytdl-material.svg)](https://hub.docker.com/r/voc0der/ytdl-material)
 [![Docker image size badge](https://img.shields.io/docker/image-size/voc0der/ytdl-material?sort=date)](https://hub.docker.com/r/voc0der/ytdl-material)
 <a href="https://github.com/voc0der/ytdl-material/blob/main/CONTRIBUTING.md#coverage">
-  <img src="https://img.shields.io/badge/coverage-60.0%25-yellow" alt="Code coverage percentage" />
+  <img src="https://img.shields.io/badge/coverage-60.1%25-yellow" alt="Code coverage percentage" />
 </a>
 [![GitHub issues badge](https://img.shields.io/github/issues/voc0der/ytdl-material)](https://github.com/voc0der/ytdl-material/issues)
 [![License badge](https://img.shields.io/github/license/voc0der/ytdl-material)](https://github.com/voc0der/ytdl-material/blob/main/LICENSE.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6213,9 +6213,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.11.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
-      "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
+      "version": "17.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.12.0.tgz",
+      "integrity": "sha512-cezEd/DTyyht9cvSSURyygXPfy04GtWO/5e6ZPvH7fCtjKz9PYOmuawphw1Ctd1f6C+5JypXfGD7ahNMXvevBA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/app/player/player.component.html
+++ b/src/app/player/player.component.html
@@ -10,6 +10,9 @@
                   <track [attr.kind]="subtitle.kind || 'subtitles'" [attr.label]="subtitle.label" [attr.srclang]="subtitle.language" [attr.src]="subtitle.src" [attr.default]="subtitle.default ? '' : null">
                 }
               </video>
+              @if (blackout_enabled && canToggleBlackout()) {
+                <div class="video-blackout-overlay" aria-hidden="true"></div>
+              }
               @if (currentChapters.length > 0 && currentItem.type !== 'audio/mp3') {
                 <div class="chapter-overlay" [class.visible]="chapterTimelineVisible">
                   <div class="chapter-overlay-header">
@@ -121,9 +124,6 @@
                           <button (click)="cancelPlaylistDownload()" matTooltip="Cancel playlist download" i18n-matTooltip="Cancel playlist download tooltip" aria-label="Cancel playlist download" i18n-aria-label="Cancel playlist download label" mat-icon-button><mat-icon>cancel</mat-icon></button>
                           <mat-spinner class="spinner" [diameter]="35"></mat-spinner>
                         }
-                        @if ((!postsService.isLoggedIn || postsService.permissions.includes('sharing')) && !auto) {
-                          <button (click)="openShareDialog()" matTooltip="Share" i18n-matTooltip="Share tooltip" aria-label="Share" i18n-aria-label="Share label" mat-icon-button><mat-icon>share</mat-icon></button>
-                        }
                       </span>
                     }
                     @if (db_file) {
@@ -132,10 +132,18 @@
                         @if (downloading) {
                           <mat-spinner class="spinner" [diameter]="35"></mat-spinner>
                         }
-                        @if (!postsService.isLoggedIn || postsService.permissions.includes('sharing')) {
-                          <button (click)="openShareDialog()" matTooltip="Share" i18n-matTooltip="Share tooltip" aria-label="Share" i18n-aria-label="Share label" mat-icon-button><mat-icon>share</mat-icon></button>
-                        }
                       </span>
+                    }
+                    @if (canToggleBlackout()) {
+                      <button class="playback-mode-button" [class.active]="blackout_enabled" [attr.aria-pressed]="blackout_enabled" (click)="toggleBlackout()" matTooltip="Blackout video" i18n-matTooltip="Blackout video toggle tooltip" aria-label="Blackout video" i18n-aria-label="Blackout video toggle label" mat-icon-button>
+                        <mat-icon>movie</mat-icon>
+                      </button>
+                    }
+                    @if (db_playlist && (!postsService.isLoggedIn || postsService.permissions.includes('sharing')) && !auto) {
+                      <button (click)="openShareDialog()" matTooltip="Share" i18n-matTooltip="Share tooltip" aria-label="Share" i18n-aria-label="Share label" mat-icon-button><mat-icon>share</mat-icon></button>
+                    }
+                    @if (db_file && (!postsService.isLoggedIn || postsService.permissions.includes('sharing'))) {
+                      <button (click)="openShareDialog()" matTooltip="Share" i18n-matTooltip="Share tooltip" aria-label="Share" i18n-aria-label="Share label" mat-icon-button><mat-icon>share</mat-icon></button>
                     }
                     @if (db_file || playlist[currentIndex]) {
                       @if (canToggleSubtitles()) {
@@ -143,9 +151,6 @@
                           <mat-icon>closed_caption</mat-icon>
                         </button>
                       }
-                      <button class="playback-mode-button" [class.active]="autoplay_enabled" [attr.aria-pressed]="autoplay_enabled" (click)="toggleAutoplay()" matTooltip="Autoplay" i18n-matTooltip="Autoplay toggle tooltip" aria-label="Autoplay" i18n-aria-label="Autoplay toggle label" mat-icon-button>
-                        <mat-icon>playlist_play</mat-icon>
-                      </button>
                       <button class="playback-mode-button" [class.active]="repeat_enabled" [attr.aria-pressed]="repeat_enabled" (click)="toggleRepeat()" matTooltip="Repeat current video" i18n-matTooltip="Repeat current video toggle tooltip" aria-label="Repeat current video" i18n-aria-label="Repeat toggle label" mat-icon-button>
                         <mat-icon>repeat_one</mat-icon>
                       </button>
@@ -164,7 +169,14 @@
           <div style="height: fit-content; width: 100%; margin-top: 10px;">
             <mat-button-toggle-group cdkDropList [cdkDropListSortingDisabled]="true" (cdkDropListDropped)="drop($event)" style="width: 80%; left: 9%" vertical name="videoSelect" aria-label="Video Select" #group="matButtonToggleGroup">
               @for (playlist_item of playlist; track (playlist_item.uid ?? playlist_item.url ?? $index); let i = $index) {
-                <mat-button-toggle cdkDrag [checked]="currentItem.title === playlist_item.title" (click)="onClickPlaylistItem(playlist_item, i)" class="toggle-button" [value]="playlist_item.title">{{playlist_item.label}}</mat-button-toggle>
+                <div cdkDrag class="playlist-row" [class.current]="currentItem === playlist_item">
+                  <mat-button-toggle [checked]="currentItem === playlist_item" (click)="onClickPlaylistItem(playlist_item, i)" class="toggle-button" [value]="playlist_item.title">{{playlist_item.label}}</mat-button-toggle>
+                  @if (currentItem === playlist_item) {
+                    <button class="playlist-autoplay-button playback-mode-button" [class.active]="autoplay_enabled" [attr.aria-pressed]="autoplay_enabled" (click)="toggleAutoplayFromPlaylistRow($event)" matTooltip="Autoplay" i18n-matTooltip="Autoplay toggle tooltip" aria-label="Autoplay" i18n-aria-label="Autoplay toggle label" mat-icon-button>
+                      <mat-icon>playlist_play</mat-icon>
+                    </button>
+                  }
+                </div>
               }
             </mat-button-toggle-group>
           </div>

--- a/src/app/player/player.component.spec.ts
+++ b/src/app/player/player.component.spec.ts
@@ -29,6 +29,9 @@ describe('PlayerComponent', () => {
           subscriptions_base_path: '/tmp/subscriptions'
         }
       },
+      theme: {
+        drawer_color: '#fff'
+      },
       setPageTitle: vi.fn().mockName('setPageTitle'),
       openSnackBar: vi.fn().mockName('openSnackBar'),
       getAllFiles: vi.fn().mockName('getAllFiles').mockReturnValue({
@@ -87,6 +90,14 @@ describe('PlayerComponent', () => {
   function actionBarButtons(): HTMLButtonElement[] {
     const row = fixture.debugElement.query(By.css('.action-buttons-row'));
     return row ? Array.from(row.nativeElement.querySelectorAll('button')) : [];
+  }
+
+  function playlistRows(): HTMLElement[] {
+    return Array.from(fixture.nativeElement.querySelectorAll('.playlist-row'));
+  }
+
+  function playlistAutoplayButtons(): HTMLButtonElement[] {
+    return Array.from(fixture.nativeElement.querySelectorAll('.playlist-autoplay-button'));
   }
 
   // The whole toolbar sits behind the player's own guard, so a spec has to get far enough
@@ -174,31 +185,129 @@ describe('PlayerComponent', () => {
   it('should mark only the engaged playback toggles', () => {
     showPlayer();
     component.db_file = {uid: 'f1', title: 'A video', url: 'https://example.com/watch', isAudio: false} as any;
-    component.autoplay_enabled = true;
+    component.blackout_enabled = true;
     component.repeat_enabled = false;
     fixture.detectChanges();
 
     const toggles = actionBarButtons().filter(button => button.classList.contains('playback-mode-button'));
-    const autoplay = toggles.find(button => button.getAttribute('aria-label') === 'Autoplay');
+    const blackout = toggles.find(button => button.getAttribute('aria-label') === 'Blackout video');
     const repeat = toggles.find(button => button.getAttribute('aria-label') === 'Repeat current video');
     // Idle toggles carry no marker at all, so they render at the same colour as the
     // actions beside them rather than dimmed.
-    expect(autoplay.classList.contains('active')).toBe(true);
+    expect(blackout.classList.contains('active')).toBe(true);
     expect(repeat.classList.contains('active')).toBe(false);
   });
 
   it('should mark playback toggles as pressed for assistive tech', () => {
     showPlayer();
     component.db_file = {uid: 'f1', title: 'A video', url: 'https://example.com/watch', isAudio: false} as any;
-    component.autoplay_enabled = true;
+    component.blackout_enabled = true;
     component.repeat_enabled = false;
     fixture.detectChanges();
 
     const toggles = actionBarButtons().filter(button => button.classList.contains('playback-mode-button'));
-    const autoplay = toggles.find(button => button.getAttribute('aria-label') === 'Autoplay');
+    const blackout = toggles.find(button => button.getAttribute('aria-label') === 'Blackout video');
     const repeat = toggles.find(button => button.getAttribute('aria-label') === 'Repeat current video');
-    expect(autoplay.getAttribute('aria-pressed')).toBe('true');
+    expect(blackout.getAttribute('aria-pressed')).toBe('true');
     expect(repeat.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('should put autoplay only on the current playlist row and keep its click on that control', () => {
+    showPlayer();
+    const currentItem = component.currentItem;
+    const updateCurrentItem = vi.spyOn(component, 'updateCurrentItem');
+    fixture.detectChanges();
+
+    expect(actionBarButtons().some(button => button.getAttribute('aria-label') === 'Autoplay')).toBe(false);
+    expect(playlistAutoplayButtons()).toHaveLength(1);
+    expect(playlistRows()[0].querySelector('.playlist-autoplay-button')).toBeTruthy();
+
+    playlistAutoplayButtons()[0].click();
+    fixture.detectChanges();
+
+    expect(component.currentItem).toBe(currentItem);
+    expect(updateCurrentItem).not.toHaveBeenCalled();
+    expect(component.autoplay_enabled).toBe(true);
+    expect(playlistAutoplayButtons()[0].getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('should move the autoplay control with the playing item', () => {
+    component.playlist_id = 'playlist-1';
+    component.file_objs = [
+      {uid: 'f1', title: 'First video', isAudio: false, url: 'https://example.com/first'} as DatabaseFile,
+      {uid: 'f2', title: 'Second video', isAudio: false, url: 'https://example.com/second'} as DatabaseFile
+    ];
+    component.uids = ['f1', 'f2'];
+    component.parseFileNames();
+    fixture.detectChanges();
+
+    expect(playlistRows()[0].querySelector('.playlist-autoplay-button')).toBeTruthy();
+    expect(playlistRows()[1].querySelector('.playlist-autoplay-button')).toBeFalsy();
+
+    component.onClickPlaylistItem(component.playlist[1], 1);
+    fixture.detectChanges();
+
+    expect(playlistRows()[0].querySelector('.playlist-autoplay-button')).toBeFalsy();
+    expect(playlistRows()[1].querySelector('.playlist-autoplay-button')).toBeTruthy();
+
+    component.drop({previousIndex: 1, currentIndex: 0} as any);
+    fixture.detectChanges();
+
+    expect(component.currentIndex).toBe(0);
+    expect(playlistRows()[0].querySelector('.playlist-autoplay-button')).toBeTruthy();
+  });
+
+  it('should place blackout immediately before share and cover the video while it remains selected', () => {
+    showPlayer();
+    component.db_file = {uid: 'f1', title: 'A video', url: 'https://example.com/watch', isAudio: false} as DatabaseFile;
+    postsServiceStub.isLoggedIn = false;
+    fixture.detectChanges();
+
+    const buttons = actionBarButtons();
+    const blackoutIndex = buttons.findIndex(button => button.getAttribute('aria-label') === 'Blackout video');
+    const shareIndex = buttons.findIndex(button => button.getAttribute('aria-label') === 'Share');
+    expect(blackoutIndex).toBeGreaterThan(-1);
+    expect(shareIndex).toBe(blackoutIndex + 1);
+
+    buttons[blackoutIndex].click();
+    fixture.detectChanges();
+
+    expect(component.blackout_enabled).toBe(true);
+    expect(buttons[blackoutIndex].getAttribute('aria-pressed')).toBe('true');
+    expect(fixture.nativeElement.querySelector('.video-blackout-overlay')).toBeTruthy();
+    expect(component.currentItem?.uid).toBe('f1');
+  });
+
+  it('should not offer blackout for audio', () => {
+    component.playlist_id = 'playlist-1';
+    component.file_objs = [
+      {uid: 'a1', title: 'An audio track', isAudio: true, url: 'https://example.com/audio'} as DatabaseFile
+    ];
+    component.uids = ['a1'];
+    component.parseFileNames();
+    fixture.detectChanges();
+
+    expect(actionBarButtons().some(button => button.getAttribute('aria-label') === 'Blackout video')).toBe(false);
+    component.toggleBlackout();
+    expect(component.blackout_enabled).toBe(false);
+  });
+
+  it('should expose row autoplay and blackout when playing a subscription', () => {
+    component.sub_id = 'subscription-1';
+    component.subscription = {
+      id: 'subscription-1',
+      type: 'video',
+      videos: [
+        {uid: 's1', title: 'Subscriber video', isAudio: false, url: 'https://example.com/subscriber'} as DatabaseFile
+      ]
+    } as any;
+    component.type = component.subscription.type;
+    component.uids = ['s1'];
+    component.parseFileNames();
+    fixture.detectChanges();
+
+    expect(playlistAutoplayButtons()).toHaveLength(1);
+    expect(actionBarButtons().some(button => button.getAttribute('aria-label') === 'Blackout video')).toBe(true);
   });
 
   it('should create', () => {

--- a/src/app/player/player.component.ts
+++ b/src/app/player/player.component.ts
@@ -109,6 +109,7 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
 
   autoplay_enabled = false;
   repeat_enabled = false;
+  blackout_enabled = false;
   autoplay_queue_loading = false;
   autoplay_queue_initialized = false;
   pending_autoplay_advance = false;
@@ -422,7 +423,13 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   onClickPlaylistItem(item: IMedia, index: number): void {
-      this.updateCurrentItem(item, index);
+    if (item === this.currentItem) return;
+    this.updateCurrentItem(item, index);
+  }
+
+  toggleAutoplayFromPlaylistRow(event: MouseEvent): void {
+    event.stopPropagation();
+    this.toggleAutoplay();
   }
 
   toggleAutoplay(): void {
@@ -449,6 +456,15 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
       this.collapseAutoplayQueueToCurrentItem();
     }
     this.saveRepeatMode();
+  }
+
+  canToggleBlackout(): boolean {
+    return this.currentItem?.type !== 'audio/mp3';
+  }
+
+  toggleBlackout(): void {
+    if (!this.canToggleBlackout()) return;
+    this.blackout_enabled = !this.blackout_enabled;
   }
 
   getFileNames(): string[] {
@@ -532,6 +548,7 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
 
   drop(event: CdkDragDrop<string[]>): void {
     moveItemInArray(this.playlist, event.previousIndex, event.currentIndex);
+    this.currentIndex = this.playlist.indexOf(this.currentItem);
   }
 
    playlistChanged(): boolean {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -188,6 +188,36 @@ app-player vg-player {
   position: relative;
 }
 
+app-player .video-blackout-overlay {
+  background: #000;
+  inset: 0;
+  pointer-events: none;
+  position: absolute;
+  z-index: 3;
+}
+
+app-player .playlist-row {
+  position: relative;
+  width: 100%;
+}
+
+app-player .playlist-row .toggle-button {
+  width: 100%;
+}
+
+app-player .playlist-row.current .mat-button-toggle-label-content {
+  padding-left: 48px;
+  padding-right: 48px;
+}
+
+app-player .playlist-autoplay-button {
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 1;
+}
+
 app-player .chapter-overlay {
   background: transparent;
   bottom: 34px;


### PR DESCRIPTION
## Summary

- move the autoplay toggle from the action bar onto the currently playing playlist row
- add a movie-glyph Blackout video toggle immediately before Share while keeping playback active
- support regular-library queues, subscription-filtered queues, and subscription Play all views
- keep the active row aligned after playlist reordering
- add five player behavior tests for row controls, blackout behavior, audio exclusion, and subscription playback

## Coverage

- frontend: 51.9% (3051/5876 lines)
- backend with the seeded LDAP test server: 62.3% (13552/21746 lines)
- combined README badge: 60.1% (16603/27622 lines)

## Dependency sweep

- refresh globals in the frontend lockfile from 17.11.0 to 17.12.0, the only dependency behind its declared wanted range
- backend dependencies are current; clean installs report zero audit vulnerabilities in both trees
- dependency declaration audit passes for 360 frontend and 82 backend import specifiers

## Testing

- npm ci --ignore-scripts (frontend and backend)
- npm run lint
- npx tsc -p src/tsconfig.app.json --noEmit
- npx tsc -p src/tsconfig.spec.json --noEmit
- npm run test:headless (288 tests)
- dev/coverage/coverage.sh
- node dev/deps/check-declared.mjs
- npx ng build --configuration production