### PR TITLE
chore(release): bump version to 1.1.2

### DIFF
--- a/backend/consts.js
+++ b/backend/consts.js
@@ -491,4 +491,4 @@ exports.SUBSCRIPTION_BACKUP_PATH = 'subscription_backup.json'
 // we're using a Set here for performance
 exports.YTDL_ARGS_WITH_VALUES = new Set(YTDL_ARGS_WITH_VALUES);
 
-exports.CURRENT_VERSION = 'v1.1.1';
+exports.CURRENT_VERSION = 'v1.1.2';

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@discordjs/builders": "^1.14.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "backend for ytdl-material",
   "main": "index.js",
   "scripts": {

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.1.1"
+appVersion: "1.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ytdl-material",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ytdl-material",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^22.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ytdl-material",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/consts.ts
+++ b/src/app/consts.ts
@@ -1,1 +1,1 @@
-export const CURRENT_VERSION = 'v1.1.1';
+export const CURRENT_VERSION = 'v1.1.2';


### PR DESCRIPTION
Version bump for v1.1.2. This updates the same seven canonical release files as v1.1.1: both package.json files and lockfiles, backend/consts.js, src/app/consts.ts, and chart/Chart.yaml (version and appVersion).

## Why patch rather than minor

The player features are additive and no route, response shape or configuration key changed. Upgrading requires no action.

## Contents

11 PRs since v1.1.1: queue-aware Autoplay and Theater mode (#421–#425), dependency updates (#415–#421), and the security-policy clarification in b12b9762.

## Verification

- Frontend lint passed.
- Production build passed.
- Frontend tests: **290 passing** across 48 files.
- Backend tests: **558 passing**, 52 LDAP-dependent tests pending.
- Both package trees audit with **0 vulnerabilities**.
- Every imported dependency is declared.

## After merging

The prepared annotated v1.1.2 tag will supply the release notes to build.yml, which creates the GitHub release and dispatches the Docker release.