### PR TITLE
chore(deps): drop every override but got, refresh Angular and compression

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -33,7 +33,7 @@
         "mime-types": "^3.0.2",
         "moment": "^2.30.1",
         "mongodb": "^7.6.0",
-        "multer": "2.3.0",
+        "multer": "^2.3.0",
         "node-id3": "^0.2.9",
         "openid-client": "^6.8.6",
         "passport": "^0.7.0",
@@ -54,7 +54,7 @@
       },
       "devDependencies": {
         "c8": "^12.0.0",
-        "js-yaml": "5.4.1",
+        "js-yaml": "^5.4.1",
         "mocha": "^12.0.0",
         "pg-mem": "^3.0.14",
         "supertest": "^7.2.2"
@@ -1372,14 +1372,15 @@
       }
     },
     "node_modules/compression": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
-      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.2.tgz",
+      "integrity": "sha512-o8vI5RE5A6EVVOd9o41jKp41aJom+QTEO/Bx8MYNjexMo/Bv2WOjUfZr+aL0WnYSgymUy6zeguqLTsIhV0gMvQ==",
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "compressible": "~2.0.18",
         "debug": "2.6.9",
+        "destroy": "1.2.0",
         "negotiator": "~0.6.4",
         "on-headers": "~1.1.0",
         "safe-buffer": "5.2.1",
@@ -1387,6 +1388,10 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/compression/node_modules/debug": {
@@ -1649,6 +1654,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/dezalgo": {
@@ -2682,6 +2697,7 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
       "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5141,6 +5157,28 @@
       },
       "engines": {
         "node": ">=20.0"
+      }
+    },
+    "node_modules/xmlbuilder2/node_modules/js-yaml": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/xtend": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -47,7 +47,7 @@
     "mime-types": "^3.0.2",
     "moment": "^2.30.1",
     "mongodb": "^7.6.0",
-    "multer": "2.3.0",
+    "multer": "^2.3.0",
     "node-id3": "^0.2.9",
     "openid-client": "^6.8.6",
     "passport": "^0.7.0",
@@ -67,17 +67,11 @@
     "xmlbuilder2": "^4.0.3"
   },
   "overrides": {
-    "brace-expansion": "5.0.9",
-    "cross-spawn": "7.0.6",
-    "form-data": "4.0.6",
-    "got": "11.8.6",
-    "js-yaml": "5.4.1",
-    "undici": "6.28.1",
-    "ws": "8.21.3"
+    "got": "11.8.6"
   },
   "devDependencies": {
     "c8": "^12.0.0",
-    "js-yaml": "5.4.1",
+    "js-yaml": "^5.4.1",
     "mocha": "^12.0.0",
     "pg-mem": "^3.0.14",
     "supertest": "^7.2.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "fs-extra": "^11.4.0",
         "material-icons": "^1.10.8",
         "nan": "^2.28.0",
-        "ngx-avatars": "1.10.2",
+        "ngx-avatars": "^1.10.2",
         "ngx-file-drop": "^16.0.0",
         "rxjs": "^7.8.2",
         "tslib": "^2.0.0",
@@ -79,13 +79,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.2201.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2201.7.tgz",
-      "integrity": "sha512-qffChB0+3WuLcwDk9gx3p/Vl3zYJDomweui5zsLESDMzvJ8zsbKRkgohTieOngajx+XBsklp0gKcxjiVn4NvWQ==",
+      "version": "0.2201.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2201.8.tgz",
+      "integrity": "sha512-EUQo8RDS1my2Bo5FRS+gBYgz1/klfIp9XESfMpTBO04nBkjF6DkPCeOxeAf1CYjWy9nCXcWn968eSdEhV5jXiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.1.7",
+        "@angular-devkit/core": "22.1.8",
         "rxjs": "7.8.2"
       },
       "bin": {
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "22.1.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.1.7.tgz",
-      "integrity": "sha512-RKayeOOjhcIe/iBOM1fmtI5pjXwBEJh+u55VnSeIwYvFNXyxI0/jdRw4T6uhwusQ+1bzyya4d8q1mT9oaOQ/5A==",
+      "version": "22.1.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.1.8.tgz",
+      "integrity": "sha512-34lsgg2FwMVBX7nR/ZqzRUcdvdYPvSB8XAEr2GudXAyZwLI9ehzfQlagAWR/gEb8p4uCFZW0r7uU0toxydq4Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -126,13 +126,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "22.1.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.1.7.tgz",
-      "integrity": "sha512-KOcVeT4MCsoPt6AMnXH7AbWZnzlKXhMyua2ITWij4UbLaNWCDwfIug/xrZssYLHUFwebCIqsR8iuG/BPH8Cz2w==",
+      "version": "22.1.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.1.8.tgz",
+      "integrity": "sha512-Pv3cPa/44kvEwYcqwx4Ns5dhIDmcFNSHhbpheqiEG1Z/u4e2t4zHKDtE3eHZB+8o+IcC7xJj+d+AqGR44RoZDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.1.7",
+        "@angular-devkit/core": "22.1.8",
         "jsonc-parser": "3.3.1",
         "magic-string": "1.0.0",
         "ora": "9.4.1",
@@ -145,9 +145,9 @@
       }
     },
     "node_modules/@angular/animations": {
-      "version": "22.1.5",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-22.1.5.tgz",
-      "integrity": "sha512-lWxbbZ7v2J3Vq/FTb3isRsEb2sQtI9tcSDuZzhIZpOS9kdGf6Wg/GCf1u41pN6CJA4++iTQQ29gqVblARqQfpg==",
+      "version": "22.1.6",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-22.1.6.tgz",
+      "integrity": "sha512-o3tad5WSlcq80aFvZGQ1VrNtY2fieJWbYn1h2AxJXE1Mj0h3atvw4zgQ+qx9ZRCYsZvsluW88YxA1Zk0bCuZvQ==",
       "deprecated": "@angular/animations is deprecated. Use `animate.enter` and `animate.leave` instead. For more information see: https://v22.angular.dev/guide/animations.",
       "license": "MIT",
       "dependencies": {
@@ -157,18 +157,18 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "22.1.5"
+        "@angular/core": "22.1.6"
       }
     },
     "node_modules/@angular/build": {
-      "version": "22.1.7",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.1.7.tgz",
-      "integrity": "sha512-YNZL3R2YS1qZud9zbJfW3ZSeEB0xAURBJEE0cf7WRCCwkn7NFlH7xXLW/zR+WRBwtcCBRsLrM2/ix3Y8FoKX9A==",
+      "version": "22.1.8",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.1.8.tgz",
+      "integrity": "sha512-tw+Evk0EITb8p8dTu743ONoFztCEiyDkdRbtZsh7C0vBS7Q9ElsOcFeg2Z9OAAwrmtZMIBuW3jrdPRQp7OCSdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2201.7",
+        "@angular-devkit/architect": "0.2201.8",
         "@babel/core": "8.0.1",
         "@babel/helper-annotate-as-pure": "8.0.0",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -210,7 +210,7 @@
         "@angular/platform-browser": "^22.0.0",
         "@angular/platform-server": "^22.0.0",
         "@angular/service-worker": "^22.0.0",
-        "@angular/ssr": "^22.1.7",
+        "@angular/ssr": "^22.1.8",
         "istanbul-lib-instrument": "^6.0.0",
         "karma": "^6.4.0",
         "less": "^4.2.0",
@@ -285,19 +285,19 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "22.1.7",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.1.7.tgz",
-      "integrity": "sha512-dsOAAPHTXSrTvH5jIdZsFhqmcrTU9+aLXPSYSkQ1afMxPUT/JDjWH228xURYmCaM3ml0vVaT9R2p7/FrS7CJmg==",
+      "version": "22.1.8",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.1.8.tgz",
+      "integrity": "sha512-MFN/FydqDndai8vF12hDxG5RlBt1HUUheeJgJNmuHYIne4bOAfOT+xuMpIK8+gLSRwCemdqR3OMM38pnsFJ/nA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2201.7",
-        "@angular-devkit/core": "22.1.7",
-        "@angular-devkit/schematics": "22.1.7",
+        "@angular-devkit/architect": "0.2201.8",
+        "@angular-devkit/core": "22.1.8",
+        "@angular-devkit/schematics": "22.1.8",
         "@inquirer/prompts": "8.5.2",
         "@listr2/prompt-adapter-inquirer": "4.2.5",
         "@modelcontextprotocol/sdk": "1.30.0",
-        "@schematics/angular": "22.1.7",
+        "@schematics/angular": "22.1.8",
         "jsonc-parser": "3.3.1",
         "listr2": "11.0.0",
         "npm-package-arg": "14.0.0",
@@ -316,9 +316,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "22.1.5",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-22.1.5.tgz",
-      "integrity": "sha512-KgB+MTDotlTn67YK4sCTNFLja+G+EMCqHo5bB1cvRKw7Gd9AtAi5kgDmYzMk7ftJ9qJ2O30zXR56Hpw37J2CTQ==",
+      "version": "22.1.6",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-22.1.6.tgz",
+      "integrity": "sha512-giuH+jJvo6YbBxbKofJCXvq6k8g1Z/xCAvh4piNFSSS6/toXTLCeZ+snr6Stw5b2wRbArM5Q5nDeuto3NqVPnQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -327,14 +327,14 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "22.1.5",
+        "@angular/core": "22.1.6",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "22.1.5",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-22.1.5.tgz",
-      "integrity": "sha512-GvM0oNCuI09Up5Lk0ZQCX5yA2cGyHYB/rZsa/EGTnzwuxgLDlhOOa19QaVaoxDCo9vO43Ix9rG7SLppEv+qd1w==",
+      "version": "22.1.6",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-22.1.6.tgz",
+      "integrity": "sha512-JjOUm/qD338+fGfZvxSNn/vTUiVqNwOiPzacInVUq1eVp7Jev+cnvEwXA2cFJkYZoy3Imz6wHoMvTUZNN8cbKQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -344,9 +344,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "22.1.5",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-22.1.5.tgz",
-      "integrity": "sha512-XyeLlCqngUiZK8EMQo2DFfDxDoFdlsOe98eK7++N9Cs7qETTaMM3mu8iZbT2o6KhEwzjabW+mqipts1/ecEhyQ==",
+      "version": "22.1.6",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-22.1.6.tgz",
+      "integrity": "sha512-C1fQuaSLnibhfbb7Im/vurdBEcfQk+/GqPkY4+dgEKd4EPleO0xWlD+k5DwyNFX8a9w7HebWfo0Zl66HuaEwOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -367,7 +367,7 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "22.1.5",
+        "@angular/compiler": "22.1.6",
         "typescript": ">=6.0 <6.1"
       },
       "peerDependenciesMeta": {
@@ -377,9 +377,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "22.1.5",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-22.1.5.tgz",
-      "integrity": "sha512-uiL+xVL4264NEuc3E5ILd6meSv9I4Xt82VQHvYlAVYlcjHlWY49yVe0/apzncUOGxUKzvK8/GDbyFEH7WfJYFw==",
+      "version": "22.1.6",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-22.1.6.tgz",
+      "integrity": "sha512-3Ln9YYOhsaU2vPufnpcu6C4dlmX4e/nJTlggVcKMT7bGZH5KlEtw3h0uh9YfANv8YhQCEk1AcuRI7KpBnh5ing==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -388,7 +388,7 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "22.1.5",
+        "@angular/compiler": "22.1.6",
         "rxjs": "^6.5.3 || ^7.4.0",
         "zone.js": "~0.15.0 || ~0.16.0"
       },
@@ -402,9 +402,9 @@
       }
     },
     "node_modules/@angular/forms": {
-      "version": "22.1.5",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-22.1.5.tgz",
-      "integrity": "sha512-E7pDEKtSvO1MNw222ZcvphzT4GAQ9D725v2Rq7ft8orT2qvHS6RlVnEc5ioPDhYTAD0HmbwDmutxkcuxqc16VA==",
+      "version": "22.1.6",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-22.1.6.tgz",
+      "integrity": "sha512-rfV4G4UB4l69yXSRvhaHPzTMIruvBlRO+ak9NtTcYMnsoj8O5ZCyPv0ledGIrLTBwGSI3X1j4nr9aoV+Rj/n+Q==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -415,16 +415,16 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "22.1.5",
-        "@angular/core": "22.1.5",
-        "@angular/platform-browser": "22.1.5",
+        "@angular/common": "22.1.6",
+        "@angular/core": "22.1.6",
+        "@angular/platform-browser": "22.1.6",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/language-service": {
-      "version": "22.1.5",
-      "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-22.1.5.tgz",
-      "integrity": "sha512-siezUdZm4wfA+wUWbTdPDlPzrEDM5LdFghyhspJyKMLQPs88c4MyD28d6AcEo7JzqdHPCF6PO/sXv910PElJtw==",
+      "version": "22.1.6",
+      "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-22.1.6.tgz",
+      "integrity": "sha512-qsOgDUGR62lsdyJF+hoLx1kTSZtBoc+r2GJ64o6O+HqlsTPw0Q6aI6Y1qQkAurQbGa0s7qfhuXEHtKmG9MFiXA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -432,9 +432,9 @@
       }
     },
     "node_modules/@angular/localize": {
-      "version": "22.1.5",
-      "resolved": "https://registry.npmjs.org/@angular/localize/-/localize-22.1.5.tgz",
-      "integrity": "sha512-TzXeTkVnq5b00Sm3ZL8bzY+ftZyLdx1HDvcTpzcsCHExu4Vk0w+0sn12UkHjjVTzvAOpIn67y/UiiZjZX6UA6w==",
+      "version": "22.1.6",
+      "resolved": "https://registry.npmjs.org/@angular/localize/-/localize-22.1.6.tgz",
+      "integrity": "sha512-lxj8t1FtwzQq9ogZLWa7hkKl2jWAeWDsBE7pw9mg28XPAPHrwAKIRGz1TG4XUck0wyMn8LovlSeo/7A4gmY+0Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "8.0.1",
@@ -450,8 +450,8 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "22.1.5",
-        "@angular/compiler-cli": "22.1.5"
+        "@angular/compiler": "22.1.6",
+        "@angular/compiler-cli": "22.1.6"
       }
     },
     "node_modules/@angular/material": {
@@ -472,9 +472,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "22.1.5",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-22.1.5.tgz",
-      "integrity": "sha512-xRX7TvHzFcur5bhZUqT7QPkezcSuWRzcltcsrqh3UsZnEJ2p+olilFyLq5yAneO13hffNifFkxngoSxVwKwnHw==",
+      "version": "22.1.6",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-22.1.6.tgz",
+      "integrity": "sha512-jrRi6zpdz+jOle5l0OW7QL0a8xPgdnxWT5FrJabbiNKfYzQfqKcaAu02l8uJoJxtGb8fLQ8pbjkPpZEvKO2z+w==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -483,9 +483,9 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "22.1.5",
-        "@angular/common": "22.1.5",
-        "@angular/core": "22.1.5"
+        "@angular/animations": "22.1.6",
+        "@angular/common": "22.1.6",
+        "@angular/core": "22.1.6"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -494,9 +494,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "22.1.5",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-22.1.5.tgz",
-      "integrity": "sha512-xs1oU90Q5+c/hcIL3dOvIKP6zAY5bAL+/dpvbiV+Gg0aFk1SiWadGnrE99VIFhzR4GRFp701uORw/cpgp4ZNNw==",
+      "version": "22.1.6",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-22.1.6.tgz",
+      "integrity": "sha512-ixLGQoRkF1ctIN01opG8XaT84TR2/RngMvA0DKsbCjoz0+ECCq3RtsrXUB5Qdny7AXzPvsJchxQ+ZubtOX9MYQ==",
       "deprecated": "@angular/platform-browser-dynamic is deprecated. Use `@angular/platform-browser` instead.",
       "license": "MIT",
       "dependencies": {
@@ -506,16 +506,16 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "22.1.5",
-        "@angular/compiler": "22.1.5",
-        "@angular/core": "22.1.5",
-        "@angular/platform-browser": "22.1.5"
+        "@angular/common": "22.1.6",
+        "@angular/compiler": "22.1.6",
+        "@angular/core": "22.1.6",
+        "@angular/platform-browser": "22.1.6"
       }
     },
     "node_modules/@angular/router": {
-      "version": "22.1.5",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-22.1.5.tgz",
-      "integrity": "sha512-RYgL2iTGpMFcqZtXjcjxGVqGraDfOdk/epbLK8z/vy5cI+W2uVdiu5ait7xhv82KoaWT8lUU3sDc4jdI17qHcg==",
+      "version": "22.1.6",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-22.1.6.tgz",
+      "integrity": "sha512-ex0vrkcVyJJdn7NzZXun+5ctaPPLTZJ/gE7A3g1dun7BM3g4Z6zT738mODFeJgtPtJNf4bTs2gpgvyegvzWH7w==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -524,9 +524,9 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "22.1.5",
-        "@angular/core": "22.1.5",
-        "@angular/platform-browser": "22.1.5",
+        "@angular/common": "22.1.6",
+        "@angular/core": "22.1.6",
+        "@angular/platform-browser": "22.1.6",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -3996,14 +3996,14 @@
       "license": "MIT"
     },
     "node_modules/@schematics/angular": {
-      "version": "22.1.7",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.1.7.tgz",
-      "integrity": "sha512-acBv147JjnwtWFgC8Af0KFBzPpb/TWaYxoWN/Ou3pXtUhYiEqnrdJeoFz3ssDw26eKFIdWnVBLB/dHORBykPBg==",
+      "version": "22.1.8",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.1.8.tgz",
+      "integrity": "sha512-V37T9uHOQVHyxxOqwcJ9xjSIW/mW9UuSfjOc7WJE4V8+3zj0abDJLHuoxDZKe0icYGapgOcvHyYjtNOjSeSivw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.1.7",
-        "@angular-devkit/schematics": "22.1.7",
+        "@angular-devkit/core": "22.1.8",
+        "@angular-devkit/schematics": "22.1.8",
         "jsonc-parser": "3.3.1",
         "typescript": "6.0.3"
       },
@@ -4124,9 +4124,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.5.0.tgz",
-      "integrity": "sha512-dVSGpriSoCgz8WnDNTuSSuSv1PC/ALXihO4ulRZt7Md8k9mlbdin3lGOcDE8SnWOgf513ByWlXd7BK4azmyg/A==",
+      "version": "26.5.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.5.1.tgz",
+      "integrity": "sha512-CzNm2FezW4VR/LjG6yUdiEgLE/rAQ9Slj5gCu/C2VrdcW7I0ahNZ8DRbHT7zOZ6r3ONgd/bsQIeSaoDGrd1C6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7392,9 +7392,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.18",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
-      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "version": "3.3.19",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.19.tgz",
+      "integrity": "sha512-Y2tUNy4ouw6tq5oDSKeQYGOyhkUBhNOcGV/02KC+6kd9eDGqdZd++mjMiIDilrBYvjEnCYvVtsuHCuP+okSfug==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "fs-extra": "^11.4.0",
     "material-icons": "^1.10.8",
     "nan": "^2.28.0",
-    "ngx-avatars": "1.10.2",
+    "ngx-avatars": "^1.10.2",
     "ngx-file-drop": "^16.0.0",
     "rxjs": "^7.8.2",
     "tslib": "^2.0.0",
@@ -72,21 +72,5 @@
     "openapi-typescript-codegen": "^0.31.0",
     "ts-node": "~10.9.2",
     "vitest": "^5.0.0"
-  },
-  "overrides": {
-    "@hono/node-server": "2.1.1",
-    "@modelcontextprotocol/sdk": "1.30.0",
-    "esbuild": "0.28.2",
-    "express-rate-limit": "8.7.0",
-    "ngx-avatars": {
-      "@angular/common": "21.2.0",
-      "@angular/core": "21.2.0"
-    },
-    "flatted": "3.4.4",
-    "hono": "4.13.7",
-    "immutable": "5.1.9",
-    "js-yaml": "4.3.2",
-    "nanoid": "3.3.18",
-    "postcss": "8.5.28"
   }
 }


### PR DESCRIPTION
Seventh pass over the dependency trees and #373 — and the first one aimed at **removing** pins rather than re-validating them.

## The short version

Of the 17 string overrides plus the `ngx-avatars` peer shim, **17 are removed**. Only `got` stays, and it stays for a concrete, audit-verified reason. Three exact version specs are loosened to carets as well. None of it changes a single installed version beyond the in-range refreshes below.

## How each pin was tested

Previous passes judged a pin by reading ranges: *can the newer version work?* That question never asked whether **the override is what's actually doing the holding**. So this pass tested it directly:

1. **Delete each override on its own, regenerate the lockfile, diff it.** Sixteen of the seventeen, and the shim, produced a zero-byte lockfile change.
2. **Confirm with a from-scratch resolve.** Step 1 alone isn't proof: with a lockfile present, npm keeps any locked version that still satisfies the declared ranges. So each tree was resolved twice *without* a lockfile — once with the current overrides, once with the proposed set. **Frontend: identical, all 635 packages at the same versions, with the whole `overrides` block gone.** Backend: one difference, covered below.

The reason they were inert: wherever a real constraint exists, **the consumer's own declared range already enforces it**, and npm never crosses a major on its own.

| Pin | 373 said | What actually holds it |
| --- | --- | --- |
| `nanoid` 3.3.18 | "the only working version" | `postcss` declares `nanoid ^3.3.18` |
| `undici` 6.28.1 | "correctly held" | `@discordjs/rest` declares `undici ^6.27.0` |
| `js-yaml` 4.3.2 (frontend) | "still held" | `json-schema-ref-parser` declares `js-yaml ^4.1.0` |

The underlying facts in #373 were right — nanoid 4+ really can't be `require`d, undici 7+ really isn't admitted — but the override was never the mechanism enforcing them. The remaining dedupe pins pinned versions every consumer already resolves to.

## Removed

**Frontend** (the entire `overrides` block): `@hono/node-server`, `@modelcontextprotocol/sdk`, `esbuild`, `express-rate-limit`, `flatted`, `hono`, `immutable`, `js-yaml`, `nanoid`, `postcss`, and the `ngx-avatars` Angular peer shim.

**Backend:** `brace-expansion`, `cross-spawn`, `form-data`, `undici`, `ws`, and `js-yaml`.

`js-yaml` was the one backend removal with a lockfile effect. Without the override, `xmlbuilder2` gets a nested `js-yaml@4.3.2` — inside its declared `^4.1.1` and at the top of that line — instead of being forced up a major onto 5.4.1. One extra small copy, in exchange for every consumer sitting inside its declared range. Audit stays at 0.

## Kept: `got` 11.8.6

The only override whose removal makes the tree worse. `gotify` 1.1.0 — its latest release — hard-pins `got: "10.7.0"`, and without the override:

```
got  <11.8.5
Severity: moderate
Got allows a redirect to a UNIX socket - GHSA-pfrx-2q88-qq97
No fix available
```

"No fix available" is the key line: the override is the fix.

## Exact specs loosened to carets

All three sit at latest, so `^X` keeps the same floor and only drops the ceiling. Resolution is unchanged.

| Spec | Why it was exact |
| --- | --- |
| `ngx-avatars` `1.10.2` → `^1.10.2` | Pinned 2023-11 to fix an install failure, alongside the peer shim — before `legacy-peer-deps` covered it. |
| `multer` `2.3.0` → `^2.3.0` | Pinned 2026-03 as "pin patched multer version". A caret keeps that patched floor, and unlike the exact pin, doesn't block *future* 2.x security fixes. |
| backend `js-yaml` `5.4.1` → `^5.4.1` | Its own commit records it was exact only because "npm rejects a direct range that its own override contradicts". The override is gone. It remains a real devDependency — two tests `require('js-yaml')` directly. |

## In-range refreshes

`package.json` ranges already admitted all of these.

| Package | From | To |
| --- | --- | --- |
| `@angular/*` framework | 22.1.5 | 22.1.6 |
| `@angular/*` tooling (build, cli, devkit, schematics) | 22.1.7 | 22.1.8 |
| `@types/node` | 26.5.0 | 26.5.1 |
| `compression` (backend) | 1.8.1 | 1.8.2 |
| `nanoid` (via postcss, no longer overridden) | 3.3.18 | 3.3.19 |

Two of these were published within the last day, so both tarballs were diffed rather than taken on trust:

- **`compression` 1.8.2** (published today) releases the zlib stream when a client disconnects before the response finishes — a native-resource leak fix — and matches `no-transform` case-insensitively. It adds `destroy@1.2.0` (zero dependencies, Express maintainers, unchanged since 2022). Published via GitHub Actions trusted publishing with SLSA provenance.
- **`nanoid` 3.3.19** (published yesterday) hardens the CJS build — the one `postcss` actually loads — to reset its pool if `randomFillSync` throws, bringing it to parity with the ESM build. Its exports map, including the `require` condition, is byte-identical to 3.3.18.

## One visible side effect

`npm ls` now also reports `ngx-avatars`' `^21.1.2` peer as invalid; the shim used to paper over that line. This is cosmetic:

- the installed tree is identical (proven above);
- `npm ls` **already exits non-zero on main** for `@videogular/ngx-videogular` (Angular `^20`, `zone.js ^0.15.1`) and `vitest` (`@angular/build` peers `^4.0.8`);
- nothing in CI, Docker, or `dev/` runs `npm ls`, and the Docker frontend stage copies `.npmrc`, so `legacy-peer-deps` applies there too.

## #373 status

No upstream trigger fired this pass. `@angular/build` 22.1.8 still peers `vitest ^4.0.8`; `compiler-cli` 22.1.6 still peers `typescript >=6.0 <6.1`; `ngx-avatars` and `ngx-videogular` are unmoved; `gotify` still declares got 10.7.0.

What's left on #373 after this merges is short, and none of it is an override: `got` (blocked on `gotify`), `typescript ~6.0.3` (load-bearing — TS 7 breaks the build), `legacy-peer-deps` (now masking `ngx-videogular`, `ngx-avatars`, and `vitest`), and the Docker/`engines` Node mismatch.

Also noticed: `@types/node`'s `latest` dist-tag currently points at **22.20.2**, not 26.5.1 — DefinitelyTyped published four majors within 80 seconds on 2026-09-09 and 22.20.2 went last. `npm outdated` shows it as a downgrade. Same misleading-Latest-column trap #373 records for the deprecated Angular packages, but on a package that isn't deprecated. Nothing to do.

Refs #373.

## Verification

`npm ci` clean in both trees · lint clean · both `tsc` projects clean · 297 frontend tests across 48 files · 558 backend passing / 52 pending · 8 extension tests · production build clean apart from the pre-existing budget/Sass/CJS warnings · `npm audit` 0 vulnerabilities in both trees · `check-declared` clean (360 frontend / 82 backend specifiers) · `npm outdated` reports nothing behind `wanted` in either tree.

One backend run failed while it was running alongside other CPU-heavy checks; two sequential runs afterwards were clean with identical counts. CONTRIBUTING notes parts of that suite are timing-dependent.