### PR TITLE
chore(deps): raise the js-yaml and undici pins, refresh scalar

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -447,13 +447,13 @@
       }
     },
     "node_modules/@scalar/client-side-rendering": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@scalar/client-side-rendering/-/client-side-rendering-0.3.10.tgz",
-      "integrity": "sha512-FlUByzYhsas54zIvsiTJ7UgAZiVUQmErWvrQm+CKTBnIvSmIb5eWowJ4/O0bbkUa8rsOIdmCcX+HtX+EDdf0CA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@scalar/client-side-rendering/-/client-side-rendering-0.4.0.tgz",
+      "integrity": "sha512-a8OUod1LZbNqkPv73ijRPL3MH2/3E92I5Awa9mGXtCaIVavY3JcF7+qZW4GOtffihTfuD/CxhZ+CnQhCZds2oQ==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/schemas": "0.8.4",
-        "@scalar/types": "0.18.3",
+        "@scalar/schemas": "0.9.0",
+        "@scalar/types": "0.19.0",
         "@scalar/validation": "0.6.3"
       },
       "engines": {
@@ -461,33 +461,33 @@
       }
     },
     "node_modules/@scalar/express-api-reference": {
-      "version": "0.10.17",
-      "resolved": "https://registry.npmjs.org/@scalar/express-api-reference/-/express-api-reference-0.10.17.tgz",
-      "integrity": "sha512-+44Z5YBGwDBjm/tN2L3ep2VGsgR2msw06GKYnYEVaLpsj39C83HavNLL1eI8LOAFFE/Jw0u3NdpEiWA8ZpmucA==",
+      "version": "0.10.18",
+      "resolved": "https://registry.npmjs.org/@scalar/express-api-reference/-/express-api-reference-0.10.18.tgz",
+      "integrity": "sha512-PvDEMUNwfMnn0ak7L+rfbN6YwSY4UtM6SaOZPVjvGvHqxt7GrMV8rdax/Vu9sOLK1pL5F92K/UVmu0K9eMEcdQ==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/client-side-rendering": "0.3.10"
+        "@scalar/client-side-rendering": "0.4.0"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/helpers": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.11.2.tgz",
-      "integrity": "sha512-IgHW/hIj1XAvsPIBKiOgmK87qbyDjaQQg9S/auXU4MUtvnwKKpOeIOJc0NC71FkMdr4Mok0SSVI748cmlptoXQ==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.11.3.tgz",
+      "integrity": "sha512-4zPzuNTXObDUtZS93xzAoK83ddHDgBGifv/vKFe6bHqEl5i+IMLTTtEHOaaOZK4dusPEXcXsU5TBSaY/I6Mi+A==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/schemas": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@scalar/schemas/-/schemas-0.8.4.tgz",
-      "integrity": "sha512-gbx/UjAswjJc+OZp/vcVRIopjqoJ62pOkrKLvVHa1MuMRoVxcPyNzW2/SQmnvdJku7C7a6PsKaPUQ6gZXGA4eg==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@scalar/schemas/-/schemas-0.9.0.tgz",
+      "integrity": "sha512-yYRlIWzw+7HuIX4z7rk7tg4y1nERwvvWKbolZOm7LveSTrppllGKyjtnIqS5uXsmJddERxuurSgDW224gGJlFQ==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.11.2",
+        "@scalar/helpers": "0.11.3",
         "@scalar/validation": "0.6.3"
       },
       "engines": {
@@ -495,12 +495,12 @@
       }
     },
     "node_modules/@scalar/types": {
-      "version": "0.18.3",
-      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.18.3.tgz",
-      "integrity": "sha512-hPLLxVt/ah4RpCVp5UrLEpnBEgTwf+RvPtRiSEty3QqfBJUfADMXHz+oWK6UAa/vALg2AWuJLCD8hRlyQ2ET9w==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.19.0.tgz",
+      "integrity": "sha512-EKeoWgUlP+uepbM/zEHKbsdpBNyOmSrw6DdU/WC0p53gz5uRzI7d/IEecIP9SQMUkResPR9DmWeWfFQftG7vqg==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.11.2",
+        "@scalar/helpers": "0.11.3",
         "nanoid": "^5.1.6",
         "type-fest": "^5.8.0",
         "zod": "^4.4.3"
@@ -4794,9 +4794,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
-      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "version": "6.28.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.1.tgz",
+      "integrity": "sha512-zWpdTVD54H48CIybL0rWQ3ukpb9d23wM7eH5RtfdmeP70cWHNjtfo7P4vZX+5CoDcO53J4Pu5uXp7lNfjc6DRA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/backend/package.json
+++ b/backend/package.json
@@ -72,7 +72,7 @@
     "form-data": "4.0.6",
     "got": "11.8.6",
     "js-yaml": "5.4.1",
-    "undici": "6.28.0",
+    "undici": "6.28.1",
     "ws": "8.21.3"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6725,9 +6725,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "flatted": "3.4.4",
     "hono": "4.13.7",
     "immutable": "5.1.9",
-    "js-yaml": "4.3.1",
+    "js-yaml": "4.3.2",
     "nanoid": "3.3.18",
     "postcss": "8.5.28"
   }


### PR DESCRIPTION
Fifth compat-pin pass against #373. Every recorded hold is unmoved and none were retired. What moved is the other direction again — two pins that had drifted below the top of their own allowed range, the same shape as the hono and postcss raises in #434.

## Raised

| pin | from | to | tree |
| --- | --- | --- | --- |
| `js-yaml` | 4.3.1 | 4.3.2 | frontend override |
| `undici` | 6.28.0 | 6.28.1 | backend override |

Neither is a deliberate hold being lifted:

- **js-yaml** stays on the 4.x line. Still capped by `openapi-typescript-codegen@0.31.0` -> `@apidevtools/json-schema-ref-parser@14.2.1` declaring `^4.1.0`; 4.3.2 is simply the top of that line now. The corrected trigger in #373 (an `openapi-typescript-codegen` release moving to jsrp 15+) has still not fired.
- **undici** stays on 6.x. Still capped by `@discordjs/rest@2.6.3` declaring `^6.27.0`. #373 records 6.28.0 as "the pin is the top of the declared range, which is exactly where it should sit" — true when written, no longer true.

Each still collapses to a single deduped copy afterwards, which is the whole point of the pin:

```
$ npm ls js-yaml     -> js-yaml@4.3.2 overridden        (1 entry)
$ npm ls undici      -> undici@6.28.1 overridden        (1 entry)
```

`npm audit` stays at 0 vulnerabilities in both trees.

## Refreshed

`@scalar/express-api-reference` 0.10.17 -> 0.10.18 in the backend — an ordinary in-range update (`^0.10.11`) the lockfile had not picked up. It carries its transitive tree with it (`@scalar/client-side-rendering`, `helpers`, `schemas`, `types`), all within their declared ranges.

## Deliberately not changed

Everything `npm outdated` reports as available is blocked, and I verified each rather than trusting the peer ranges:

- **vitest / @vitest/coverage-v8** stay at 4.1.11. 5.0.0 is out, installs cleanly (the peer is optional), and I ran the full suite plus coverage on it — 297/297 pass, coverage reports fine. But `@angular/build@22.1.7` peers `vitest ^4.0.8` and `angular.json` runs the suite through `@angular/build:unit-test`, so the builder's range is binding. #373 records this as a hold with a trigger; a passing suite is not grounds to take it.
- **typescript** stays at `~6.0.3`. Confirmed rather than assumed: 7.0.2 installs (that peer is optional too) and then breaks the build outright — `@angular/compiler-cli` throws `TypeError: Cannot read properties of undefined (reading 'Error')` in `readConfiguration`. The `>=6.0 <6.1` range is real.
- **ngx-avatars Angular peer shim** stays at 21.2.0. `ngx-avatars@1.10.2` is still latest and still caps at `^21.1.2`; the shim materializes no nested tree, so the exact value is cosmetic, as #373 already notes. Not worth the churn.
- **got** stays at 11.8.6 — still the top of the 11.x line, and `gotify@1.1.0` still declares `10.7.0`.
- **nanoid** stays at 3.3.18 — still the last version `postcss` can `require`.

Also worth recording: `npm outdated` reports `@angular/animations` and `@angular/platform-browser-dynamic` as behind, with "Latest" columns of 20.1.8 and 20.0.7. Both are wrong — `npm view <pkg> dist-tags.latest` returns 22.1.5 for each, which is what is installed. Anyone sweeping deps from `npm outdated` alone would try to downgrade Angular by two majors.

## Verification

| check | result |
| --- | --- |
| `npm run lint` | clean |
| `npm run test:headless` | 297/297 |
| backend `npm run test` | 558 passing, 52 pending |
| `npm run test:extension` | 0 fail |
| `npm run build` | succeeds |
| `npm audit` (both trees) | 0 vulnerabilities |