### PR TITLE
fix(player): correct theater mode behavior

### DIFF
--- a/src/app/player/player.component.html
+++ b/src/app/player/player.component.html
@@ -1,5 +1,5 @@
 @if (playlist.length > 0 && show_player && currentItem) {
-  <div style="height: 100%">
+  <div class="player-page" [class.theater-mode-active]="theater_mode_enabled" style="height: 100%">
     <div style="height: 100%" [ngClass]="(currentItem.type === 'audio/mp3') ? null : 'container-video'">
       <div style="max-width: 100%; margin-left: 0px; height: 100%">
         <mat-drawer-container style="height: 100%" class="example-container" autosize>
@@ -10,9 +10,6 @@
                   <track [attr.kind]="subtitle.kind || 'subtitles'" [attr.label]="subtitle.label" [attr.srclang]="subtitle.language" [attr.src]="subtitle.src" [attr.default]="subtitle.default ? '' : null">
                 }
               </video>
-              @if (blackout_enabled && canToggleBlackout()) {
-                <div class="video-blackout-overlay" aria-hidden="true"></div>
-              }
               @if (currentChapters.length > 0 && currentItem.type !== 'audio/mp3') {
                 <div class="chapter-overlay" [class.visible]="chapterTimelineVisible">
                   <div class="chapter-overlay-header">
@@ -70,7 +67,7 @@
               </div>
             }
           </div>
-          <div class="player-toolbar-section">
+          <div class="player-toolbar-section" [class.theater-mode-active]="theater_mode_enabled">
             <div class="container-fluid player-toolbar-container">
               <div class="row media-info-row mx-0">
                 <div class="col-auto view-column">
@@ -115,6 +112,11 @@
                 </div>
                 <div class="col-auto action-column">
                   <span class="action-buttons-row">
+                    @if (canToggleTheaterMode()) {
+                      <button class="theater-mode-button playback-mode-button" [class.active]="theater_mode_enabled" [attr.aria-pressed]="theater_mode_enabled" (click)="toggleTheaterMode()" matTooltip="Theater mode" i18n-matTooltip="Theater mode toggle tooltip" aria-label="Theater mode" i18n-aria-label="Theater mode toggle label" mat-icon-button>
+                        <mat-icon>movie</mat-icon>
+                      </button>
+                    }
                     @if (db_playlist) {
                       <span class="buttons">
                         @if (!downloading) {
@@ -133,11 +135,6 @@
                           <mat-spinner class="spinner" [diameter]="35"></mat-spinner>
                         }
                       </span>
-                    }
-                    @if (canToggleBlackout()) {
-                      <button class="playback-mode-button" [class.active]="blackout_enabled" [attr.aria-pressed]="blackout_enabled" (click)="toggleBlackout()" matTooltip="Blackout video" i18n-matTooltip="Blackout video toggle tooltip" aria-label="Blackout video" i18n-aria-label="Blackout video toggle label" mat-icon-button>
-                        <mat-icon>movie</mat-icon>
-                      </button>
                     }
                     @if (db_playlist && (!postsService.isLoggedIn || postsService.permissions.includes('sharing')) && !auto) {
                       <button (click)="openShareDialog()" matTooltip="Share" i18n-matTooltip="Share tooltip" aria-label="Share" i18n-aria-label="Share label" mat-icon-button><mat-icon>share</mat-icon></button>

--- a/src/app/player/player.component.spec.ts
+++ b/src/app/player/player.component.spec.ts
@@ -92,6 +92,14 @@ describe('PlayerComponent', () => {
     return row ? Array.from(row.nativeElement.querySelectorAll('button')) : [];
   }
 
+  function playerToolbar(): HTMLElement | null {
+    return fixture.nativeElement.querySelector('.player-toolbar-section');
+  }
+
+  function playerPage(): HTMLElement | null {
+    return fixture.nativeElement.querySelector('.player-page');
+  }
+
   function playlistRows(): HTMLElement[] {
     return Array.from(fixture.nativeElement.querySelectorAll('.playlist-row'));
   }
@@ -185,30 +193,30 @@ describe('PlayerComponent', () => {
   it('should mark only the engaged playback toggles', () => {
     showPlayer();
     component.db_file = {uid: 'f1', title: 'A video', url: 'https://example.com/watch', isAudio: false} as any;
-    component.blackout_enabled = true;
+    component.theater_mode_enabled = true;
     component.repeat_enabled = false;
     fixture.detectChanges();
 
     const toggles = actionBarButtons().filter(button => button.classList.contains('playback-mode-button'));
-    const blackout = toggles.find(button => button.getAttribute('aria-label') === 'Blackout video');
+    const theaterMode = toggles.find(button => button.getAttribute('aria-label') === 'Theater mode');
     const repeat = toggles.find(button => button.getAttribute('aria-label') === 'Repeat current video');
     // Idle toggles carry no marker at all, so they render at the same colour as the
     // actions beside them rather than dimmed.
-    expect(blackout.classList.contains('active')).toBe(true);
+    expect(theaterMode.classList.contains('active')).toBe(true);
     expect(repeat.classList.contains('active')).toBe(false);
   });
 
   it('should mark playback toggles as pressed for assistive tech', () => {
     showPlayer();
     component.db_file = {uid: 'f1', title: 'A video', url: 'https://example.com/watch', isAudio: false} as any;
-    component.blackout_enabled = true;
+    component.theater_mode_enabled = true;
     component.repeat_enabled = false;
     fixture.detectChanges();
 
     const toggles = actionBarButtons().filter(button => button.classList.contains('playback-mode-button'));
-    const blackout = toggles.find(button => button.getAttribute('aria-label') === 'Blackout video');
+    const theaterMode = toggles.find(button => button.getAttribute('aria-label') === 'Theater mode');
     const repeat = toggles.find(button => button.getAttribute('aria-label') === 'Repeat current video');
-    expect(blackout.getAttribute('aria-pressed')).toBe('true');
+    expect(theaterMode.getAttribute('aria-pressed')).toBe('true');
     expect(repeat.getAttribute('aria-pressed')).toBe('false');
   });
 
@@ -257,28 +265,51 @@ describe('PlayerComponent', () => {
     expect(playlistRows()[0].querySelector('.playlist-autoplay-button')).toBeTruthy();
   });
 
-  it('should place blackout immediately before share and cover the video while it remains selected', () => {
+  it('should place theater mode before download and keep the video visible', () => {
     showPlayer();
     component.db_file = {uid: 'f1', title: 'A video', url: 'https://example.com/watch', isAudio: false} as DatabaseFile;
     postsServiceStub.isLoggedIn = false;
     fixture.detectChanges();
 
     const buttons = actionBarButtons();
-    const blackoutIndex = buttons.findIndex(button => button.getAttribute('aria-label') === 'Blackout video');
+    const theaterModeIndex = buttons.findIndex(button => button.getAttribute('aria-label') === 'Theater mode');
+    const downloadIndex = buttons.findIndex(button => button.getAttribute('aria-label') === 'Download this file');
     const shareIndex = buttons.findIndex(button => button.getAttribute('aria-label') === 'Share');
-    expect(blackoutIndex).toBeGreaterThan(-1);
-    expect(shareIndex).toBe(blackoutIndex + 1);
+    expect(theaterModeIndex).toBeGreaterThan(-1);
+    expect(downloadIndex).toBe(theaterModeIndex + 1);
+    expect(shareIndex).toBe(downloadIndex + 1);
 
-    buttons[blackoutIndex].click();
+    buttons[theaterModeIndex].click();
     fixture.detectChanges();
 
-    expect(component.blackout_enabled).toBe(true);
-    expect(buttons[blackoutIndex].getAttribute('aria-pressed')).toBe('true');
-    expect(fixture.nativeElement.querySelector('.video-blackout-overlay')).toBeTruthy();
+    expect(component.theater_mode_enabled).toBe(true);
+    expect(buttons[theaterModeIndex].getAttribute('aria-pressed')).toBe('true');
+    expect(playerPage()?.classList.contains('theater-mode-active')).toBe(true);
+    expect(fixture.nativeElement.querySelector('.video-player')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('.video-blackout-overlay')).toBeFalsy();
     expect(component.currentItem?.uid).toBe('f1');
   });
 
-  it('should not offer blackout for audio', () => {
+  it('should keep the whole toolbar available as the theater mode hover target', () => {
+    showPlayer();
+    component.db_file = {uid: 'f1', title: 'A video', url: 'https://example.com/watch', isAudio: false} as DatabaseFile;
+    fixture.detectChanges();
+
+    const theaterMode = actionBarButtons().find(button => button.getAttribute('aria-label') === 'Theater mode');
+    expect(theaterMode.classList.contains('theater-mode-button')).toBe(true);
+    theaterMode.click();
+    fixture.detectChanges();
+
+    expect(playerToolbar()?.classList.contains('theater-mode-active')).toBe(true);
+    expect(playerToolbar()?.querySelector('[aria-label="Theater mode"]')).toBeTruthy();
+
+    theaterMode.click();
+    fixture.detectChanges();
+
+    expect(playerToolbar()?.classList.contains('theater-mode-active')).toBe(false);
+  });
+
+  it('should not offer theater mode for audio', () => {
     component.playlist_id = 'playlist-1';
     component.file_objs = [
       {uid: 'a1', title: 'An audio track', isAudio: true, url: 'https://example.com/audio'} as DatabaseFile
@@ -287,12 +318,12 @@ describe('PlayerComponent', () => {
     component.parseFileNames();
     fixture.detectChanges();
 
-    expect(actionBarButtons().some(button => button.getAttribute('aria-label') === 'Blackout video')).toBe(false);
-    component.toggleBlackout();
-    expect(component.blackout_enabled).toBe(false);
+    expect(actionBarButtons().some(button => button.getAttribute('aria-label') === 'Theater mode')).toBe(false);
+    component.toggleTheaterMode();
+    expect(component.theater_mode_enabled).toBe(false);
   });
 
-  it('should expose row autoplay and blackout when playing a subscription', () => {
+  it('should expose row autoplay and theater mode when playing a subscription', () => {
     component.sub_id = 'subscription-1';
     component.subscription = {
       id: 'subscription-1',
@@ -307,7 +338,7 @@ describe('PlayerComponent', () => {
     fixture.detectChanges();
 
     expect(playlistAutoplayButtons()).toHaveLength(1);
-    expect(actionBarButtons().some(button => button.getAttribute('aria-label') === 'Blackout video')).toBe(true);
+    expect(actionBarButtons().some(button => button.getAttribute('aria-label') === 'Theater mode')).toBe(true);
   });
 
   it('should create', () => {

--- a/src/app/player/player.component.ts
+++ b/src/app/player/player.component.ts
@@ -109,7 +109,7 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
 
   autoplay_enabled = false;
   repeat_enabled = false;
-  blackout_enabled = false;
+  theater_mode_enabled = false;
   autoplay_queue_loading = false;
   autoplay_queue_initialized = false;
   pending_autoplay_advance = false;
@@ -458,13 +458,13 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
     this.saveRepeatMode();
   }
 
-  canToggleBlackout(): boolean {
+  canToggleTheaterMode(): boolean {
     return this.currentItem?.type !== 'audio/mp3';
   }
 
-  toggleBlackout(): void {
-    if (!this.canToggleBlackout()) return;
-    this.blackout_enabled = !this.blackout_enabled;
+  toggleTheaterMode(): void {
+    if (!this.canToggleTheaterMode()) return;
+    this.theater_mode_enabled = !this.theater_mode_enabled;
   }
 
   getFileNames(): string[] {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -188,21 +188,28 @@ app-player vg-player {
   position: relative;
 }
 
-app-player .video-blackout-overlay {
-  background: #000;
-  inset: 0;
-  pointer-events: none;
-  position: absolute;
-  z-index: 3;
+app-player .player-page.theater-mode-active,
+app-player .player-page.theater-mode-active .example-container,
+app-player .player-page.theater-mode-active .mat-drawer-content {
+  background-color: #000 !important;
+  color: #fff;
 }
 
 app-player .playlist-row {
+  display: flex;
+  min-width: 0;
   position: relative;
   width: 100%;
 }
 
 app-player .playlist-row .toggle-button {
+  flex: 1 1 auto;
+  min-width: 0;
   width: 100%;
+}
+
+app-player .playlist-row + .playlist-row {
+  border-top: solid 1px var(--mat-button-toggle-divider-color, var(--mat-sys-outline));
 }
 
 app-player .playlist-row.current .mat-button-toggle-label-content {
@@ -216,6 +223,24 @@ app-player .playlist-autoplay-button {
   top: 50%;
   transform: translateY(-50%);
   z-index: 1;
+}
+
+@media (hover: hover) {
+  app-player .player-toolbar-section.theater-mode-active {
+    opacity: 0;
+    transition: opacity 0.12s ease;
+  }
+
+  app-player .player-toolbar-section.theater-mode-active:hover,
+  app-player .player-toolbar-section.theater-mode-active:has(:focus-visible) {
+    opacity: 1;
+  }
+}
+
+@media (hover: none), (pointer: coarse) {
+  app-player .theater-mode-button {
+    display: none !important;
+  }
 }
 
 app-player .chapter-overlay {


### PR DESCRIPTION
## Summary

- keep video visible while Theater mode blacks out the surrounding player area
- place Theater mode immediately before Download, and hide the whole toolbar until hover or keyboard focus
- hide Theater mode on touch/no-hover devices
- restore a full-width playlist row while keeping Autoplay clickable on the current item
- cover regular-library and subscription playback behavior in the player tests

## Validation

- visually checked desktop and mobile layouts in Chromium
- `npm run lint`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npm run test:headless` (289 tests)
- `npx ng build --configuration production`
- combined coverage recalculated at 60.1%; README badge remains current
- frontend and backend `npm ci --ignore-scripts --dry-run`
- dependency sweep found no packages behind their declared wanted versions
