### PR TITLE
chore(deps): raise the hono and postcss pins to current

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6384,9 +6384,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.13.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
-      "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8057,9 +8057,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.26",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
-      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
       "dev": true,
       "funding": [
         {
@@ -8077,7 +8077,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.17",
+        "nanoid": "^3.3.18",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -83,10 +83,10 @@
       "@angular/core": "21.2.0"
     },
     "flatted": "3.4.4",
-    "hono": "4.13.5",
+    "hono": "4.13.7",
     "immutable": "5.1.9",
     "js-yaml": "4.3.1",
     "nanoid": "3.3.18",
-    "postcss": "8.5.26"
+    "postcss": "8.5.28"
   }
 }


### PR DESCRIPTION
Two `overrides` entries had gone stale since the third compat-pin sweep in #373. Both are dedupe-only pins, not deliberate holds.

| Pin | Was | Now | Reached through |
| --- | --- | --- | --- |
| `hono` | 4.13.5 | 4.13.7 | `@angular/cli` → `@modelcontextprotocol/sdk` → `@hono/node-server` |
| `postcss` | 8.5.26 | 8.5.28 | `@angular/build`, `beasties`, `vite` |

## Why these are different from the other pins

The pins in #373 are held *against* upstream — each one waits on a named blocker. These two are the opposite: they exist only to collapse the tree onto a single copy, so the correct value is simply whatever is current. Left behind, they pin the tree *below* what every consumer would otherwise resolve to on its own.

`npm outdated` cannot see either of them, because an override satisfies its own range by construction. They only surface by diffing the pinned value against the registry, which is what the #373 sweep does — so the miss is expected, and this is the follow-up.

## This does not disturb the nanoid hold

Worth stating explicitly, since the two interact: `postcss@8.5.28` still declares `nanoid ^3.3.18`. The `nanoid` 3.3.18 pin remains both necessary and correctly valued, and its recorded trigger — a postcss release declaring `nanoid ^6` — still has not fired.

## Verification

- Each still resolves to exactly one deduped copy (`npm ls hono postcss`)
- `npm audit` — 0 vulnerabilities
- `npm run lint` — clean
- `npx tsc -p src/tsconfig.app.json --noEmit` — clean
- `npx tsc -p src/tsconfig.spec.json --noEmit` — clean
- `npm run test:headless` — 290 passed (48 files)
- `npx ng build --configuration production` — succeeded, only the pre-existing budget/Sass/CJS warnings

Backend was not touched, so its suite and the extension packaging steps do not apply. Install reports `changed 2 packages`.