### PR TITLE
fix(player): reveal theater toolbar on hover

### DIFF
--- a/src/app/player/player.component.html
+++ b/src/app/player/player.component.html
@@ -67,7 +67,7 @@
               </div>
             }
           </div>
-          <div class="player-toolbar-section" [hidden]="theater_mode_enabled">
+          <div class="player-toolbar-section" [class.theater-toolbar-visible]="theater_mode_enabled && theater_toolbar_visible" (mouseenter)="onTheaterToolbarMouseEnter()" (mouseleave)="onTheaterToolbarMouseLeave()">
             <div class="container-fluid player-toolbar-container">
               <div class="row media-info-row mx-0">
                 <div class="col-auto view-column">

--- a/src/app/player/player.component.spec.ts
+++ b/src/app/player/player.component.spec.ts
@@ -294,7 +294,7 @@ describe('PlayerComponent', () => {
     expect(buttons[theaterModeIndex].getAttribute('aria-pressed')).toBe('true');
     expect(playerPage()?.classList.contains('theater-mode-active')).toBe(true);
     expect(document.body.classList.contains('player-theater-mode-active')).toBe(true);
-    expect(playerToolbar()?.hidden).toBe(true);
+    expect(playerToolbar()?.classList.contains('theater-toolbar-visible')).toBe(false);
     expect(playerPlaylist()?.hidden).toBe(true);
     expect(fixture.nativeElement.querySelector('.watch-together-section')?.hidden).toBe(true);
     expect(fixture.nativeElement.querySelector('.video-player')).toBeTruthy();
@@ -302,24 +302,50 @@ describe('PlayerComponent', () => {
     expect(component.currentItem?.uid).toBe('f1');
   });
 
-  it('should exit theater mode with Escape and restore the surrounding controls', () => {
+  it('should reveal the theater toolbar on video hover, keep it usable, and hide it after inactivity', fakeAsync(() => {
     showPlayer();
     component.db_file = {uid: 'f1', title: 'A video', url: 'https://example.com/watch', isAudio: false} as DatabaseFile;
     fixture.detectChanges();
 
     const theaterMode = actionBarButtons().find(button => button.getAttribute('aria-label') === 'Theater mode');
+    theaterMode.focus();
+    expect(document.activeElement).toBe(theaterMode);
     theaterMode.click();
     fixture.detectChanges();
 
-    expect(playerToolbar()?.hidden).toBe(true);
+    expect(playerToolbar()?.classList.contains('theater-toolbar-visible')).toBe(false);
+    expect(document.activeElement).not.toBe(theaterMode);
     expect(playerPlaylist()?.hidden).toBe(true);
 
+    const playerElement = fixture.nativeElement.querySelector('vg-player') as HTMLElement;
+    component.onPlayerMouseMove({currentTarget: playerElement, clientY: 100} as unknown as MouseEvent);
+    fixture.detectChanges();
+
+    expect(playerToolbar()?.classList.contains('theater-toolbar-visible')).toBe(true);
+
+    component.onTheaterToolbarMouseEnter();
+    tick(2500);
+    fixture.detectChanges();
+    expect(playerToolbar()?.classList.contains('theater-toolbar-visible')).toBe(true);
+
+    component.onTheaterToolbarMouseLeave();
+    tick(2000);
+    fixture.detectChanges();
+    expect(playerToolbar()?.classList.contains('theater-toolbar-visible')).toBe(false);
+  }));
+
+  it('should exit theater mode with Escape and restore the surrounding controls', () => {
+    showPlayer();
+    component.db_file = {uid: 'f1', title: 'A video', url: 'https://example.com/watch', isAudio: false} as DatabaseFile;
+    fixture.detectChanges();
+
+    actionBarButtons().find(button => button.getAttribute('aria-label') === 'Theater mode').click();
+    fixture.detectChanges();
     document.dispatchEvent(new KeyboardEvent('keydown', {key: 'Escape'}));
     fixture.detectChanges();
 
     expect(component.theater_mode_enabled).toBe(false);
     expect(document.body.classList.contains('player-theater-mode-active')).toBe(false);
-    expect(playerToolbar()?.hidden).toBe(false);
     expect(playerPlaylist()?.hidden).toBe(false);
   });
 

--- a/src/app/player/player.component.ts
+++ b/src/app/player/player.component.ts
@@ -47,6 +47,7 @@ const REPEAT_STORAGE_KEY = 'player_repeat_enabled';
 const MIN_SNIP_DURATION_SECONDS = 1;
 const SNIP_STATUS_POLL_INTERVAL_MS = 1000;
 const SNIP_SEEK_DEBOUNCE_MS = 80;
+const THEATER_TOOLBAR_HIDE_DELAY_MS = 2000;
 
 @Component({
     selector: 'app-player',
@@ -110,6 +111,8 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
   autoplay_enabled = false;
   repeat_enabled = false;
   theater_mode_enabled = false;
+  theater_toolbar_visible = false;
+  theater_toolbar_hide_timer: ReturnType<typeof setTimeout> | null = null;
   autoplay_queue_loading = false;
   autoplay_queue_initialized = false;
   pending_autoplay_advance = false;
@@ -188,6 +191,7 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
     this.subtitleTrackRefreshToken += 1;
     // prevents volume save feature from running in the background
     clearInterval(this.save_volume_timer);
+    this.clearTheaterToolbarHideTimer();
     this.clearSnipPoll();
     if (this.subtitleTrackActivationTimer) {
       clearTimeout(this.subtitleTrackActivationTimer);
@@ -475,7 +479,43 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
 
   private setTheaterMode(enabled: boolean): void {
     this.theater_mode_enabled = enabled;
+    this.theater_toolbar_visible = false;
+    this.clearTheaterToolbarHideTimer();
+    if (enabled && document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
     document.body.classList.toggle('player-theater-mode-active', enabled);
+  }
+
+  onTheaterToolbarMouseEnter(): void {
+    if (!this.theater_mode_enabled) return;
+    this.theater_toolbar_visible = true;
+    this.clearTheaterToolbarHideTimer();
+  }
+
+  onTheaterToolbarMouseLeave(): void {
+    this.scheduleTheaterToolbarHide();
+  }
+
+  private revealTheaterToolbar(): void {
+    if (!this.theater_mode_enabled) return;
+    this.theater_toolbar_visible = true;
+    this.scheduleTheaterToolbarHide();
+  }
+
+  private scheduleTheaterToolbarHide(): void {
+    if (!this.theater_mode_enabled) return;
+    this.clearTheaterToolbarHideTimer();
+    this.theater_toolbar_hide_timer = setTimeout(() => {
+      this.theater_toolbar_visible = false;
+      this.theater_toolbar_hide_timer = null;
+    }, THEATER_TOOLBAR_HIDE_DELAY_MS);
+  }
+
+  private clearTheaterToolbarHideTimer(): void {
+    if (!this.theater_toolbar_hide_timer) return;
+    clearTimeout(this.theater_toolbar_hide_timer);
+    this.theater_toolbar_hide_timer = null;
   }
 
   getFileNames(): string[] {
@@ -1295,6 +1335,8 @@ export class PlayerComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   onPlayerMouseMove(event: MouseEvent): void {
+    this.revealTheaterToolbar();
+
     if (this.currentItem?.type === 'audio/mp3' || this.currentChapters.length === 0) {
       this.chapterTimelineVisible = false;
       return;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -245,6 +245,33 @@ app-player .player-page.theater-mode-active .video-styles {
   object-fit: contain;
 }
 
+app-player .player-page.theater-mode-active .player-toolbar-section {
+  background: rgba(0, 0, 0, 0.82);
+  bottom: 0;
+  color: #fff;
+  left: 0;
+  margin: 0;
+  opacity: 0;
+  pointer-events: none;
+  position: fixed;
+  transition: opacity 0.12s ease, visibility 0.12s linear;
+  visibility: hidden;
+  width: 100vw;
+  z-index: 1102;
+}
+
+app-player .player-page.theater-mode-active .player-toolbar-section.theater-toolbar-visible,
+app-player .player-page.theater-mode-active .player-toolbar-section:focus-within {
+  opacity: 1;
+  pointer-events: auto;
+  visibility: visible;
+}
+
+app-player .player-page.theater-mode-active .player-toolbar-section button,
+app-player .player-page.theater-mode-active .player-toolbar-section mat-icon {
+  color: inherit;
+}
+
 app-player .playlist-row {
   display: flex;
   min-width: 0;


### PR DESCRIPTION
## Summary

- keep Theater mode as a full-screen blackout with the video as the only persistent content
- reveal the complete player toolbar when the pointer moves over the video
- keep the toolbar visible while it is hovered or keyboard-focused so its controls remain usable
- hide it again after two seconds of inactivity or after the pointer leaves it
- preserve Escape as an immediate Theater mode exit

## Validation

- `npm run lint`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npm run test:headless` (290 tests)
- `npm run build`