### PR TITLE
fix(player): make theater mode a true blackout

### DIFF
--- a/src/app/player/player.component.html
+++ b/src/app/player/player.component.html
@@ -3,7 +3,7 @@
     <div style="height: 100%" [ngClass]="(currentItem.type === 'audio/mp3') ? null : 'container-video'">
       <div style="max-width: 100%; margin-left: 0px; height: 100%">
         <mat-drawer-container style="height: 100%" class="example-container" autosize>
-          <div style="height: fit-content" [ngClass]="(currentItem.type === 'audio/mp3') ? 'audio-col' : 'video-col'">
+          <div class="theater-video-stage" style="height: fit-content" [ngClass]="(currentItem.type === 'audio/mp3') ? 'audio-col' : 'video-col'">
             <vg-player style="height: fit-content; max-height: 75vh" (onPlayerReady)="onPlayerReady($event)" (mousemove)="onPlayerMouseMove($event)" (mouseleave)="onPlayerMouseLeave()" [style.background-color]="(currentItem.type === 'audio/mp3') ? postsService.theme.drawer_color : 'black'">
               <video [ngClass]="(currentItem.type === 'audio/mp3') ? 'audio-styles' : 'video-styles'" #media class="video-player" [vgMedia]="$any(media)" [src]="currentItem.src" id="singleVideo" preload="auto" controls playsinline>
                 @for (subtitle of currentSubtitleTracks; track subtitle.src ?? subtitle.language ?? $index) {
@@ -42,7 +42,7 @@
                 </div>
               }
             </vg-player>
-            @if (snip_mode) {
+            @if (snip_mode && !theater_mode_enabled) {
               <div class="snip-panel">
                 <div class="snip-header">
                   <span class="snip-title"><mat-icon class="snip-title-icon">content_cut</mat-icon><ng-container i18n="Snip panel title">Snip</ng-container></span>
@@ -67,7 +67,7 @@
               </div>
             }
           </div>
-          <div class="player-toolbar-section" [class.theater-mode-active]="theater_mode_enabled">
+          <div class="player-toolbar-section" [hidden]="theater_mode_enabled">
             <div class="container-fluid player-toolbar-container">
               <div class="row media-info-row mx-0">
                 <div class="col-auto view-column">
@@ -163,7 +163,7 @@
               </div>
             </div>
           </div>
-          <div style="height: fit-content; width: 100%; margin-top: 10px;">
+          <div class="player-playlist-section" [hidden]="theater_mode_enabled" style="height: fit-content; width: 100%; margin-top: 10px;">
             <mat-button-toggle-group cdkDropList [cdkDropListSortingDisabled]="true" (cdkDropListDropped)="drop($event)" style="width: 80%; left: 9%" vertical name="videoSelect" aria-label="Video Select" #group="matButtonToggleGroup">
               @for (playlist_item of playlist; track (playlist_item.uid ?? playlist_item.url ?? $index); let i = $index) {
                 <div cdkDrag class="playlist-row" [class.current]="currentItem === playlist_item">
@@ -178,11 +178,11 @@
             </mat-button-toggle-group>
           </div>
           @if (db_file && api && api.time && postsService.config) {
-            <div class="watch-together-section">
+            <div class="watch-together-section" [hidden]="theater_mode_enabled">
               <app-concurrent-stream (setPlaybackRate)="setPlaybackRate($event)" (togglePlayback)="togglePlayback($event)" (setPlaybackTimestamp)="setPlaybackTimestamp($event)" [playing]="api?.state === 'playing'" [uid]="uid" [playback_timestamp]="(api?.time?.current ?? 0)/1000" [server_mode]="!postsService.config.Advanced.multi_user_mode || postsService.isLoggedIn"></app-concurrent-stream>
             </div>
           }
-          <mat-drawer #drawer class="example-sidenav" mode="side" position="end" [opened]="db_file && db_file['chat_exists']">
+          <mat-drawer #drawer class="example-sidenav" mode="side" position="end" [hidden]="theater_mode_enabled" [opened]="!theater_mode_enabled && db_file && db_file['chat_exists']">
             @if (api_ready && db_file && db_file.url.includes('twitch.tv')) {
               <app-twitch-chat #twitchchat [db_file]="db_file" [current_timestamp]="api?.currentTime ?? 0" [sub]="subscription"></app-twitch-chat>
             }

--- a/src/app/player/player.component.spec.ts
+++ b/src/app/player/player.component.spec.ts
@@ -27,6 +27,9 @@ describe('PlayerComponent', () => {
         },
         Subscriptions: {
           subscriptions_base_path: '/tmp/subscriptions'
+        },
+        Advanced: {
+          multi_user_mode: false
         }
       },
       theme: {
@@ -94,6 +97,10 @@ describe('PlayerComponent', () => {
 
   function playerToolbar(): HTMLElement | null {
     return fixture.nativeElement.querySelector('.player-toolbar-section');
+  }
+
+  function playerPlaylist(): HTMLElement | null {
+    return fixture.nativeElement.querySelector('.player-playlist-section');
   }
 
   function playerPage(): HTMLElement | null {
@@ -265,9 +272,10 @@ describe('PlayerComponent', () => {
     expect(playlistRows()[0].querySelector('.playlist-autoplay-button')).toBeTruthy();
   });
 
-  it('should place theater mode before download and keep the video visible', () => {
+  it('should place theater mode before download and make the video the only visible player content', () => {
     showPlayer();
     component.db_file = {uid: 'f1', title: 'A video', url: 'https://example.com/watch', isAudio: false} as DatabaseFile;
+    component.api = {state: 'paused', time: {current: 0}} as unknown as VgApiService;
     postsServiceStub.isLoggedIn = false;
     fixture.detectChanges();
 
@@ -285,28 +293,34 @@ describe('PlayerComponent', () => {
     expect(component.theater_mode_enabled).toBe(true);
     expect(buttons[theaterModeIndex].getAttribute('aria-pressed')).toBe('true');
     expect(playerPage()?.classList.contains('theater-mode-active')).toBe(true);
+    expect(document.body.classList.contains('player-theater-mode-active')).toBe(true);
+    expect(playerToolbar()?.hidden).toBe(true);
+    expect(playerPlaylist()?.hidden).toBe(true);
+    expect(fixture.nativeElement.querySelector('.watch-together-section')?.hidden).toBe(true);
     expect(fixture.nativeElement.querySelector('.video-player')).toBeTruthy();
     expect(fixture.nativeElement.querySelector('.video-blackout-overlay')).toBeFalsy();
     expect(component.currentItem?.uid).toBe('f1');
   });
 
-  it('should keep the whole toolbar available as the theater mode hover target', () => {
+  it('should exit theater mode with Escape and restore the surrounding controls', () => {
     showPlayer();
     component.db_file = {uid: 'f1', title: 'A video', url: 'https://example.com/watch', isAudio: false} as DatabaseFile;
     fixture.detectChanges();
 
     const theaterMode = actionBarButtons().find(button => button.getAttribute('aria-label') === 'Theater mode');
-    expect(theaterMode.classList.contains('theater-mode-button')).toBe(true);
     theaterMode.click();
     fixture.detectChanges();
 
-    expect(playerToolbar()?.classList.contains('theater-mode-active')).toBe(true);
-    expect(playerToolbar()?.querySelector('[aria-label="Theater mode"]')).toBeTruthy();
+    expect(playerToolbar()?.hidden).toBe(true);
+    expect(playerPlaylist()?.hidden).toBe(true);
 
-    theaterMode.click();
+    document.dispatchEvent(new KeyboardEvent('keydown', {key: 'Escape'}));
     fixture.detectChanges();
 
-    expect(playerToolbar()?.classList.contains('theater-mode-active')).toBe(false);
+    expect(component.theater_mode_enabled).toBe(false);
+    expect(document.body.classList.contains('player-theater-mode-active')).toBe(false);
+    expect(playerToolbar()?.hidden).toBe(false);
+    expect(playerPlaylist()?.hidden).toBe(false);
   });
 
   it('should not offer theater mode for audio', () => {

--- a/src/app/player/player.component.ts
+++ b/src/app/player/player.component.ts
@@ -182,6 +182,7 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.destroyed = true;
+    this.setTheaterMode(false);
     this.playlistDownloadSubscription?.unsubscribe();
     this.playlistDownloadSubscription = null;
     this.subtitleTrackRefreshToken += 1;
@@ -204,6 +205,11 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
   @HostListener('document:click')
   onDocumentClick(): void {
     this.chapterDropdownOpen = false;
+  }
+
+  @HostListener('document:keydown.escape')
+  exitTheaterMode(): void {
+    if (this.theater_mode_enabled) this.setTheaterMode(false);
   }
 
   constructor(public postsService: PostsService, private route: ActivatedRoute, private dialog: MatDialog, private router: Router,
@@ -464,7 +470,12 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
 
   toggleTheaterMode(): void {
     if (!this.canToggleTheaterMode()) return;
-    this.theater_mode_enabled = !this.theater_mode_enabled;
+    this.setTheaterMode(!this.theater_mode_enabled);
+  }
+
+  private setTheaterMode(enabled: boolean): void {
+    this.theater_mode_enabled = enabled;
+    document.body.classList.toggle('player-theater-mode-active', enabled);
   }
 
   getFileNames(): string[] {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -188,11 +188,61 @@ app-player vg-player {
   position: relative;
 }
 
-app-player .player-page.theater-mode-active,
+body.player-theater-mode-active {
+  background: #000;
+  overflow: hidden;
+}
+
+body.player-theater-mode-active app-root > div > .mat-elevation-z3 {
+  display: none !important;
+}
+
+body.player-theater-mode-active app-root > div > .sidenav-container {
+  height: 100% !important;
+}
+
+app-player .player-page.theater-mode-active {
+  background: #000;
+  inset: 0;
+  position: fixed;
+  z-index: 1100;
+}
+
 app-player .player-page.theater-mode-active .example-container,
 app-player .player-page.theater-mode-active .mat-drawer-content {
-  background-color: #000 !important;
-  color: #fff;
+  background: #000 !important;
+  height: 100vh !important;
+  height: 100dvh !important;
+  overflow: hidden;
+}
+
+app-player .player-page.theater-mode-active .theater-video-stage {
+  align-items: center;
+  background: #000;
+  display: flex;
+  height: 100vh !important;
+  height: 100dvh !important;
+  inset: 0;
+  justify-content: center;
+  position: fixed;
+  width: 100vw;
+  z-index: 1101;
+}
+
+app-player .player-page.theater-mode-active vg-player {
+  height: 100vh !important;
+  height: 100dvh !important;
+  max-height: 100vh !important;
+  max-height: 100dvh !important;
+  width: 100vw;
+}
+
+app-player .player-page.theater-mode-active .video-styles {
+  height: 100vh !important;
+  height: 100dvh !important;
+  max-height: 100vh;
+  max-height: 100dvh;
+  object-fit: contain;
 }
 
 app-player .playlist-row {
@@ -223,18 +273,6 @@ app-player .playlist-autoplay-button {
   top: 50%;
   transform: translateY(-50%);
   z-index: 1;
-}
-
-@media (hover: hover) {
-  app-player .player-toolbar-section.theater-mode-active {
-    opacity: 0;
-    transition: opacity 0.12s ease;
-  }
-
-  app-player .player-toolbar-section.theater-mode-active:hover,
-  app-player .player-toolbar-section.theater-mode-active:has(:focus-visible) {
-    opacity: 1;
-  }
 }
 
 @media (hover: none), (pointer: coarse) {


### PR DESCRIPTION
## Summary

- turn Theater mode into a fixed, viewport-wide black stage with only the video visible
- hide the application header, player toolbar, playlist, Watch Together, drawer/chat, and snip UI while active
- size the video to the viewport with aspect-ratio-preserving containment
- exit Theater mode with Escape and restore all surrounding controls
- replace the old toolbar-hover expectations with coverage for the complete blackout behavior

## Validation

- `npm run lint`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npm run test:headless` (289 tests)
- `npm run build`