### PR TITLE
chore(deps): refresh the @types/node lockfile pin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4124,13 +4124,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.4.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
-      "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.5.0.tgz",
+      "integrity": "sha512-dVSGpriSoCgz8WnDNTuSSuSv1PC/ALXihO4ulRZt7Md8k9mlbdin3lGOcDE8SnWOgf513ByWlXd7BK4azmyg/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~8.9.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -8842,9 +8842,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.9.0.tgz",
+      "integrity": "sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
Turns main's `Dependencies` run green again.

## What happened

`@types/node@26.5.0` published at **14:07:48Z**. #439's checks ran at 14:08 and the merge landed at 14:13, so the new version appeared in the ~5 minute gap between the two.

The `outdated` job only blocks on `push` to main — on a pull request it emits a warning and exits 0, by design, so that upstream drift never fails whichever PR happens to be open at the time. That is why #439 showed `outdated` as passing and main went red the moment it merged.

Nothing in #439 touched this pin. `@types/node` reads 26.4.1 in the lockfile at both `1c9aabb6` (before) and `b00f2478` (after).

## The change

The declared range is already `^26.3.0`, which 26.5.0 satisfies, so `package.json` does not move — only the lockfile:

- `@types/node` 26.4.1 → 26.5.0
- `undici-types` 8.3.0 → 8.9.0 (transitive)

## Verification

- The `outdated` check, replicated locally against the same comparison the workflow makes — passes for both trees:
  - frontend: every dependency at its wanted version
  - backend: every dependency at its wanted version
- `npx tsc -p src/tsconfig.spec.json --noEmit` — clean (the check that matters most for a types bump)
- `npm run lint` — clean
- `npm run test:headless` — 48 files, 297 tests pass
- `npm run build` — succeeds