### PR TITLE
fix: stop no-op clicks in the library and the player

### DIFF
--- a/src/app/components/media-library/media-library.component.scss
+++ b/src/app/components/media-library/media-library.component.scss
@@ -436,9 +436,13 @@
     filter: blur(2px);
 }
 
+/* Downloading a file to the browser does not stop the card from opening, and the card stays
+   clickable all around this spinner, so the spinner must not be the one spot on it that
+   silently does nothing. */
 .downloading-spinner {
     align-self: center;
     position: absolute;
+    pointer-events: none;
 }
 
 .hide {

--- a/src/app/components/media-library/media-library.component.spec.ts
+++ b/src/app/components/media-library/media-library.component.spec.ts
@@ -834,4 +834,87 @@ describe('MediaLibraryComponent', () => {
     expect(get_all_files_spy).toHaveBeenCalled();
     expect(postsServiceStub.openSnackBar).toHaveBeenCalledWith('Playlist removed, but 2 file(s) could not be deleted.');
   });
+  describe('background refreshes during a press', () => {
+    let gridElement: HTMLElement;
+
+    const pressGrid = () => gridElement.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+    const releasePointer = () => window.dispatchEvent(new Event('pointerup'));
+
+    beforeEach(() => {
+      fixture.detectChanges();
+      gridElement = document.createElement('div');
+      document.body.appendChild(gridElement);
+      component.videoGridContainer = { nativeElement: gridElement } as any;
+    });
+
+    afterEach(() => {
+      gridElement.remove();
+    });
+
+    it('should hold a background file refresh until the pointer is released', () => {
+      const get_all_files_spy = vi.spyOn(component, 'getAllFiles').mockReturnValue(undefined);
+
+      pressGrid();
+      postsServiceStub.files_changed.next(true);
+
+      // Rebuilding here would detach the card being pressed, and a browser fires no click at
+      // all when the pressed element leaves the document before the release.
+      expect(get_all_files_spy).not.toHaveBeenCalled();
+
+      releasePointer();
+
+      expect(get_all_files_spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should refresh straight away when nothing is being pressed', () => {
+      const get_all_files_spy = vi.spyOn(component, 'getAllFiles').mockReturnValue(undefined);
+
+      postsServiceStub.files_changed.next(true);
+
+      expect(get_all_files_spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should collapse repeated background events into a single deferred refresh', () => {
+      const get_all_files_spy = vi.spyOn(component, 'getAllFiles').mockReturnValue(undefined);
+
+      pressGrid();
+      postsServiceStub.files_changed.next(true);
+      postsServiceStub.files_changed.next(true);
+      postsServiceStub.files_changed.next(true);
+      releasePointer();
+
+      expect(get_all_files_spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should keep a deferred refresh queued when the grid container is swapped mid-press', () => {
+      const get_all_files_spy = vi.spyOn(component, 'getAllFiles').mockReturnValue(undefined);
+
+      pressGrid();
+      postsServiceStub.files_changed.next(true);
+
+      // Switching library tabs swaps which element the view query resolves to, which rebinds
+      // the press listeners. A refresh already waiting must survive that, not be thrown away.
+      const replacement_grid = document.createElement('div');
+      document.body.appendChild(replacement_grid);
+      component.videoGridContainer = { nativeElement: replacement_grid } as any;
+
+      expect(get_all_files_spy).not.toHaveBeenCalled();
+
+      releasePointer();
+
+      expect(get_all_files_spy).toHaveBeenCalledTimes(1);
+      replacement_grid.remove();
+    });
+
+    it('should drop a deferred refresh when the library is torn down mid-press', () => {
+      const get_all_files_spy = vi.spyOn(component, 'getAllFiles').mockReturnValue(undefined);
+
+      pressGrid();
+      postsServiceStub.files_changed.next(true);
+      component.ngOnDestroy();
+      releasePointer();
+
+      expect(get_all_files_spy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/app/components/media-library/media-library.component.spec.ts
+++ b/src/app/components/media-library/media-library.component.spec.ts
@@ -906,6 +906,51 @@ describe('MediaLibraryComponent', () => {
       replacement_grid.remove();
     });
 
+    it('should hold a refresh already in flight when its response lands mid-press', () => {
+      const response_subject = new Subject<any>();
+      postsServiceStub.getAllFiles.mockReturnValue(response_subject);
+
+      // The request goes out before the press starts, so deferring the request is not enough:
+      // it is applying the response that rebuilds the grid and detaches the pressed card.
+      component.getAllFiles();
+      const rebuild_spy = vi.spyOn(component, 'rebuildVideoRows');
+
+      pressGrid();
+      response_subject.next({ files: [{ uid: 'file-1', duration: 10 }], file_count: 1 });
+
+      expect(rebuild_spy).not.toHaveBeenCalled();
+
+      releasePointer();
+
+      expect(rebuild_spy).toHaveBeenCalledTimes(1);
+      expect(component.paged_data.map(file => file.uid)).toEqual(['file-1']);
+    });
+
+    it('should not start an auto-load append while a file response waits on the press', fakeAsync(() => {
+      component.autoPaginationEnabled = true;
+      component.file_count = 100;
+      const response_subject = new Subject<any>();
+      postsServiceStub.getAllFiles.mockReturnValue(response_subject);
+
+      component.getAllFiles();
+      pressGrid();
+      response_subject.next({ files: [{ uid: 'file-1', duration: 10 }], file_count: 100 });
+
+      // An append here would be ranged off paged_data that the waiting response has not
+      // updated yet, and would supersede that response by bumping the request id.
+      const load_more_spy = vi.spyOn(component, 'loadMoreAutoFiles').mockReturnValue(undefined);
+      component.maybeLoadMoreAutoFiles();
+      flushMicrotasks();
+
+      expect(load_more_spy).not.toHaveBeenCalled();
+
+      releasePointer();
+      component.maybeLoadMoreAutoFiles();
+      flushMicrotasks();
+
+      expect(load_more_spy).toHaveBeenCalledTimes(1);
+    }));
+
     it('should drop a deferred refresh when the library is torn down mid-press', () => {
       const get_all_files_spy = vi.spyOn(component, 'getAllFiles').mockReturnValue(undefined);
 

--- a/src/app/components/media-library/media-library.component.ts
+++ b/src/app/components/media-library/media-library.component.ts
@@ -136,13 +136,25 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
   private fullFileRefreshInProgress = false;
   private queuedFullFileRefresh = false;
   private queuedFullFileRefreshCacheMode = false;
+  private gridPressElement: HTMLElement = null;
+  private gridPressActive = false;
+  private readonly deferredGridRefreshes = new Map<string, () => void>();
   private readonly destroy$ = new Subject<void>();
   private readonly scrollHandler = () => this.scheduleVirtualVideoWindowUpdate();
+  private readonly gridPressStartHandler = () => { this.gridPressActive = true; };
+  private readonly gridPressEndHandler = () => {
+    this.gridPressActive = false;
+    if (this.deferredGridRefreshes.size === 0) {
+      return;
+    }
+    this.ngZone.run(() => this.flushDeferredGridRefreshes());
+  };
 
   @ViewChild('videoGridContainer')
   set videoGridContainer(container: ElementRef<HTMLElement> | undefined) {
     this.videoGridContainerElement = container?.nativeElement ?? null;
     this.refreshScrollListener();
+    this.refreshGridPressListeners();
     this.refreshVideoGridResizeObserver();
     this.refreshVideoRowsForCurrentLayout();
     this.schedulePendingScrollRestore();
@@ -251,7 +263,7 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe(changed => {
         if (changed) {
-          this.getAllFiles();
+          this.runWhenGridIdle('files', () => this.getAllFiles());
         }
       });
 
@@ -259,10 +271,12 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe(changed => {
       if (changed) {
-        this.getAvailablePlaylists();
-        if (this.showLibraryTabs) {
-          this.getPlaylistLibraryItems();
-        }
+        this.runWhenGridIdle('playlists', () => {
+          this.getAvailablePlaylists();
+          if (this.showLibraryTabs) {
+            this.getPlaylistLibraryItems();
+          }
+        });
       }
     });
 
@@ -270,9 +284,11 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe(changed => {
         if (!changed) return;
-        if (this.pruneUnavailableCategoryFilters() && this.isVideoLibraryActive()) {
-          this.getAllFiles();
-        }
+        this.runWhenGridIdle('categories', () => {
+          if (this.pruneUnavailableCategoryFilters() && this.isVideoLibraryActive()) {
+            this.getAllFiles();
+          }
+        });
       });
 
     
@@ -299,7 +315,9 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
+    this.deferredGridRefreshes.clear();
     this.unbindScrollListener();
+    this.unbindGridPressListeners();
     this.unbindVideoGridResizeObserver();
   }
 
@@ -1457,6 +1475,65 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
     }
 
     this.autoLoadQueued = false;
+  }
+
+  /**
+   * A click is dispatched to the nearest common ancestor of the press and the release that is
+   * still in the document, so losing an inner node mid-click is survivable -- but when a whole
+   * card is detached between the two, no click fires at all, even though mousedown, mouseup
+   * and the ripple all still happen. Rebuilding the grid does exactly that to every card whose
+   * position moves, so any download finishing at the wrong moment eats a click that was
+   * already underway. Rendering the grid as one flat @for tracked by uid does not help: that
+   * makes the teardown a view move, and a move loses the press just the same. So the refresh
+   * is what has to wait.
+   */
+  private runWhenGridIdle(key: string, refresh: () => void): void {
+    if (!this.gridPressActive) {
+      refresh();
+      return;
+    }
+
+    // Repeat events collapse onto one deferred refresh rather than queueing a burst of them.
+    this.deferredGridRefreshes.set(key, refresh);
+  }
+
+  private flushDeferredGridRefreshes(): void {
+    if (this.deferredGridRefreshes.size === 0) {
+      return;
+    }
+
+    const deferred_refreshes = [...this.deferredGridRefreshes.values()];
+    this.deferredGridRefreshes.clear();
+    deferred_refreshes.forEach(refresh => refresh());
+  }
+
+  private refreshGridPressListeners(): void {
+    this.unbindGridPressListeners();
+    if (!this.videoGridContainerElement || typeof window === 'undefined') {
+      return;
+    }
+
+    this.gridPressElement = this.videoGridContainerElement;
+    this.ngZone.runOutsideAngular(() => {
+      // The press is only interesting when it starts on the grid, but it can end anywhere --
+      // including outside the card it started on -- so the release is watched on the window.
+      this.gridPressElement.addEventListener('pointerdown', this.gridPressStartHandler);
+      window.addEventListener('pointerup', this.gridPressEndHandler);
+      window.addEventListener('pointercancel', this.gridPressEndHandler);
+    });
+  }
+
+  private unbindGridPressListeners(): void {
+    this.gridPressElement?.removeEventListener('pointerdown', this.gridPressStartHandler);
+    this.gridPressElement = null;
+
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('pointerup', this.gridPressEndHandler);
+      window.removeEventListener('pointercancel', this.gridPressEndHandler);
+    }
+
+    // A queued refresh outlives the element it was queued on: the next release flushes it.
+    this.gridPressActive = false;
   }
 
   private refreshVideoGridResizeObserver(): void {

--- a/src/app/components/media-library/media-library.component.ts
+++ b/src/app/components/media-library/media-library.component.ts
@@ -866,27 +866,11 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
     const favoriteFilter = this.getFavoriteFilter();
     const categoryFilterUids = this.getCategoryFilterUids();
     this.postsService.getAllFiles(sort, this.usePaginator ? range : null, this.search_mode ? this.search_text : null, fileTypeFilter as FileTypeFilter, favoriteFilter, this.sub_id, false, categoryFilterUids).subscribe(res => {
-      // A newer request (of either kind) may have superseded this one. Its data must not be
-      // applied, but the in-progress flags below still belong solely to this request and must
-      // always be cleared, or a stale response would leave future filter/sort/append calls stuck.
-      if (request_id === this.latestFileRequestId) {
-        const previous_loaded_count = this.paged_data?.length ?? 0;
-        this.file_count = res['file_count'];
-        const files = this.normalizeFiles(res['files'] ?? []);
-        this.paged_data = append ? this.mergeFiles(this.paged_data ?? [], files) : files;
-        if (append && (this.paged_data?.length ?? 0) <= previous_loaded_count) {
-          // Stop auto-prefetch if the backend response did not advance the loaded range.
-          this.file_count = this.paged_data?.length ?? this.file_count;
-        }
-        this.rebuildVideoRows();
-
-        // set cached file count for future use, note that we convert the amount of files to a string
-        localStorage.setItem('cached_file_count', '' + this.file_count);
-
-        this.normal_files_received = true;
-        this.scheduleVirtualVideoWindowUpdate(true);
-        this.schedulePendingScrollRestore();
-      }
+      // Deferring the request is not enough on its own: a refresh asked for just before a card
+      // was pressed lands during it, and it is applying the response that rebuilds the grid.
+      // The in-progress flags below belong solely to this request and are cleared either way,
+      // or a stale response would leave future filter/sort/append calls stuck.
+      this.runWhenGridIdle('file-response', () => this.applyFileResponse(request_id, res, append));
 
       this.autoPageLoadInProgress = false;
       if (!append) {
@@ -907,6 +891,34 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
         this.flushQueuedFullFileRefresh();
       }
     });
+  }
+
+  /**
+   * A newer request (of either kind) may have superseded this one, either before the response
+   * arrived or while it waited for a press to finish, so the check is made here rather than at
+   * the call site -- by the time this runs the answer may have changed.
+   */
+  private applyFileResponse(request_id: number, res: Record<string, unknown>, append: boolean): void {
+    if (request_id !== this.latestFileRequestId) {
+      return;
+    }
+
+    const previous_loaded_count = this.paged_data?.length ?? 0;
+    this.file_count = res['file_count'] as number;
+    const files = this.normalizeFiles((res['files'] ?? []) as DatabaseFile[]);
+    this.paged_data = append ? this.mergeFiles(this.paged_data ?? [], files) : files;
+    if (append && (this.paged_data?.length ?? 0) <= previous_loaded_count) {
+      // Stop auto-prefetch if the backend response did not advance the loaded range.
+      this.file_count = this.paged_data?.length ?? this.file_count;
+    }
+    this.rebuildVideoRows();
+
+    // set cached file count for future use, note that we convert the amount of files to a string
+    localStorage.setItem('cached_file_count', '' + this.file_count);
+
+    this.normal_files_received = true;
+    this.scheduleVirtualVideoWindowUpdate(true);
+    this.schedulePendingScrollRestore();
   }
 
   private queueFullFileRefresh(cache_mode = false): void {
@@ -1386,8 +1398,17 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
     });
   }
 
+  /**
+   * A file response waiting on a press has not reached paged_data yet, so an append started now
+   * would be ranged off stale data and, worse, would supersede the waiting response and discard
+   * it. The release applies that response and re-runs this, so nothing is lost by waiting.
+   */
+  private get fileResponseAwaitingRelease(): boolean {
+    return this.deferredGridRefreshes.has('file-response');
+  }
+
   maybeLoadMoreAutoFiles(): void {
-    if (!this.autoPaginationEnabled || this.autoPageLoadInProgress || this.autoLoadQueued || this.fullFileRefreshInProgress || (this.paged_data?.length ?? 0) >= this.file_count) {
+    if (!this.autoPaginationEnabled || this.autoPageLoadInProgress || this.autoLoadQueued || this.fullFileRefreshInProgress || this.fileResponseAwaitingRelease || (this.paged_data?.length ?? 0) >= this.file_count) {
       return;
     }
 
@@ -1399,7 +1420,7 @@ export class MediaLibraryComponent implements OnInit, OnDestroy {
     this.autoLoadQueued = true;
     queueMicrotask(() => {
       this.autoLoadQueued = false;
-      if (!this.autoPaginationEnabled || this.autoPageLoadInProgress || this.fullFileRefreshInProgress || (this.paged_data?.length ?? 0) >= this.file_count) {
+      if (!this.autoPaginationEnabled || this.autoPageLoadInProgress || this.fullFileRefreshInProgress || this.fileResponseAwaitingRelease || (this.paged_data?.length ?? 0) >= this.file_count) {
         return;
       }
 

--- a/src/app/components/unified-file-card/unified-file-card.component.scss
+++ b/src/app/components/unified-file-card/unified-file-card.component.scss
@@ -163,6 +163,9 @@
   color: black;
 }
 
+/* This strip is a sibling of the card rather than a child of it, so it covers the top
+   192x24px of the card without carrying the card's click handler. Left hit-testable it
+   swallows every click landing on it, which reads as the card not responding at all. */
 .download-time {
   position: absolute;
   top: 1px;
@@ -173,6 +176,7 @@
   overflow: hidden;
   display: block;
   text-overflow: ellipsis;
+  pointer-events: none;
 }
 
 .audio-video-icon {

--- a/src/app/player/player.component.css
+++ b/src/app/player/player.component.css
@@ -51,10 +51,14 @@
     bottom: -1px;
 }
 
+/* This spinner is a sibling of the button it sits over, not a child of it, so it does not
+   pass clicks on. It covers 66% of that button including the icon at the centre, which left
+   "Cancel playlist download" unclickable for as long as the download it cancels was running. */
 .spinner {
     bottom: -2px;
     left: 6px;
     position: absolute;
+    pointer-events: none;
 }
 
 .buttons {


### PR DESCRIPTION
Clicks that do nothing, in two places. Everything below was verified in headless Chromium with real input injection (CDP `Input.dispatchMouseEvent`) rather than synthetic events, since the bug is in the browser's own click derivation.

## 1. The date strip covers the top of every library card

The click handler is on the `<mat-card>`, but the metadata strip is a **sibling** of that card, not a child, so its clicks bubble to the wrapper `<div>` and go nowhere. It is `position: absolute; z-index: 999` over the card.

Measured hit map down the card centre:

```
y=0        -> card        (clickable)
y=1..24    -> download-time (DEAD - never reaches the card)
y=25..36   -> card        (clickable)
y=37..149  -> thumbnail   (clickable)
y=150..199 -> card        (clickable)
```

A 192x24 band, roughly 12% of a 200x200 medium card, directly above the thumbnail where the date you are reading is. mousedown, mouseup and the ripple all fire there; no click reaches the card. Pressing on the strip and releasing on the thumbnail is dead too, since their common ancestor is the wrapper.

This was diagnosed once before: ae5db5b4 added exactly this rule and it was reverted inside #118, where only the `.preview-video` rule survived. The rule now carries a comment saying why it is there.

The library's own download spinner has the same shape, so it made a 32px hole in the middle of a card that stays clickable everywhere else. Fixed the same way.

## 2. Cancelling a playlist download was impossible

Same bug class, worse consequence. The spinner shown while a playlist download runs is a sibling of the cancel button, not a child. Measured: it covers **66% of that button including the dead centre** where the icon is, and a click there lands on the spinner's `svg`. So the button that cancels the download was unclickable for exactly as long as the download was running.

## 3. A grid rebuild between press and release

A click is dispatched to the nearest common ancestor of the press and the release that is still in the document. Losing an inner node mid-click is survivable; losing the whole card means no click fires at all.

Refreshing the library rebuilds the grid, and a file arriving at the top shifts every card into a different row's `@for` block, tearing each one down and building it again. A download completing between press and release therefore ate a click already underway.

Rendering the grid as one flat `@for` tracked by uid does **not** fix this - that turns the teardown into a view move, and a move loses the press just the same. So the refresh is what waits, and the guard sits where the DOM actually changes: both the refresh request and the application of its response are held while a pointer is down on the grid, and run on release. Guarding only the request would have left roughly half the race, since a refresh asked for just before the press lands during it. Guarding the response also covers the paginator view, which renders straight from `paged_data`.

User-driven rebuilds (sort, filter, search, resize) are untouched, as none can happen while a card is held down.

## Scan for the same bug class elsewhere

An analyzer (sass -> postcss for positioned rules, parse5 for template nesting) flags non-interactive positioned elements sitting over clickable siblings, across every component. Validated against the known bug first: it flagged `.download-time` on the unfixed tree and went quiet once fixed. Also run with the check widened to "uncles", and supplemented by a manual pass over the global rules in `styles.scss` and the app shell, which have no paired template.

Everything else it surfaced is benign, for a reason worth recording - a spinner **inside** its button is fine, because clicks bubble to the button; only a **sibling** overlay is a bug:

| Finding | Verdict |
| --- | --- |
| `.spinner` (subscription, archive-viewer, cookies-uploader) | child of the button, clicks bubble |
| `.chapter-segment-fill` (player) | child of its `<button>`, clicks bubble |
| `.icon-button-spinner` (downloads, duplicates) | sibling, but the button is `[disabled]` under exactly the condition that renders the spinner |
| `.login-progress-bar` | rendered only while the button is disabled, and painted under `.login-button-div` anyway |
| `.dot` (notifications) | 8x8px at card top-right, actions are `margin-top: auto` at the bottom; no overlap |
| `.download-progress-bar`, `.input-clear-button`, `.spinner` (main) | dead CSS, referenced by no template |

`custom-playlists` renders cards and has the same refresh race, but its selector appears in no template and no route, so it is unreachable and left alone.

## Tests

7 tests on the deferral behaviour. Each was verified to fail without the fix it covers, including one that was vacuous on first writing (it asserted before the `queueMicrotask` it depended on had run) and now flushes properly.

The CSS half is not unit-testable - the suite runs in jsdom, which has no layout or `pointer-events` hit testing - which is why the browser harness was used for those.

Lint clean, typecheck clean, 297/297 tests pass, production build succeeds.

Note: the build warns that `media-library.component.scss` is 79 bytes over its 6.00 kB budget. Pre-existing (6067 bytes compressed before these changes, budget 6000); this adds 20. `main.component.css` is over too, and carries the three dead rules noted above. Worth addressing separately.