### PR TITLE
ci(deps): float codeql-action and login-action on their major tags

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -24,6 +24,25 @@ updates:
       minor-updates:
         update-types:
           - "minor"
+    ignore:
+      # These publishers move their major tag (@v4) to every new minor and patch
+      # release, so @v4 is already current. Letting Dependabot propose those rewrites
+      # @v4 into an exact tag that then goes stale silently; only offer new majors.
+      # Third-party actions are deliberately left out: their major tags are not
+      # always maintained (jsdaniell/create-json@v1 still points at v1.1), so they
+      # stay exact and keep receiving minor and patch updates.
+      - dependency-name: "actions/*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+      - dependency-name: "docker/*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+      - dependency-name: "github/*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,7 +48,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4.37.9
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -59,7 +59,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4.37.9
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -73,4 +73,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4.37.9
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -65,14 +65,14 @@ jobs:
 
       - name: Login to DockerHub
         if: steps.build_params.outputs.push == 'true'
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
         if: steps.build_params.outputs.push == 'true'
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -78,13 +78,13 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,13 +65,13 @@ jobs:
             type=sha,prefix=sha-,format=short
 
       - name: Login to DockerHub
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
Follow-up to #442, same goal: remove pins rather than raise them. #442 covered npm; this covers the two exact GitHub Actions pins, one of which had already gone stale.

## What changed

| Action | Was | Now | Uses |
| --- | --- | --- | --- |
| `github/codeql-action/{init,autobuild,analyze}` | `v4.37.9` | `v4` | 3 |
| `docker/login-action` | `v4.6.0` | `v4` | 6 |

`codeql-action` **v4.38.0 has shipped**, so the `v4.37.9` pin was already behind.

## Why these two were exact

Nobody decided that. **Dependabot wrote both pins** in #346 — *"Updates `github/codeql-action` from 4 to 4.37.3"* and *"`docker/login-action` from 4 to 4.5.2"* — converting floating `@v4` refs into exact tags, then bumped them precisely from then on. Every other first-party action here floats on its major and can't go stale this way; these two were the only exceptions, which is exactly why #373 kept noting they were "the only two that can go stale silently".

## Why `@v4` is safe

The floating tag is only as good as whoever moves it, so each one was checked against its newest release rather than assumed:

| Floating tag | Resolves to the same commit as |
| --- | --- |
| `github/codeql-action@v4` | `v4.38.0` |
| `docker/login-action@v4` | `v4.6.0` |
| `actions/checkout@v7` | `v7.0.1` |
| `actions/cache@v6` | `v6.1.0` |
| `actions/setup-node@v7` | `v7.0.0` |
| `actions/upload-artifact@v7` | `v7.0.1` |
| `actions/download-artifact@v8` | `v8.0.1` |
| `docker/build-push-action@v7` | `v7.3.0` |
| `docker/metadata-action@v6` | `v6.2.0` |
| `docker/setup-buildx-action@v4` | `v4.3.0` |
| `docker/setup-qemu-action@v4` | `v4.3.0` |

All eleven match.

## Making it stick

Floating alone would be undone: the next Dependabot run could rewrite `@v4` into an exact tag again. So the `github-actions` entry in `dependabot.yaml` now **ignores minor and patch updates for `actions/*`, `docker/*` and `github/*`** — for those publishers it only proposes new majors, and `@v4` picks up everything else on its own. The existing patch/minor groups are unchanged.

### Third-party actions are deliberately excluded

Their major tags are not reliably maintained, and one of ours proves it:

| Floating tag | Actually points at | Newest |
| --- | --- | --- |
| `jsdaniell/create-json@v1` | the **`v1.1`** commit | `v1.2.3` |
| `FedericoCarboni/setup-ffmpeg@v3` | an older commit than `v3.1` | `v3.1` |

Floating `create-json` to `@v1` would silently **downgrade** it to v1.1, so it stays exact at `v1.2.3` and keeps getting minor/patch proposals. A blanket `"*"` ignore would have frozen it there permanently — which is why the rule names publishers instead.

`setup-ffmpeg` is untouched here. `@v3` lags `v3.1` by 13 commits (February 2024: shared-linking support and clearer error messages), but v3.1 does not change the download path, so moving to it would add a pin without fixing anything. See below.

## Not fixed here: the `setup-ffmpeg` flake

The backend mocha job failed twice on 2026-09-11 — once on #442 and once on `main` after it merged — both at the same step, **before any test ran**:

```
Run FedericoCarboni/setup-ffmpeg@v3
##[error]AssertionError [ERR_ASSERTION]: Failed to read version from readme
```

The action fetches `johnvansickle.com/ffmpeg/release-readme.txt` and matches `/version: (.+)\n/`. The fetch succeeded — a failed fetch raises a different assertion — so the host returned a 200 without the version line. Fetched directly, the file is unchanged since August 2024 and the action's own regex parses it, so this is intermittent rather than broken, and re-runs of both jobs passed (558 passing / 52 pending). v3.1's `getLatestRelease()` is identical to v3's, so upgrading would not help.

The action has not released since February 2024 and runs on the deprecated Node 20 runtime. The durable fix is to drop it and install ffmpeg from the runner's package manager, removing both the action and the third-party host. That's a CI behaviour change and wants its own PR.

## Also noticed, pre-existing

`actionlint` flags `::set-output` in `docker.yml` and `docker-pr.yml` (lines 31–36) as deprecated in favour of `$GITHUB_OUTPUT`. Untouched by this change; unrelated to it.

Refs #373.