### PR TITLE
fix(deps): update frontend dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,13 +79,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.2201.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2201.6.tgz",
-      "integrity": "sha512-oGQEdof2/1bZk58PN9dvpGi8pvtbgE5vkP1xRtCqN8dSVxwre1l0pKynOj/Uge1KxjCvs4c1QrQu0vsAnY0vpg==",
+      "version": "0.2201.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2201.7.tgz",
+      "integrity": "sha512-qffChB0+3WuLcwDk9gx3p/Vl3zYJDomweui5zsLESDMzvJ8zsbKRkgohTieOngajx+XBsklp0gKcxjiVn4NvWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.1.6",
+        "@angular-devkit/core": "22.1.7",
         "rxjs": "7.8.2"
       },
       "bin": {
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "22.1.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.1.6.tgz",
-      "integrity": "sha512-KLBsZoc2RhOy0xSdeYcLoSOqV/fBP3feBmhY9o12ry2IuyW/17sCmWr6XbIfTIYQN6M98Y1ewmwVNFsvV5b0gA==",
+      "version": "22.1.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.1.7.tgz",
+      "integrity": "sha512-RKayeOOjhcIe/iBOM1fmtI5pjXwBEJh+u55VnSeIwYvFNXyxI0/jdRw4T6uhwusQ+1bzyya4d8q1mT9oaOQ/5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -126,13 +126,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "22.1.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.1.6.tgz",
-      "integrity": "sha512-IbDO9KbQyQm20uinsfT8d9ZtQw41/WVutI/65mAw39WZfN8Ky+MOgOUJCGLiSccMprvZ9YdodBTnN9bLH149Ag==",
+      "version": "22.1.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.1.7.tgz",
+      "integrity": "sha512-KOcVeT4MCsoPt6AMnXH7AbWZnzlKXhMyua2ITWij4UbLaNWCDwfIug/xrZssYLHUFwebCIqsR8iuG/BPH8Cz2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.1.6",
+        "@angular-devkit/core": "22.1.7",
         "jsonc-parser": "3.3.1",
         "magic-string": "1.0.0",
         "ora": "9.4.1",
@@ -161,14 +161,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "22.1.6",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.1.6.tgz",
-      "integrity": "sha512-J7JBd3hDAV4dlGNMavDC0KjtvbDd4KOddaom1inwkq92tYnD1ljmhDDigAsUBnRvQhJ82cvagD8zi0s9Ki4rTQ==",
+      "version": "22.1.7",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.1.7.tgz",
+      "integrity": "sha512-YNZL3R2YS1qZud9zbJfW3ZSeEB0xAURBJEE0cf7WRCCwkn7NFlH7xXLW/zR+WRBwtcCBRsLrM2/ix3Y8FoKX9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2201.6",
+        "@angular-devkit/architect": "0.2201.7",
         "@babel/core": "8.0.1",
         "@babel/helper-annotate-as-pure": "8.0.0",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -210,7 +210,7 @@
         "@angular/platform-browser": "^22.0.0",
         "@angular/platform-server": "^22.0.0",
         "@angular/service-worker": "^22.0.0",
-        "@angular/ssr": "^22.1.6",
+        "@angular/ssr": "^22.1.7",
         "istanbul-lib-instrument": "^6.0.0",
         "karma": "^6.4.0",
         "less": "^4.2.0",
@@ -268,9 +268,9 @@
       }
     },
     "node_modules/@angular/cdk": {
-      "version": "22.1.4",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-22.1.4.tgz",
-      "integrity": "sha512-//KICh/rxeLbYLgNj8HawaliVAPNlSV0aRmki45Tf/YhoXVhzon9DfFqCs5u1cLvmMkMTHdFm5ghGTB8SUv3DA==",
+      "version": "22.1.5",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-22.1.5.tgz",
+      "integrity": "sha512-1tYAeI5KKIqNGNvyDuMM0Drs2FU3M4B25Q1BlAnwtZe3wvrpVETAGXgHaBX3Hs/pvWfgMNwgbcHkxlKVUBNXMA==",
       "license": "MIT",
       "dependencies": {
         "parse5": "^8.0.0",
@@ -279,24 +279,25 @@
       "peerDependencies": {
         "@angular/common": "^22.0.0 || ^23.0.0",
         "@angular/core": "^22.0.0 || ^23.0.0",
+        "@angular/forms": "^22.0.0 || ^23.0.0",
         "@angular/platform-browser": "^22.0.0 || ^23.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/cli": {
-      "version": "22.1.6",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.1.6.tgz",
-      "integrity": "sha512-HT3OzYkSpCyXMTgD5G1tsS7vkrY8cYJ/JgSjRjrpwOAooSMtKF1hv7BgBcn79sKg4eaiPLrDpQLXP93vHxgSFg==",
+      "version": "22.1.7",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.1.7.tgz",
+      "integrity": "sha512-dsOAAPHTXSrTvH5jIdZsFhqmcrTU9+aLXPSYSkQ1afMxPUT/JDjWH228xURYmCaM3ml0vVaT9R2p7/FrS7CJmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2201.6",
-        "@angular-devkit/core": "22.1.6",
-        "@angular-devkit/schematics": "22.1.6",
+        "@angular-devkit/architect": "0.2201.7",
+        "@angular-devkit/core": "22.1.7",
+        "@angular-devkit/schematics": "22.1.7",
         "@inquirer/prompts": "8.5.2",
         "@listr2/prompt-adapter-inquirer": "4.2.5",
         "@modelcontextprotocol/sdk": "1.30.0",
-        "@schematics/angular": "22.1.6",
+        "@schematics/angular": "22.1.7",
         "jsonc-parser": "3.3.1",
         "listr2": "11.0.0",
         "npm-package-arg": "14.0.0",
@@ -454,15 +455,15 @@
       }
     },
     "node_modules/@angular/material": {
-      "version": "22.1.4",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-22.1.4.tgz",
-      "integrity": "sha512-d4+uajpIYmyjar/4dypd5L+z8pbgkaCOsSxsrslmE0o0wK7mfFvXCkn0wwfucey5yUHXjswlKu1X5RzJZLOZ+w==",
+      "version": "22.1.5",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-22.1.5.tgz",
+      "integrity": "sha512-CeXPascggzu5w0xKETYVQhxlyYU+Vcj/DCY4JdND2veRr6/bmPM8uA/xY4jEvsFccz3HQ9OrkY+V+sNai2h++g==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/cdk": "22.1.4",
+        "@angular/cdk": "22.1.5",
         "@angular/common": "^22.0.0 || ^23.0.0",
         "@angular/core": "^22.0.0 || ^23.0.0",
         "@angular/forms": "^22.0.0 || ^23.0.0",
@@ -3947,14 +3948,14 @@
       "license": "MIT"
     },
     "node_modules/@schematics/angular": {
-      "version": "22.1.6",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.1.6.tgz",
-      "integrity": "sha512-RiD4OZJ4yuaM1aXb3pt1gjDSWwkP0jrgiCuoaBls1eabcrDmlsNuQv0ekxbcGgCRPdSJvmHRZIHHmFPzei8w3Q==",
+      "version": "22.1.7",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.1.7.tgz",
+      "integrity": "sha512-acBv147JjnwtWFgC8Af0KFBzPpb/TWaYxoWN/Ou3pXtUhYiEqnrdJeoFz3ssDw26eKFIdWnVBLB/dHORBykPBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.1.6",
-        "@angular-devkit/schematics": "22.1.6",
+        "@angular-devkit/core": "22.1.7",
+        "@angular-devkit/schematics": "22.1.7",
         "jsonc-parser": "3.3.1",
         "typescript": "6.0.3"
       },
@@ -4075,9 +4076,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
-      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
+      "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9830,9 +9831,9 @@
       }
     },
     "node_modules/zone.js": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.2.tgz",
-      "integrity": "sha512-Eky7p2Z1Ig3NnbfodSPoARCjKBSTFMnE/ACsP1L/XJEfY4SdOFce19BsUCWVwL6K5ABZFy5J3bjcMWffX+YM3Q==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.3.tgz",
+      "integrity": "sha512-ihXL9+vhYyEhXz4TDNpHeAOZN9FVrbog0Il64OIEI28UP/n5AaI6gsccRuOHBfx+206agzyoK527bYIO0Foy6A==",
       "license": "MIT"
     }
   }


### PR DESCRIPTION
## Summary

- refresh the seven frontend dependencies reported as behind their declared ranges by the dependency workflow
- update the three required Angular toolchain transitive packages
- leave backend dependencies unchanged because their drift check is clean

## Updated

- `@angular-devkit/core` 22.1.6 → 22.1.7
- `@angular/build` 22.1.6 → 22.1.7
- `@angular/cdk` 22.1.4 → 22.1.5
- `@angular/cli` 22.1.6 → 22.1.7
- `@angular/material` 22.1.4 → 22.1.5
- `@types/node` 26.4.0 → 26.4.1
- `zone.js` 0.16.2 → 0.16.3

## Validation

- dependency workflow current/wanted filter: clean
- `npm run lint`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npm run test:extension`
- `npm run test:headless` (290 tests)
- `npx ng build --configuration production`

Follow-up to #428.